### PR TITLE
Document method doc-comment convention

### DIFF
--- a/docs/nix-api.md
+++ b/docs/nix-api.md
@@ -137,6 +137,14 @@ The builder prepends steps before your `preConfigure`:
 
 - **`"interface": "provider"`** — runs `logos-cpp-generator --provider-header` on `src/<name>_impl.h`. Override with `"codegen": { "provider_header": "src/other.h" }`.
 
+  > **Method docs:** a comment directly above a method's declaration becomes that method's
+  > `description`, carried in `getMethods()` and shown by `lm methods`, `logoscore module-info`,
+  > and Basecamp's Methods list:
+  > ```cpp
+  > /// Processes the input and returns a result.
+  > LOGOS_METHOD QString doSomething(const QString& input);
+  > ```
+
 - **External libraries** — `logos-plugin-qt` already copies flake-built externals into `lib/` before your hook; you usually do **not** need to `cp` them in `preConfigure`.
 
 - **`go_build: true`** on an `nix.external_libraries` entry — passes `-DLOGOS_MODULE_GO_STATIC_LIBS=…` to CMake so `LogosModule.cmake` links the static archive with whole-archive / `-force_load` as needed.

--- a/flake.lock
+++ b/flake.lock
@@ -177,16 +177,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1780520803,
+        "lastModified": 1780583907,
         "narHash": "sha256-BVYWW8sFPmTrWCUZc9IgPRI3C0dPw1aEz0ddphlRrho=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "9a394ffbc36730c6e7fc5f0c74bb7338c42639ae",
+        "rev": "760916e97b1feff928c1d86ef61a28e043326778",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
-        "ref": "parse-method-comments-as-description",
         "repo": "logos-cpp-sdk",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780510434,
-        "narHash": "sha256-iUdftNps5f3aLIdmClMvULcjAhZy5eMvDbjrqBRTDD0=",
+        "lastModified": 1780520096,
+        "narHash": "sha256-rwLFZWYYhlvI+md/sGlT3m5lWd1dYMTZRMrT3ChKj2w=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "8b32e19fc5fa908dbadc596449a198ca1cccd269",
+        "rev": "46378768245bca4f62937b074c755d657fa82aec",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780520096,
-        "narHash": "sha256-rwLFZWYYhlvI+md/sGlT3m5lWd1dYMTZRMrT3ChKj2w=",
+        "lastModified": 1780520803,
+        "narHash": "sha256-BVYWW8sFPmTrWCUZc9IgPRI3C0dPw1aEz0ddphlRrho=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "46378768245bca4f62937b074c755d657fa82aec",
+        "rev": "9a394ffbc36730c6e7fc5f0c74bb7338c42639ae",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -177,15 +177,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1780426494,
-        "narHash": "sha256-u4S2n1wTpLMcWjJKIEYvFcesu8W7bkz3713bap9+phs=",
+        "lastModified": 1780510434,
+        "narHash": "sha256-iUdftNps5f3aLIdmClMvULcjAhZy5eMvDbjrqBRTDD0=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "c71089abe9cb4ad169bccfb7cdb8d0d42523a148",
+        "rev": "8b32e19fc5fa908dbadc596449a198ca1cccd269",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "parse-method-comments-as-description",
         "repo": "logos-cpp-sdk",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1780583965,
+        "narHash": "sha256-mp2J60ULkWIORERo/rd4BTRcFjBXvdL+JmVg3URMT6M=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "740d484bb1f90f3ed6697a7cadc99766a0926226",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,9 @@
   inputs = {
     logos-nix.url = "github:logos-co/logos-nix";
     # SDK and module deps — owned by this builder, injected into backends
-    logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
+    # Pinned to the method-description branch so the generator emits per-method
+    # `description` from impl-header doc comments (verification branch).
+    logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk/parse-method-comments-as-description";
     logos-module.url = "github:logos-co/logos-module";
     # UI modules (type: ui, ui_qml) always use Qt
     logos-plugin-qt.url = "github:logos-co/logos-plugin-qt";

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,7 @@
   inputs = {
     logos-nix.url = "github:logos-co/logos-nix";
     # SDK and module deps — owned by this builder, injected into backends
-    # Pinned to the method-description branch so the generator emits per-method
-    # `description` from impl-header doc comments (verification branch).
-    logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk/parse-method-comments-as-description";
+    logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-module.url = "github:logos-co/logos-module";
     # UI modules (type: ui, ui_qml) always use Qt
     logos-plugin-qt.url = "github:logos-co/logos-plugin-qt";


### PR DESCRIPTION
## What

- `docs/nix-api.md`: document that a `///` doc comment above a method becomes its `description` (surfaced by `lm`, `logoscore module-info`, Basecamp).

## ⚠️ Verification-only flake pin — revert before merge
This branch also repoints `logos-cpp-sdk` to the `parse-method-comments-as-description` branch (`flake.nix` + `flake.lock`) so the tutorial doctest builds modules with the description-emitting generator. **That pin is scaffolding** — drop it (point cpp-sdk back to a released `master`/tag) before merging; only the `docs/nix-api.md` change is intended to land.

Part of the coordinated `parse-method-comments-as-description` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)