### PR TITLE
fix: support static libraries (.a) in EXTERNAL_LIBS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,9 @@ jobs:
 
       - name: Run QML integration tests
         run: nix build '.#checks.x86_64-linux.qml-integration'
+
+      - name: Run static external library tests
+        run: nix build '.#checks.x86_64-linux.static-extlib'
+
+      - name: Run test-framework integration tests
+        run: nix build '.#checks.x86_64-linux.test-framework-integration'

--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -380,11 +380,11 @@ function(logos_module)
     foreach(ext_lib ${MODULE_EXTERNAL_LIBS})
         set(EXT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
         
-        # Find the library
+        # Find the library (prefer shared, fall back to static)
         if(APPLE)
-            set(EXT_LIB_NAMES lib${ext_lib}.dylib lib${ext_lib}.so ${ext_lib}.dylib ${ext_lib}.so)
+            set(EXT_LIB_NAMES lib${ext_lib}.dylib lib${ext_lib}.so ${ext_lib}.dylib ${ext_lib}.so lib${ext_lib}.a ${ext_lib}.a)
         else()
-            set(EXT_LIB_NAMES lib${ext_lib}.so lib${ext_lib}.dylib ${ext_lib}.so ${ext_lib}.dylib)
+            set(EXT_LIB_NAMES lib${ext_lib}.so lib${ext_lib}.dylib ${ext_lib}.so ${ext_lib}.dylib lib${ext_lib}.a ${ext_lib}.a)
         endif()
         
         find_library(${ext_lib}_PATH NAMES ${EXT_LIB_NAMES} PATHS ${EXT_LIB_DIR} NO_DEFAULT_PATH)
@@ -393,14 +393,16 @@ function(logos_module)
             target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${${ext_lib}_PATH})
             target_include_directories(${MODULE_NAME}_module_plugin PRIVATE ${EXT_LIB_DIR})
             
-            # Copy to output directory
+            # Copy shared libraries to output directory (static archives are linked in, no runtime copy needed)
             get_filename_component(EXT_LIB_FILENAME "${${ext_lib}_PATH}" NAME)
-            add_custom_command(TARGET ${MODULE_NAME}_module_plugin PRE_LINK
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                    ${${ext_lib}_PATH}
-                    ${CMAKE_BINARY_DIR}/modules/${EXT_LIB_FILENAME}
-                COMMENT "Copying ${EXT_LIB_FILENAME} to modules directory"
-            )
+            if(NOT EXT_LIB_FILENAME MATCHES "\\.a$")
+                add_custom_command(TARGET ${MODULE_NAME}_module_plugin PRE_LINK
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        ${${ext_lib}_PATH}
+                        ${CMAKE_BINARY_DIR}/modules/${EXT_LIB_FILENAME}
+                    COMMENT "Copying ${EXT_LIB_FILENAME} to modules directory"
+                )
+            endif()
         else()
             message(WARNING "External library ${ext_lib} not found in ${EXT_LIB_DIR}")
         endif()

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,10 @@
           inherit (lib) parseMetadata;
           fixturesRoot = ./tests/fixtures;
         };
+        # Integration test: verifies static library (.a) support in EXTERNAL_LIBS
+        static-extlib = import ./tests/test-static-extlib.nix {
+          inherit pkgs;
+        };
       });
 
       # Development shell for working on the builder itself

--- a/tests/test-static-extlib.nix
+++ b/tests/test-static-extlib.nix
@@ -1,0 +1,117 @@
+# Integration tests for static library (.a) support in EXTERNAL_LIBS
+# Verifies commit 3d3a6830: .a files are discoverable via find_library and the
+# runtime copy step is skipped for static archives (linked at build time).
+{ pkgs }:
+
+let
+  logosModuleCmake = ../cmake/LogosModule.cmake;
+
+  # cmake -P script: find_library resolves a .a when no shared lib is present.
+  # LIB_DIR is injected via -D on the cmake command line.
+  findStaticScript = pkgs.writeText "find_static_test.cmake" ''
+    find_library(staticonly_PATH
+      NAMES libstaticonly.dylib libstaticonly.so staticonly.dylib staticonly.so
+            libstaticonly.a staticonly.a
+      PATHS ''${LIB_DIR} NO_DEFAULT_PATH)
+    if(NOT staticonly_PATH)
+      message(FATAL_ERROR "FAIL: find_library did not locate libstaticonly.a")
+    endif()
+    get_filename_component(FOUND_NAME "''${staticonly_PATH}" NAME)
+    if(NOT FOUND_NAME STREQUAL "libstaticonly.a")
+      message(FATAL_ERROR "FAIL: expected libstaticonly.a, got ''${FOUND_NAME}")
+    endif()
+    message(STATUS "FOUND: ''${staticonly_PATH}")
+  '';
+
+  # cmake -P script: find_library prefers a shared lib over .a when both exist.
+  findPreferSharedScript = pkgs.writeText "find_prefer_shared_test.cmake" ''
+    find_library(duallib_PATH
+      NAMES libduallib.dylib libduallib.so duallib.dylib duallib.so
+            libduallib.a duallib.a
+      PATHS ''${LIB_DIR} NO_DEFAULT_PATH)
+    if(NOT duallib_PATH)
+      message(FATAL_ERROR "FAIL: find_library found nothing in dual-lib dir")
+    endif()
+    get_filename_component(FOUND_NAME "''${duallib_PATH}" NAME)
+    if(FOUND_NAME STREQUAL "libduallib.a")
+      message(FATAL_ERROR "FAIL: find_library chose .a over shared lib (wrong preference)")
+    endif()
+    message(STATUS "PREFERRED: ''${duallib_PATH}")
+  '';
+
+  # cmake -P script: verify the .a$ MATCHES regex used in the copy guard.
+  regexScript = pkgs.writeText "regex_test.cmake" ''
+    foreach(name libfoo.a foo.a libbar.a)
+      if(NOT ''${name} MATCHES "\\.a$")
+        message(FATAL_ERROR "FAIL: ''${name} should match \\.a$ but did not")
+      endif()
+    endforeach()
+    foreach(name libfoo.so libfoo.dylib foo.so foo.dylib libfoo.so.1)
+      if(''${name} MATCHES "\\.a$")
+        message(FATAL_ERROR "FAIL: ''${name} should NOT match \\.a$ but did")
+      endif()
+    endforeach()
+    message(STATUS "All regex tests passed")
+  '';
+
+  sharedExt = if pkgs.stdenv.hostPlatform.isDarwin then "dylib" else "so";
+
+in pkgs.runCommand "static-extlib-tests" {
+  nativeBuildInputs = [ pkgs.cmake ];
+} ''
+  set -euo pipefail
+  echo "=== Static External Library (.a) Tests ==="
+
+  # -------------------------------------------------------------------
+  # Test 1: find_library NAMES list now includes .a entries
+  # (verifies the "prefer shared, fall back to static" comment added by commit)
+  # -------------------------------------------------------------------
+  grep -q 'prefer shared, fall back to static' ${logosModuleCmake}
+  echo "PASS: .a names added to find_library NAMES list (shared preferred, .a fallback)"
+
+  # -------------------------------------------------------------------
+  # Test 2: .a$ guard wraps copy_if_different (NOT EXT_LIB_FILENAME MATCHES)
+  # -------------------------------------------------------------------
+  grep -q 'NOT EXT_LIB_FILENAME MATCHES' ${logosModuleCmake}
+  echo "PASS: copy_if_different is guarded by NOT EXT_LIB_FILENAME MATCHES"
+
+  # -------------------------------------------------------------------
+  # Test 3: copy step is skipped for static archives (comment in commit)
+  # -------------------------------------------------------------------
+  grep -q 'static archives are linked in' ${logosModuleCmake}
+  echo "PASS: comment confirms static archives skip the runtime copy step"
+
+  # -------------------------------------------------------------------
+  # Test 4: copy_if_different command is still present (not removed)
+  # -------------------------------------------------------------------
+  grep -q 'copy_if_different' ${logosModuleCmake}
+  echo "PASS: copy_if_different still present for shared library handling"
+
+  # -------------------------------------------------------------------
+  # Test 5: cmake find_library resolves .a when only static archive present
+  # -------------------------------------------------------------------
+  mkdir -p testdir_static/lib
+  touch testdir_static/lib/libstaticonly.a
+  cmake -DLIB_DIR="$PWD/testdir_static/lib" -P ${findStaticScript} 2>&1 | grep -q 'FOUND:'
+  echo "PASS: find_library resolves .a when only static archive is present"
+
+  # -------------------------------------------------------------------
+  # Test 6: cmake find_library prefers shared lib over .a when both exist
+  # -------------------------------------------------------------------
+  mkdir -p testdir_dual/lib
+  touch "testdir_dual/lib/libduallib.${sharedExt}"
+  touch testdir_dual/lib/libduallib.a
+  cmake -DLIB_DIR="$PWD/testdir_dual/lib" -P ${findPreferSharedScript} 2>&1 | grep -q 'PREFERRED:'
+  echo "PASS: find_library prefers shared lib over .a when both exist"
+
+  # -------------------------------------------------------------------
+  # Test 7: .a$ regex correctly identifies static archives vs shared libs
+  # -------------------------------------------------------------------
+  cmake -P ${regexScript} 2>&1 | grep -q 'All regex tests passed'
+  echo "PASS: .a\$ regex correctly classifies static archives and shared libs"
+
+  echo ""
+  echo "All static external library tests passed."
+  mkdir -p $out
+  echo "passed" > $out/results.txt
+''


### PR DESCRIPTION
- Add .a to the search pattern and 
- skip the runtime copy step for static archives since they are linked into the plugin binary at build time