### PR TITLE
support different external lib outputs for portable builds

### DIFF
--- a/docs/external-libraries.md
+++ b/docs/external-libraries.md
@@ -4,10 +4,11 @@ How to wrap external C/C++ libraries in Logos modules.
 
 ## Overview
 
-Logos modules can wrap external C/C++ libraries to expose their functionality to the Logos ecosystem. There are two approaches:
+Logos modules can wrap external C/C++ libraries to expose their functionality to the Logos ecosystem. There are three approaches:
 
 1. **Vendor/Pre-built** — Library already compiled, in the `lib/` directory (simplest)
-2. **Flake Input** — Library source as a flake input, built during nix build
+2. **Flake Input (build from source)** — Library source as a flake input, built by `mkExternalLib` during nix build
+3. **Flake Input (Nix package)** — Library provided by a flake that has its own Nix build (`built_nix: true`)
 
 ## Approach 1: Vendor / Pre-built Library
 
@@ -128,7 +129,73 @@ For Go libraries that produce C shared libraries:
 
 The `go_build: true` flag sets up `GOCACHE`, `GOPATH`, `CGO_ENABLED=1`, and the Go toolchain in the build environment.
 
-## Approach 3: Vendor Submodule (Build from Source in Repo)
+## Approach 3: Flake Input (Nix Package)
+
+Best for: Libraries that already have their own `flake.nix` producing a Nix derivation with `lib/` and `include/` outputs. The module builder detects this automatically — if the resolved input is a Nix derivation, it's used directly; no extra flags needed in `metadata.json`.
+
+### How detection works
+
+The module builder calls `lib.isDerivation` on the resolved input:
+- **Derivation** (a specific package output) → used directly, no build step
+- **Raw source** (non-flake input, `flake = false`) → built with `make` / custom command (Approach 2)
+
+When you point `externalLibInputs` at a specific package output (or use the structured format with `packages`), the resolved value is always a derivation, so it's used as-is.
+
+### Configuration
+
+`flake.nix`:
+```nix
+{
+  inputs = {
+    logos-module-builder.url = "github:logos-co/logos-module-builder";
+    my-lib.url = "github:org/my-lib";
+  };
+
+  outputs = inputs@{ logos-module-builder, ... }:
+    logos-module-builder.lib.mkLogosModule {
+      src = ./.;
+      configFile = ./metadata.json;
+      flakeInputs = inputs;
+      externalLibInputs = {
+        mylib = inputs.my-lib;
+      };
+    };
+}
+```
+
+`metadata.json` — only the name is needed:
+```json
+{
+  "nix": {
+    "external_libraries": [
+      { "name": "mylib" }
+    ],
+    "cmake": {
+      "extra_include_dirs": ["lib"]
+    }
+  }
+}
+```
+
+If `my-lib` has `packages.${system}.default`, the module builder resolves to that derivation and uses it directly. If it's a non-flake source repo, it falls back to building with `make`.
+
+### Per-variant packages
+
+If the flake input provides multiple package outputs (e.g. a dev build and a portable build), use the structured `externalLibInputs` format:
+
+```nix
+externalLibInputs = {
+  mylib = {
+    input = inputs.my-lib;
+    packages = {
+      default = "lib";           # used for nix build .#lib
+      portable = "lib-portable"; # used for nix build .#lib-portable
+    };
+  };
+};
+```
+
+## Approach 4: Vendor Submodule (Build from Source in Repo)
 
 Best for: Libraries requiring custom build scripts, where source lives in a git submodule.
 

--- a/docs/nix-api.md
+++ b/docs/nix-api.md
@@ -27,9 +27,9 @@ mkLogosModule {
   extraBuildInputs = [ ];
   extraNativeBuildInputs = [ ];
   configOverrides = { };
-  preConfigure = "";
+  preConfigure = "";           # String or function: { externalLibs }: "..."
   postInstall = "";
-  logosStandalone = null;      # Pass logos-standalone-app for `nix run` support
+  logosStandalone = null;      # Override logos-standalone-app for `nix run`
 }
 ```
 
@@ -62,11 +62,29 @@ outputs = inputs@{ logos-module-builder, ... }:
 ```
 
 #### externalLibInputs (optional)
-Flake inputs for external C/C++ libraries that need to be built from source. Keys must match library names in `metadata.json`'s `nix.external_libraries`. For pre-built vendor libraries, use `vendor_path` in `metadata.json` instead — no `externalLibInputs` needed.
+Flake inputs for external C/C++ libraries. Keys must match library names in `metadata.json`'s `nix.external_libraries`. For pre-built vendor libraries, use `vendor_path` in `metadata.json` instead — no `externalLibInputs` needed.
+
+The builder auto-detects whether the resolved input is a Nix derivation (via `lib.isDerivation`). If it is, the derivation is used directly. If it's raw source, it's built with `make` / custom command. No flags needed in `metadata.json`.
+
+**Simple format** — bare flake input, resolves to `packages.${system}.default`:
 
 ```nix
 externalLibInputs = {
   gowalletsdk = inputs.go-wallet-sdk;
+};
+```
+
+**Structured format** — per-variant package mappings. When any entry uses this format, the builder produces both `lib` and `lib-portable` outputs, each linked against the corresponding external lib variant. The `lgx` output bundles `lib` and `lgx-portable` bundles `lib-portable`.
+
+```nix
+externalLibInputs = {
+  logos_pm = {
+    input = inputs.logos-package-manager;
+    packages = {
+      default = "lib";           # → input.packages.${system}.lib
+      portable = "lib-portable"; # → input.packages.${system}.lib-portable
+    };
+  };
 };
 ```
 
@@ -103,13 +121,23 @@ configOverrides = {
 ```
 
 #### preConfigure (optional)
-Shell commands to run before CMake configuration.
+Shell commands (or a function) to run before CMake configuration.
+
+**String form** — plain shell commands:
 
 ```nix
 preConfigure = ''
-  # Custom setup
   echo "Running custom preConfigure"
   ./scripts/generate-something.sh
+'';
+```
+
+**Function form** — receives `{ externalLibs }` with resolved store paths keyed by library name, so you can reference them directly:
+
+```nix
+preConfigure = { externalLibs }: let pm = externalLibs.logos_pm; in ''
+  mkdir -p lib
+  cp ${pm}/lib/libpackage_manager_lib.* lib/ 2>/dev/null || true
 '';
 ```
 
@@ -148,6 +176,10 @@ Returns an attribute set with:
       lgx-portable = <portable lgx>;    # always included
       install = <dev install package>;  # always included
       install-portable = <portable install package>;  # always included
+
+      # Only when externalLibInputs uses structured format with variants:
+      <name>-lib-portable = <portable library package>;
+      lib-portable = <portable library package>;
     };
   };
 
@@ -218,7 +250,7 @@ mkLogosQmlModule {
       install-portable = <portable install package>;  # always included
     };
   };
-  apps = { ... };  # only when logosStandalone is set
+  apps = { ... };  # auto-wired for QML modules, or when logosStandalone is set
   config = <parsed config>;
   metadataJson = <metadata.json content>;
 }
@@ -277,22 +309,13 @@ logos-module-builder.lib.common.getPluginFilename pkgs "my_module"
 # "my_module_plugin.dylib" or "my_module_plugin.so"
 ```
 
-### commonNativeBuildInputs
+### collectAllModuleDeps
 
-Standard native build inputs.
-
-```nix
-logos-module-builder.lib.common.commonNativeBuildInputs pkgs
-# [ cmake ninja pkg-config qt6.wrapQtAppsNoGuiHook ]
-```
-
-### commonBuildInputs
-
-Standard build inputs.
+Recursively resolve all module dependencies (direct + transitive) from flake inputs. Returns a flat attrset mapping module names to their LGX derivations. Used internally by `mkStandaloneApp` to bundle dependencies.
 
 ```nix
-logos-module-builder.lib.common.commonBuildInputs pkgs
-# [ qt6.qtbase qt6.qtremoteobjects ]
+logos-module-builder.lib.common.collectAllModuleDeps system flakeInputs depNames
+# { waku_module = <lgx derivation>; chat = <lgx derivation>; ... }
 ```
 
 ### nameFormats
@@ -306,44 +329,23 @@ logos-module-builder.lib.common.nameFormats "my_module"
 
 ## Lower-level Builders
 
-For advanced use cases, you can use the lower-level builders directly.
+For advanced use cases, you can use some lower-level builders directly. Plugin compilation has been delegated to backends — `mkModuleLib` and `mkModuleInclude` no longer exist.
 
-### mkModuleLib
+### Plugin Backends
 
-Build the plugin library.
-
-```nix
-logos-module-builder.lib.mkModuleLib.build {
-  pkgs = ...;
-  src = ...;
-  config = ...;
-  commonArgs = ...;
-  logosSdk = ...;
-  moduleDeps = { };
-  externalLibs = { };
-  preConfigure = "";
-  postInstall = "";
-}
-```
-
-### mkModuleInclude
-
-Build generated headers.
+Plugin compilation is delegated to a backend (e.g. `logos-plugin-qt`). The active backends are exposed as `uiBackend` and `coreBackend`:
 
 ```nix
-logos-module-builder.lib.mkModuleInclude.build {
-  pkgs = ...;
-  src = ...;
-  config = ...;
-  commonArgs = ...;
-  logosSdk = ...;
-  lib = <built library>;
-}
+logos-module-builder.lib.uiBackend.buildPlugin { ... }
+logos-module-builder.lib.uiBackend.buildHeaders { ... }
+logos-module-builder.lib.coreBackend.buildPlugin { ... }
 ```
+
+These are used internally by `mkLogosModule` — most modules don't need to call them directly.
 
 ### mkExternalLib
 
-Build external libraries from flake inputs.
+Build/resolve external libraries from flake inputs. Returns an attrset mapping library names to derivations. If a resolved input is already a Nix derivation (`lib.isDerivation`), it is used directly; otherwise the source is built with `make` / custom command.
 
 ```nix
 logos-module-builder.lib.mkExternalLib.buildExternalLibs {
@@ -363,7 +365,9 @@ logos-module-builder.lib.mkStandaloneApp {
   standalone = logos-standalone-app.packages.${system}.default;
   plugin = self.packages.${system}.default;
   metadataFile = ./metadata.json;
-  format = "qt-plugin";  # or "qml"
+  dirName = "logos-my-module-plugin-dir";  # optional
+  format = "qt-plugin";                    # or "qml"
+  moduleDeps = { };                        # resolved module deps (LGX packages)
 }
 ```
 
@@ -373,5 +377,5 @@ Library version string.
 
 ```nix
 logos-module-builder.lib.version
-# "0.1.0"
+# "0.2.0"
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774530738,
-        "narHash": "sha256-EXZ0nsVbBHdeFuXZsSeMNsTi10kA/tpxwea1PJny7G8=",
+        "lastModified": 1774958555,
+        "narHash": "sha256-9FMXR+YesH0JnR3DBv3BG1jtdTDWkPwMx+kIhuBpxZ4=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "01221559b7e5d7db1362128f5888adddd8a23bda",
+        "rev": "38006e72400ee96a9d75e8feb102b474f80d3da5",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
         "process-stats": "process-stats"
       },
       "locked": {
-        "lastModified": 1774618989,
-        "narHash": "sha256-At0cTqrcSHmRL90kd7cYu2iNFvwdKC4WWsyZKs+e5+0=",
+        "lastModified": 1774967221,
+        "narHash": "sha256-i/8S4ldt0ikyjWrwp428Y7a7MRCIsS4R7pED0MFM52o=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "010e75814fc25b33831af86b5e88ba758178a64b",
+        "rev": "da6ba7210e5145bfa5cb40590a2ac7e5dbbfd30d",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455286,
-        "narHash": "sha256-rE4xxKOThAnaZhA0K8Gjf8mxne7dZyerLOlXI7qvHpQ=",
+        "lastModified": 1774633164,
+        "narHash": "sha256-TobXeKMS1RWYKo30ujYJNnrDVhu4U1JFdtL31yIOu8c=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "c4c6bb273f1020351fb4944f3243610c98bd6b49",
+        "rev": "8ed727449a4a6713a8c819c213b0d5d25f575580",
         "type": "github"
       },
       "original": {
@@ -1097,11 +1097,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774532547,
-        "narHash": "sha256-QloRHwJ1Vxq27LwL0r8kirjcmMfKT5rAA5ydzZQx4OA=",
+        "lastModified": 1774635434,
+        "narHash": "sha256-9LRXf/Wy500rNO9IhDSH+PSuadS3TguNFCbcbI4YYZU=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "e15beeac56265daf423f1d744e34d5405655c0f8",
+        "rev": "e5c25989861f4487c3dc8c7b3bc0062bcbc3221f",
         "type": "github"
       },
       "original": {
@@ -1301,11 +1301,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774630730,
-        "narHash": "sha256-dwdeFKeVtLDLgtSHpKjPwL+nHB6tKwBF8OPSaivxZrY=",
+        "lastModified": 1774975654,
+        "narHash": "sha256-U4wEYQHHQqO8TobyDdcSiLf/rJ7ApYQRoaAhILlz3tw=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "a101e8c0c9c1d4fcd49814e54b89d283b585c8fc",
+        "rev": "4ab3e4267e66093f92ecf17c7df6a5dfe9657e8b",
         "type": "github"
       },
       "original": {

--- a/lib/mkExternalLib.nix
+++ b/lib/mkExternalLib.nix
@@ -16,23 +16,24 @@
     buildLib = extLib:
       let
         name = extLib.name;
-        
-        # Check if this is a flake input or vendor submodule
+
         isFlakeInput = extLib ? flake_input || externalInputs ? ${name};
         isVendor = extLib ? vendor_path;
-        
-        # Get the source
-        source = 
+
+        source =
           if externalInputs ? ${name} then externalInputs.${name}
-          else if isVendor then null  # Will be handled in build phase
+          else if isVendor then null
           else throw "External library ${name}: must provide flake input or vendor_path";
-        
+
         buildCommand = extLib.build_command or "make";
         outputPattern = extLib.output_pattern or "build/lib${name}.*";
         buildScript = extLib.build_script or null;
-        
-      in if isFlakeInput && source != null then
-        # Build from flake input
+
+      in if source != null && lib.isDerivation source then
+        # Already a Nix derivation (resolved package output) — use directly
+        source
+      else if isFlakeInput && source != null then
+        # Build from flake input source
         pkgs.stdenv.mkDerivation {
           pname = "logos-external-${name}";
           version = "1.0.0";

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -72,28 +72,64 @@ let
         if input ? packages.${system}.default then input.packages.${system}.default else input
       ) moduleInputs;
 
-      # Resolve external library inputs
-      resolvedExternalLibs = lib.mapAttrs (_: input:
-        if input ? packages.${system}.default then input.packages.${system}.default else input
-      ) externalLibInputs;
+      # Resolve a single externalLibInputs entry for a given variant.
+      # Supports both simple (bare flake input) and structured ({ input, packages }) formats.
+      resolveExtInput = variant: name: value:
+        if builtins.isAttrs value && value ? input then
+          let
+            flakeInput = value.input;
+            packages = value.packages or {};
+            pkgName = packages.${variant} or packages.default or "default";
+          in
+            if flakeInput ? packages.${system}.${pkgName}
+            then flakeInput.packages.${system}.${pkgName}
+            else builtins.throw ''
+              External lib "${name}": flake input does not provide packages.${system}.${pkgName}.
+              Check the "externalLibInputs" structured entry and ensure the flake input exposes the expected package.
+            ''
+        else
+          if value ? packages.${system}.default then value.packages.${system}.default else value;
+
+      # Whether any external lib input declares per-variant packages
+      hasVariants = lib.any (v: builtins.isAttrs v && v ? input && v ? packages)
+        (lib.attrValues externalLibInputs);
 
       buildPkgs   = map (getPkg pkgs) (lib.filter builtins.isString config.nix_packages.build);
       runtimePkgs = map (getPkg pkgs) (lib.filter builtins.isString config.nix_packages.runtime);
 
-      # Build external libraries if any (backend-agnostic)
-      externalLibs = mkExternalLib.buildExternalLibs {
+      # Pre-resolve default variant external libs (always needed, avoids
+      # duplicate evaluation when hasVariants triggers a second buildVariant).
+      defaultResolvedExternalLibs = lib.mapAttrs (resolveExtInput "default") externalLibInputs;
+      defaultExternalLibs = mkExternalLib.buildExternalLibs {
         inherit pkgs config;
-        externalInputs = resolvedExternalLibs;
+        externalInputs = defaultResolvedExternalLibs;
       };
 
-      # Delegate plugin compilation to the backend
-      moduleLib = selectedBackend.buildPlugin {
-        inherit pkgs src config preConfigure postInstall;
-        moduleDeps = resolvedModuleDeps;
-        inherit externalLibs;
-        extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs;
-        extraBuildInputs = extraBuildInputs ++ runtimePkgs;
-      };
+      # Build the plugin for a given external-lib variant ("default" or "portable")
+      buildVariant = variant:
+        let
+          externalLibs =
+            if variant == "default" then defaultExternalLibs
+            else mkExternalLib.buildExternalLibs {
+              inherit pkgs config;
+              externalInputs = lib.mapAttrs (resolveExtInput variant) externalLibInputs;
+            };
+
+          preConfigureStr =
+            if builtins.isFunction preConfigure
+            then preConfigure { inherit externalLibs; }
+            else preConfigure;
+        in selectedBackend.buildPlugin {
+          inherit pkgs src config postInstall;
+          preConfigure = preConfigureStr;
+          moduleDeps = resolvedModuleDeps;
+          inherit externalLibs;
+          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs;
+          extraBuildInputs = extraBuildInputs ++ runtimePkgs;
+        };
+
+      moduleLib = buildVariant "default";
+      moduleLibPortable = if hasVariants then buildVariant "portable" else null;
 
       # Delegate header generation to the backend
       moduleInclude = selectedBackend.buildHeaders {
@@ -101,8 +137,10 @@ let
         pluginLib = moduleLib;
       };
 
-      # Combined package - copy files instead of symlinks
-      combined = pkgs.runCommand "logos-${config.name}-module" {} ''
+      # Combined package - copy files instead of symlinks.
+      # The `//` merge exposes src + version on the derivation so downstream
+      # bundlers (nix-bundle-lgx) can locate metadata.json.
+      combined = (pkgs.runCommand "logos-${config.name}-module" {} ''
         mkdir -p $out/lib $out/include
 
         # Copy library files (not symlinks)
@@ -114,7 +152,7 @@ let
         if [ -d "${moduleInclude}/include" ] && [ -n "$(find ${moduleInclude}/include -maxdepth 1 -not -name '.*' -not -path ${moduleInclude}/include -print -quit)" ]; then
           cp -rL ${moduleInclude}/include/* $out/include/
         fi
-      '';
+      '') // { inherit src; version = config.version; };
 
     in {
       # Individual outputs (e.g., nix build .#chat-lib)
@@ -127,6 +165,9 @@ let
 
       # Default package - combined lib + include (nix build)
       default = combined;
+    } // lib.optionalAttrs (moduleLibPortable != null) {
+      "${config.name}-lib-portable" = moduleLibPortable;
+      lib-portable = moduleLibPortable;
     }
   );
 
@@ -164,11 +205,14 @@ let
           installDev = nix-bundle-logos-module-install.bundlers.${system}.dev;
           installPortable = nix-bundle-logos-module-install.bundlers.${system}.portable;
           moduleLib = packages.${system}.lib;
+          # Use the portable-linked plugin for lgx-portable when available
+          moduleLibForPortable =
+            packages.${system}.lib-portable or moduleLib;
         in {
           lgx = bundleLgx moduleLib;
-          lgx-portable = bundleLgxPortable moduleLib;
           install = installDev moduleLib;
-          install-portable = installPortable moduleLib;
+          lgx-portable = bundleLgxPortable moduleLibForPortable;
+          install-portable = installPortable moduleLibForPortable;
         }
       );
     };


### PR DESCRIPTION
- `mkLogosModule` now determines if the externalLibInput is "raw" source code (needs to build with `make` or whatever `build_command` was passed) or a nix flake derivation (needs to build with `nix build`) and handles it accordingly.
- the module's `preConfigure` can now optionally be a function that receives the path to the built external libraries
- Allow specifying different external library versions for the standard (dev) module outputs and the portable ones.
This is required by logos-package-manager-module, which must link against `logos-package-manager#lib` in its `#lib`/`#lgx` output, and aginast `logos-package-manager#lib-portable` in its `#lib-portable`/`#lgx-portable` output.

Example usage: https://github.com/logos-co/logos-package-manager-module/pull/42

