### PR TITLE
fix(tests): expose runtime dlopen deps on loader path for test run

### DIFF
--- a/lib/mkLogosModuleTests.nix
+++ b/lib/mkLogosModuleTests.nix
@@ -100,6 +100,16 @@ let
         "${resolvedExternalLibs.${name}}/lib"
       ) (builtins.attrNames resolvedExternalLibs);
 
+      # Loader search path for the test run. Test binaries execute in place during
+      # buildPhase, so any runtime dependency that a real (non-mocked) library
+      # dlopens by bare name — e.g. libpq pulled in by a module's C library — must
+      # be reachable via the dynamic loader. Those deps are the runtime nix
+      # packages declared in metadata (nix.packages.runtime) plus the resolved
+      # external libraries. Linked deps already resolve via CMAKE_INSTALL_RPATH;
+      # this covers the dlopen-by-bare-name case the rpath cannot.
+      testRuntimeLibPath =
+        lib.makeLibraryPath (runtimePkgs ++ lib.attrValues resolvedExternalLibs);
+
       userPreConfigure =
         if builtins.isFunction preConfigure
         then preConfigure { externalLibs = resolvedExternalLibs; }
@@ -171,6 +181,13 @@ let
             ${lib.optionalString (externalLibRpath != "") "-DCMAKE_INSTALL_RPATH=${externalLibRpath} -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"} \
             ${lib.concatMapStringsSep " " (f: f) (goCmakeTestFlags ++ extraCmakeFlags)}
           cmake --build . --parallel $NIX_BUILD_CORES
+
+          ${lib.optionalString (testRuntimeLibPath != "") ''
+            # Make runtime dependencies (e.g. libpq) discoverable for real
+            # libraries that dlopen them by bare name during the test run.
+            export LD_LIBRARY_PATH="${testRuntimeLibPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            export DYLD_LIBRARY_PATH="${testRuntimeLibPath}''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+          ''}
 
           # Run all test binaries (unit tests first, integration tests last)
           echo "Running ${config.name} tests..."


### PR DESCRIPTION
Test binaries run in place during `buildPhase`. Linked deps resolve via `CMAKE_INSTALL_RPATH`, but a real (non-mocked) library that `dlopen`s a runtime dep by bare name can't be found — rpath doesn't apply to a bare soname.

This breaks `logos-delivery-module`: its integration test starts a real node, `liblogosdelivery` `dlopen`s `libpq` at startup, and the test fails with `could not load: libpq.so(.5|)` despite `postgresql` being in the module's `nix.packages.runtime`.

Fix: put the module's declared runtime packages and external libs on `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` for the test run — the harness analogue of the bundling `mkLogosModule` already does for shipped modules. Modules can then drop their per-module `tests.preConfigure` workarounds.

Verified by building `logos-delivery-module`'s tests against this branch (with its libpq workaround removed): `9 passed`, no load error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)