### PR TITLE
feat(mkLogosModule): auto-stage external_libraries in dev shell

### DIFF
--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -264,7 +264,11 @@ let
     }
   );
 
-  # Development shell (delegates to backend for deps)
+  # Development shell (delegates to backend for deps).
+  # Also stages any resolved external_libraries into ./lib so non-Nix
+  # iteration (clangd, IDEs, raw `cmake`) finds them the same way the
+  # in-sandbox build does, and exports DYLD_/LD_/CMAKE_ paths +
+  # CMAKE_EXPORT_COMPILE_COMMANDS so editor tooling Just Works.
   devShells = forAllSystems (system:
     let
       pkgs = import nixpkgs { inherit system; };
@@ -273,14 +277,70 @@ let
       backendShell = selectedBackend.devShellInputs pkgs { inherit logosModule; };
       buildPkgs = map (getPkg pkgs) config.nix_packages.build;
       runtimePkgs = map (getPkg pkgs) config.nix_packages.runtime;
+
+      # Re-use the same resolver/builder the package outputs use, with the
+      # "default" variant. Keeps dev-shell behaviour aligned with what
+      # `nix build` would produce — no second source of truth for which
+      # cdylib/header set the module links against.
+      resolveExtInputSystem = variant: name: value:
+        if builtins.isAttrs value && value ? input then
+          let
+            flakeInput = value.input;
+            packages = value.packages or {};
+            pkgName = packages.${variant} or packages.default or "default";
+          in
+            if flakeInput ? packages.${system}.${pkgName}
+            then flakeInput.packages.${system}.${pkgName}
+            else builtins.throw ''
+              External lib "${name}": flake input does not provide packages.${system}.${pkgName}.
+              Check the "externalLibInputs" structured entry and ensure the flake input exposes the expected package.
+            ''
+        else
+          if value ? packages.${system}.default then value.packages.${system}.default else value;
+
+      shellExternalLibs = mkExternalLib.buildExternalLibs {
+        inherit pkgs config;
+        externalInputs = lib.mapAttrs (resolveExtInputSystem "default") externalLibInputs;
+      };
+      extLibValues = lib.filter (v: v != null) (lib.attrValues shellExternalLibs);
+
+      libPathVar =
+        if pkgs.stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH"
+        else "LD_LIBRARY_PATH";
+
+      # Symlink each external lib's $out/lib/* and $out/include/*.h into ./lib
+      # (the convention used by modulePreConfigure.copyExternalLibsToLib and by
+      # the external-lib-module template's CMakeLists.txt) + export search
+      # paths. Idempotent: ln -sfn replaces stale symlinks on each shell entry.
+      stageExtLibsHook = lib.optionalString (extLibValues != []) ''
+        # logos-module-builder: staging external_libraries into ./lib
+        mkdir -p ./lib
+        ${lib.concatMapStringsSep "\n" (v: ''
+          for f in ${v}/lib/*; do
+            [ -e "$f" ] || continue
+            ln -sfn "$f" "./lib/$(basename "$f")"
+          done
+          for h in ${v}/include/*.h; do
+            [ -e "$h" ] || continue
+            ln -sfn "$h" "./lib/$(basename "$h")"
+          done
+        '') extLibValues}
+        ${lib.concatMapStringsSep "\n" (v: ''
+          export ${libPathVar}="${v}/lib''${${libPathVar}:+:''$${libPathVar}}"
+          export CMAKE_LIBRARY_PATH="${v}/lib''${CMAKE_LIBRARY_PATH:+:''$CMAKE_LIBRARY_PATH}"
+          export CMAKE_INCLUDE_PATH="${v}/include''${CMAKE_INCLUDE_PATH:+:''$CMAKE_INCLUDE_PATH}"
+        '') extLibValues}
+        export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+      '';
     in {
       default = pkgs.mkShell {
         nativeBuildInputs = backendShell.nativeBuildInputs ++ buildPkgs ++ [ logosSdk ];
-        buildInputs = backendShell.buildInputs ++ runtimePkgs;
+        buildInputs = backendShell.buildInputs ++ runtimePkgs ++ extLibValues;
         shellHook = ''
           ${backendShell.shellHook}
           export LOGOS_CPP_SDK_ROOT="${logosSdk}"
           ${lib.optionalString hasBuilderCmake ''export LOGOS_MODULE_BUILDER_ROOT="${builderRoot}"''}
+          ${stageExtLibsHook}
           echo "Logos ${config.name} module development environment"
           echo "LOGOS_CPP_SDK_ROOT: $LOGOS_CPP_SDK_ROOT"
           echo "LOGOS_MODULE_ROOT: $LOGOS_MODULE_ROOT"


### PR DESCRIPTION
Closes #97.

## What

When the consumer passes a non-empty `externalLibInputs`, `mkLogosModule`'s dev shell now:

1. Builds the external libraries (reusing the same `resolveExtInput` + `mkExternalLib.buildExternalLibs` path the package outputs already use).
2. Symlinks each one's `lib/*` and `include/*.h` into `./lib` so the module's existing `CMakeLists.txt` (`find_library(... PATHS lib NO_DEFAULT_PATH)`) resolves it outside the Nix sandbox.
3. Exports `DYLD_LIBRARY_PATH` (Darwin) / `LD_LIBRARY_PATH` (Linux) + `CMAKE_LIBRARY_PATH` + `CMAKE_INCLUDE_PATH`.
4. Exports `CMAKE_EXPORT_COMPILE_COMMANDS=ON` for clangd.

## Why

Every universal C++ module wrapping a Rust `cdylib` (or any external lib declared in `metadata.json#nix.external_libraries`) currently writes the same dev-shell override to make `nix develop` work with clangd / IDEs / plain `cmake`. The most recent example is [`eth-lez-atomic-swaps` PR #26](https://github.com/logos-co/eth-lez-atomic-swaps/pull/26). After this lands, that ~40-line block disappears downstream.

Full rationale + design questions in #97.

## Backward compatibility

- Modules without `external_libraries`: zero change (the new behaviour is gated on the list being non-empty).
- Modules that already override `devShells.<system>.default`: keep working.
- `nix build` derivations: untouched. Only `nix develop` is affected.

## Verification

- `nix flake check` passes on `aarch64-darwin` (all 4 checks, including `devShells.aarch64-darwin.default`).
- One file changed, `+62 / −2`.

## Notes for review

A few small calls in here I'd like a second opinion on (also in #97):

- Symlink vs copy when staging into `./lib`. Using symlinks here so a cdylib rebuild is picked up on the next shell entry; the in-sandbox `copyExternalLibsToLib` uses `cp`. Worth surfacing.
- Header glob is `*.h` only — happy to extend to `*.hpp` / extension-less outputs if anyone needs it.
- "Auto whenever `externalLibInputs` is non-empty" vs an explicit `autoStageExternalLibs` toggle. I went with implicit.
- `resolveExtInput` is duplicated locally inside `devShells` rather than hoisted, to keep the blast radius small. Happy to lift it as a follow-up if reviewers prefer.
