### PR TITLE
derive module name and version from metadata.json in templates

### DIFF
--- a/templates/external-lib-module/CMakeLists.txt
+++ b/templates/external-lib-module/CMakeLists.txt
@@ -13,10 +13,21 @@ else()
     message(FATAL_ERROR "LogosModule.cmake not found")
 endif()
 
+# Derive module identity from metadata.json
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/metadata.json" METADATA_JSON)
+string(JSON MODULE_NAME GET ${METADATA_JSON} name)
+string(JSON MODULE_VERSION GET ${METADATA_JSON} version)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/module_config.h"
+    "#pragma once\n"
+    "#define MODULE_NAME \"${MODULE_NAME}\"\n"
+    "#define MODULE_VERSION \"${MODULE_VERSION}\"\n"
+)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 # Define the module with external library
 logos_module(
-    NAME external_lib
-    SOURCES 
+    NAME ${MODULE_NAME}
+    SOURCES
         src/external_lib_interface.h
         src/external_lib_plugin.h
         src/external_lib_plugin.cpp

--- a/templates/external-lib-module/src/external_lib_plugin.cpp
+++ b/templates/external-lib-module/src/external_lib_plugin.cpp
@@ -28,7 +28,7 @@ void ExternalLibPlugin::initLogos(LogosAPI* api)
     qDebug() << "ExternalLibPlugin: initLogos called";
     m_logosAPI = api;
     
-    emit eventResponse("initialized", QVariantList() << "external_lib" << "1.0.0");
+    emit eventResponse("initialized", QVariantList() << name() << version());
 }
 
 bool ExternalLibPlugin::initLibrary(const QString& config)

--- a/templates/external-lib-module/src/external_lib_plugin.h
+++ b/templates/external-lib-module/src/external_lib_plugin.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QString>
 #include "external_lib_interface.h"
+#include "module_config.h"
 
 // Include the external library header
 // This would be the actual C header from the external library
@@ -27,8 +28,8 @@ public:
     ~ExternalLibPlugin() override;
 
     // PluginInterface implementation
-    QString name() const override { return "external_lib"; }
-    QString version() const override { return "1.0.0"; }
+    QString name() const override { return MODULE_NAME; }
+    QString version() const override { return MODULE_VERSION; }
     void initLogos(LogosAPI* api) override;
 
     // ExternalLibInterface implementation

--- a/templates/minimal-module/CMakeLists.txt
+++ b/templates/minimal-module/CMakeLists.txt
@@ -14,10 +14,21 @@ else()
     message(FATAL_ERROR "LogosModule.cmake not found")
 endif()
 
+# Derive module identity from metadata.json
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/metadata.json" METADATA_JSON)
+string(JSON MODULE_NAME GET ${METADATA_JSON} name)
+string(JSON MODULE_VERSION GET ${METADATA_JSON} version)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/module_config.h"
+    "#pragma once\n"
+    "#define MODULE_NAME \"${MODULE_NAME}\"\n"
+    "#define MODULE_VERSION \"${MODULE_VERSION}\"\n"
+)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 # Define the module
 logos_module(
-    NAME minimal
-    SOURCES 
+    NAME ${MODULE_NAME}
+    SOURCES
         src/minimal_interface.h
         src/minimal_plugin.h
         src/minimal_plugin.cpp

--- a/templates/minimal-module/src/minimal_plugin.cpp
+++ b/templates/minimal-module/src/minimal_plugin.cpp
@@ -33,7 +33,7 @@ QString MinimalPlugin::greet(const QString& name)
 {
     qDebug() << "MinimalPlugin: greet called with name:" << name;
     
-    QString greeting = QString("Hello, %1! Greetings from the Minimal module.").arg(name);
+    QString greeting = QString("Hello, %1! Greetings from %2 v%3.").arg(name, this->name(), version());
     
     // Emit an event for the greeting
     emit eventResponse("greeted", QVariantList() << name << greeting);

--- a/templates/minimal-module/src/minimal_plugin.h
+++ b/templates/minimal-module/src/minimal_plugin.h
@@ -6,6 +6,7 @@
 #include "minimal_interface.h"
 #include "logos_api.h"
 #include "logos_sdk.h"
+#include "module_config.h"
 
 /**
  * @brief Minimal module plugin implementation
@@ -24,8 +25,8 @@ public:
     ~MinimalPlugin() override;
 
     // PluginInterface implementation
-    QString name() const override { return "minimal"; }
-    QString version() const override { return "1.0.0"; }
+    QString name() const override { return MODULE_NAME; }
+    QString version() const override { return MODULE_VERSION; }
 
     // MinimalInterface implementation
     Q_INVOKABLE QString greet(const QString& name) override;

--- a/templates/ui-qml-backend/CMakeLists.txt
+++ b/templates/ui-qml-backend/CMakeLists.txt
@@ -7,8 +7,19 @@ else()
     message(FATAL_ERROR "LogosModule.cmake not found. Set LOGOS_MODULE_BUILDER_ROOT.")
 endif()
 
+# Derive module identity from metadata.json
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/metadata.json" METADATA_JSON)
+string(JSON MODULE_NAME GET ${METADATA_JSON} name)
+string(JSON MODULE_VERSION GET ${METADATA_JSON} version)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/module_config.h"
+    "#pragma once\n"
+    "#define MODULE_NAME \"${MODULE_NAME}\"\n"
+    "#define MODULE_VERSION \"${MODULE_VERSION}\"\n"
+)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 logos_module(
-    NAME ui_example
+    NAME ${MODULE_NAME}
     REP_FILE src/ui_example.rep
     SOURCES
         src/ui_example_interface.h

--- a/templates/ui-qml-backend/src/ui_example_plugin.h
+++ b/templates/ui-qml-backend/src/ui_example_plugin.h
@@ -6,6 +6,7 @@
 #include "ui_example_interface.h"
 #include "LogosViewPluginBase.h"
 #include "rep_ui_example_source.h"
+#include "module_config.h"
 
 class LogosAPI;
 
@@ -23,8 +24,8 @@ public:
     explicit UiExamplePlugin(QObject* parent = nullptr);
     ~UiExamplePlugin() override;
 
-    QString name()    const override { return "ui_example"; }
-    QString version() const override { return "1.0.0"; }
+    QString name()    const override { return MODULE_NAME; }
+    QString version() const override { return MODULE_VERSION; }
 
     Q_INVOKABLE void initLogos(LogosAPI* api);
 


### PR DESCRIPTION
Currently name() and version() must be implemented in PluginInterface, but they need to be changed manually whenever the module's identity changes. The name also has to be set separately in CMakeLists.txt. This means renaming or versioning a module touches at least three places and they can drift out of sync.

This patch makes metadata.json the single source of truth for every plugin. During the Nix build, CMake reads name and version from metadata.json  and generates a module_config.h into the build directory. Plugin headers include this generated header and return MODULE_NAME / MODULE_VERSION instead of hardcoded string literals. The logos_module() NAME argument is also driven from the same read, so renaming and versioning is now managed entirely from metadata.json