### PR TITLE
feat: dependency interfaces — parse + resolve interface_dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780614855,
-        "narHash": "sha256-zPA+Otg8zYxSj9NIf003Uyp0PWMOBNOcyBbyVSnBLk4=",
+        "lastModified": 1780703083,
+        "narHash": "sha256-Z0nOivZhmNWprngIAxx1ZwpZPKH3EvZRTPzr3nTrMgs=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "3bdd8858f52bfefbc647536f2a9d1b8a5fe7dede",
+        "rev": "eb71a1aa90e05a98814138779680de2ea60a9ff2",
         "type": "github"
       },
       "original": {
@@ -4019,11 +4019,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779206088,
-        "narHash": "sha256-a+T5XY7KL1eFREtj4fzdMFnhD9BR8juSg9bQObbMeEQ=",
+        "lastModified": 1780703355,
+        "narHash": "sha256-QwLWoeYn0yMrldG63dWaH2lqyYFn7qgTi5XFlrgCJSc=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "8f8260e6f9aba54b55bf8cc88ddb673dabb7512b",
+        "rev": "f58fbaa25acbc547ae2671e2cddcc1517d6643f0",
         "type": "github"
       },
       "original": {

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -123,7 +123,9 @@ let
       resolvedInterfaceDeps = map (e: {
         inherit (e) name impl_class;
         path = if e.input != null
-               then "${flakeInputs.${e.input}}/${e.file}"
+               then (if flakeInputs ? ${e.input}
+                     then "${flakeInputs.${e.input}}/${e.file}"
+                     else throw "interface_dependencies: interface '${e.name}' references flake input '${e.input}', but no such input was passed to mkLogosModule (declare it in flake.nix and pass it via flakeInputs).")
                else "${src}/${e.file}";
       }) config.interface_dependencies;
 

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -113,6 +113,20 @@ let
         }
       ) moduleInputs;
 
+      # Resolve interface dependencies (method/event contracts) to concrete
+      # definition-file paths. A LOCAL interface lives in this repo's `src`;
+      # a REMOTE one comes from a flake input named by `input` — mirroring
+      # how `dependencies` resolve to flake inputs. We resolve the path here
+      # so the generator never touches flake inputs: it just receives
+      # `--interface <name>=<path>[=<impl_class>]`. (System-independent, but
+      # kept in this scope alongside resolvedModuleDeps for locality.)
+      resolvedInterfaceDeps = map (e: {
+        inherit (e) name impl_class;
+        path = if e.input != null
+               then "${flakeInputs.${e.input}}/${e.file}"
+               else "${src}/${e.file}";
+      }) config.interface_dependencies;
+
       # Resolve a single externalLibInputs entry for a given variant.
       # Supports both simple (bare flake input) and structured ({ input, packages }) formats.
       resolveExtInput = variant: name: value:
@@ -191,7 +205,7 @@ let
         # Delegate plugin compilation to the backend.
         # The backend only knows about Qt + logosModule (interface.h).
         # SDK (generator, lib, headers) is injected via extra* args.
-        in selectedBackend.buildPlugin {
+        in selectedBackend.buildPlugin ({
           inherit pkgs src config postInstall logosModule;
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
@@ -204,7 +218,13 @@ let
           } // lib.optionalAttrs hasBuilderCmake {
             LOGOS_MODULE_BUILDER_ROOT = "${builderRoot}";
           };
-        };
+        }
+        # Only pass interfaceDeps when the module declares any — keeps existing
+        # dependency-only modules buildable against a backend that predates the
+        # interface-dependencies feature (graceful degradation).
+        // lib.optionalAttrs (config.interface_dependencies != []) {
+          interfaceDeps = resolvedInterfaceDeps;
+        });
 
       moduleLib = buildVariant "default";
       moduleLibPortable = if hasVariants then buildVariant "portable" else null;

--- a/lib/parseMetadata.nix
+++ b/lib/parseMetadata.nix
@@ -23,6 +23,35 @@
       dependencies = safeList (raw.dependencies or []);
       include      = safeList (raw.include      or []);
 
+      # Interface dependencies — method/event contracts decoupled from any
+      # concrete module. The consumer binds an interface to a module name at
+      # runtime (modules().bind_<name>("some_module")). Each entry:
+      #   { name, file, input?, impl_class? }
+      #   name       — interface identifier → bound wrapper class + bind_<name>
+      #   file       — path to the .lidl/.h definition. For a local interface,
+      #                relative to this repo root; for a remote one, relative
+      #                to the flake input named by `input`.
+      #   input      — (optional) flake-input attr name hosting the interface,
+      #                mirroring how `dependencies` map to flake inputs. Absent
+      #                ⇒ local file in this repo.
+      #   impl_class — (required for .h definitions) the C++ class whose public
+      #                methods + logos_events: define the interface.
+      interface_dependencies = map (e:
+        let
+          file = e.file or (throw "interface_dependencies entry '${e.name or "?"}' must specify 'file'");
+          implClass = e.impl_class or null;
+          isHeader = lib.hasSuffix ".h" file || lib.hasSuffix ".hpp" file;
+        in
+          if isHeader && implClass == null
+          then throw "interface_dependencies entry '${e.name or file}' is a C++ header (${file}) and must specify 'impl_class'"
+          else {
+            name       = e.name or (throw "interface_dependencies entry must specify 'name'");
+            inherit file;
+            input      = e.input or null;
+            impl_class = implClass;
+          }
+      ) (safeList (raw.interface_dependencies or []));
+
       # Nix/build-only fields (nested under "nix" in metadata.json)
       nix_packages = {
         build   = safeList ((nix.packages or {}).build   or []);

--- a/lib/parseMetadata.nix
+++ b/lib/parseMetadata.nix
@@ -38,7 +38,12 @@
       #                methods + logos_events: define the interface.
       interface_dependencies = map (e:
         let
-          file = e.file or (throw "interface_dependencies entry '${e.name or "?"}' must specify 'file'");
+          # Reject non-object entries with a clear message rather than the
+          # low-level "is not an attribute set" error that `e.file` would
+          # otherwise raise on a bare string / list element.
+          _ok = if builtins.isAttrs e then true
+                else throw "interface_dependencies entries must be objects like { name, file, impl_class?, input? }, got: ${builtins.toJSON e}";
+          file = if _ok then (e.file or (throw "interface_dependencies entry '${e.name or "?"}' must specify 'file'")) else null;
           implClass = e.impl_class or null;
           isHeader = lib.hasSuffix ".h" file || lib.hasSuffix ".hpp" file;
         in


### PR DESCRIPTION
## Dependency interfaces — module builder

Part of a cross-repo feature (see logos-co/logos-cpp-sdk#74). A module declares a *header interface* in `metadata.json` and binds it to a module name at runtime; this PR teaches the builder to parse and resolve those declarations.

### This PR
- **`parseMetadata.nix`** — new top-level `interface_dependencies` array. Each entry is `{ name, file, impl_class?, input? }`; a `.h` entry without `impl_class` is a hard error.
- **`mkLogosModule.nix`** — resolves each entry to a concrete definition-file path: local (`${src}/file`) or cross-repo (`${flakeInputs.<input>}/file`, exactly how concrete `dependencies` map to flake inputs). The resolved `interfaceDeps` are threaded to the backend's `buildPlugin` **only when present**, so existing dependency-only modules are untouched.

### Cross-repo chain (merge order)
1. logos-co/logos-cpp-sdk#74 — the `--interface` generator flag
2. **logos-module-builder** ← this PR
3. logos-plugin-qt — passes `--interface` flags through the build
4. logos-test-modules — verification consumer
5. logos-tutorial — executable tutorial

### Verification
`nix-instantiate --parse` on both files; a downstream module declaring a local `.h` interface builds end-to-end through nix with all three repos overridden locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
