### PR TITLE
chore: bump logos-cpp-sdk (provider event threading fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779205755,
-        "narHash": "sha256-iyVLixHdgdCbqdqwUdX4XfN9sg7dCH3yfs4F9tGcDLc=",
+        "lastModified": 1779716125,
+        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "8bdbd13848aedb28f1e0ca7475163c7774c63636",
+        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-cpp-sdk` to pick up logos-co/logos-cpp-sdk#68, which marshals provider event emission onto the remoting source thread — fixing method replies being silently dropped when a call emits an event mid-execution.

`flake.lock` only: `logos-cpp-sdk` `8bdbd13` → `d77c3dd`.