### PR TITLE
fix: bump logos-plugin-core to the interfaceDeps backend (unblocks tutorial)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3940,11 +3940,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779206088,
-        "narHash": "sha256-a+T5XY7KL1eFREtj4fzdMFnhD9BR8juSg9bQObbMeEQ=",
+        "lastModified": 1780703355,
+        "narHash": "sha256-QwLWoeYn0yMrldG63dWaH2lqyYFn7qgTi5XFlrgCJSc=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "8f8260e6f9aba54b55bf8cc88ddb673dabb7512b",
+        "rev": "f58fbaa25acbc547ae2671e2cddcc1517d6643f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Fix: tutorial (and any core module with `interface_dependencies`) fails to build

### Symptom
`logos-tutorial` CI fails building `calc_via_interface` with a nix eval error:

```
error: function 'buildPlugin' called with unexpected argument 'interfaceDeps'
```

(then everything downstream — inspect, install, logoscore calls — cascades.)

### Root cause
`flake.nix` has two inputs pointing at the same `logos-plugin-qt` repo:
`logos-plugin-qt` (→ `uiBackend`) and `logos-plugin-core` (→ `coreBackend`, used for
`type: core` modules). When the interface-dependencies feature merged, `logos-plugin-qt`
and `logos-cpp-sdk` were re-locked to the merged masters, but **`logos-plugin-core`
stayed at `8f8260e`** — which predates the `interfaceDeps` parameter on `buildPlugin`.

So `mkLogosModule` (which now passes `interfaceDeps` to `coreBackend.buildPlugin` when a
module declares `interface_dependencies`) blows up for **core** modules. Part 1's
`calc_module` is unaffected because it has no `interface_dependencies` (the `interfaceDeps`
arg is gated and never passed); only modules that actually declare interfaces hit it.

### Fix
Re-lock `logos-plugin-core` to the same merged `logos-plugin-qt` master
(`f58fbaa`). One node in `flake.lock`; `logos-plugin-qt` / `logos-cpp-sdk` were already
current.

### Verification
A `type: core` `interface: universal` module declaring `interface_dependencies` now
**evaluates and builds end-to-end** against this lock (bound `modules().bind_<iface>(...)`
wrapper generated, plugin compiled). After merge, re-running the logos-tutorial CI
(`tutorial-interface-dependencies`) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
