### PR TITLE
feat: consume concrete deps via LIDL (no dep plugin build) + publish lidl output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780703083,
-        "narHash": "sha256-Z0nOivZhmNWprngIAxx1ZwpZPKH3EvZRTPzr3nTrMgs=",
+        "lastModified": 1780929790,
+        "narHash": "sha256-lYhDm9E47IUNJwtSFVrdoOkLu/3bnaFzGx3agLPuXlQ=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "eb71a1aa90e05a98814138779680de2ea60a9ff2",
+        "rev": "42a8b9ed5c5deb29b984f86d7736c3c25a380655",
         "type": "github"
       },
       "original": {
@@ -3940,11 +3940,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780703355,
-        "narHash": "sha256-QwLWoeYn0yMrldG63dWaH2lqyYFn7qgTi5XFlrgCJSc=",
+        "lastModified": 1780929868,
+        "narHash": "sha256-yDxv9Cv5VEJDVqHz9qYCU3UXv+kCIjRoD90A7uGYuGU=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "f58fbaa25acbc547ae2671e2cddcc1517d6643f0",
+        "rev": "68090d0a976224ca1c3c606c486a9ac3dd7a4559",
         "type": "github"
       },
       "original": {
@@ -4019,11 +4019,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780703355,
-        "narHash": "sha256-QwLWoeYn0yMrldG63dWaH2lqyYFn7qgTi5XFlrgCJSc=",
+        "lastModified": 1780929868,
+        "narHash": "sha256-yDxv9Cv5VEJDVqHz9qYCU3UXv+kCIjRoD90A7uGYuGU=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "f58fbaa25acbc547ae2671e2cddcc1517d6643f0",
+        "rev": "68090d0a976224ca1c3c606c486a9ac3dd7a4559",
         "type": "github"
       },
       "original": {

--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -45,10 +45,13 @@ let
       # LIDL-based deps → bindings generated from the dep's published `lidl`
       # output (no dep plugin build). Deps without a `lidl` output take the
       # TRANSITIONAL header-copy fallback below (which builds them).
+      # Guard every level so a non-flake / raw-derivation dep input returns
+      # null (→ TRANSITIONAL header-copy fallback) rather than throwing.
       depLidlOf = name:
-        if flakeInputs ? ${name}
-        then (flakeInputs.${name}.packages.${system}.lidl or null)
-        else null;
+        let i = flakeInputs.${name} or null;
+        in if i != null && i ? packages && i.packages ? ${system}
+           then (i.packages.${system}.lidl or null)
+           else null;
       depIsLidl = name: (config.dependency_overrides ? ${name}) || (depLidlOf name != null);
       staticDeps = map (name:
         let ov = config.dependency_overrides.${name} or null;

--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -41,12 +41,39 @@ let
     let
       pkgs = import nixpkgs { inherit system; };
 
-      # Resolve module dependencies from inputs. Each entry is a struct
-      # exposing the dep's plugin (.lib) plus both header variants
-      # (.headers-qt / .headers-std) so the plugin builder can pick
-      # the one matching its own --api-style. See the matching block
-      # in mkLogosModule.nix for the full rationale + fallback chain.
-      moduleInputs = lib.filterAttrs (n: _: builtins.elem n config.dependencies) flakeInputs;
+      # ── Concrete dependency classification (mirrors mkLogosModule.nix) ──────
+      # LIDL-based deps → bindings generated from the dep's published `lidl`
+      # output (no dep plugin build). Deps without a `lidl` output take the
+      # TRANSITIONAL header-copy fallback below (which builds them).
+      depLidlOf = name:
+        if flakeInputs ? ${name}
+        then (flakeInputs.${name}.packages.${system}.lidl or null)
+        else null;
+      depIsLidl = name: (config.dependency_overrides ? ${name}) || (depLidlOf name != null);
+      staticDeps = map (name:
+        let ov = config.dependency_overrides.${name} or null;
+        in if ov != null then {
+             inherit name;
+             impl_class = ov.impl_class;
+             path = if ov.input != null
+                    then (if flakeInputs ? ${ov.input}
+                          then "${flakeInputs.${ov.input}}/${ov.file}"
+                          else throw "dependency_overrides.${name}: flake input '${ov.input}' was not passed to mkLogosQmlModule.")
+                    else "${src}/${ov.file}";
+           } else {
+             inherit name;
+             impl_class = null;
+             path = "${depLidlOf name}/${name}.lidl";
+           }
+      ) (lib.filter depIsLidl config.dependencies);
+      legacyHeaderDepNames = lib.filter (name: !(depIsLidl name)) config.dependencies;
+
+      # Resolve the TRANSITIONAL header-copy deps from inputs. Each entry is a
+      # struct exposing the dep's plugin (.lib) plus both header variants
+      # (.headers-qt / .headers-std) so the plugin builder can pick the one
+      # matching its own --api-style. See the matching block in mkLogosModule.nix
+      # for the full rationale + fallback chain. Remove once all deps publish LIDL.
+      moduleInputs = lib.filterAttrs (n: _: builtins.elem n legacyHeaderDepNames) flakeInputs;
       resolvedModuleDeps = lib.mapAttrs (_: input:
         let
           ps = input.packages.${system} or null;
@@ -132,7 +159,7 @@ let
             fixDarwin = false;
             copyExternals = false;
           };
-        in selectedBackend.buildPlugin {
+        in selectedBackend.buildPlugin ({
           inherit pkgs src config postInstall logosModule;
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
@@ -145,7 +172,11 @@ let
           } // lib.optionalAttrs hasBuilderCmake {
             LOGOS_MODULE_BUILDER_ROOT = "${src}";
           };
-        };
+        }
+        # LIDL-based concrete deps → `--dep` flags (no dep plugin build).
+        // lib.optionalAttrs (staticDeps != []) {
+          inherit staticDeps;
+        });
 
       moduleLib = buildVariant "default";
       moduleLibPortable = if hasVariants then buildVariant "portable" else null;

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -84,13 +84,51 @@ let
     let
       pkgs = import nixpkgs { inherit system; };
 
-      # Resolve module dependencies from inputs. Each entry is exposed
+      # ── Concrete dependency classification ─────────────────────────────────
+      # A dependency's typed `modules().<dep>` wrapper is generated from its
+      # published LIDL contract (`packages.<sys>.lidl`) WITHOUT building the
+      # dep's plugin. Deps that don't expose a `lidl` output yet take the
+      # TRANSITIONAL header-copy fallback (`legacyHeaderDepNames`), which DOES
+      # build them — identical to today's behavior.
+      depLidlOf = name:
+        if flakeInputs ? ${name}
+        then (flakeInputs.${name}.packages.${system}.lidl or null)
+        else null;
+      depIsLidl = name: (config.dependency_overrides ? ${name}) || (depLidlOf name != null);
+
+      # LIDL-based deps → `--dep <name>=<lidl>` for the generator. An override
+      # forces a specific definition (.lidl, or .h + impl_class); otherwise we
+      # use the dep's published `lidl` output.
+      staticDeps = map (name:
+        let ov = config.dependency_overrides.${name} or null;
+        in if ov != null then {
+             inherit name;
+             impl_class = ov.impl_class;
+             path = if ov.input != null
+                    then (if flakeInputs ? ${ov.input}
+                          then "${flakeInputs.${ov.input}}/${ov.file}"
+                          else throw "dependency_overrides.${name}: flake input '${ov.input}' was not passed to mkLogosModule.")
+                    else "${src}/${ov.file}";
+           } else {
+             inherit name;
+             impl_class = null;
+             path = "${depLidlOf name}/${name}.lidl";
+           }
+      ) (lib.filter depIsLidl config.dependencies);
+
+      # TRANSITIONAL: header-copy fallback for deps that predate the `lidl`
+      # output. These deps ARE built (their headers come from introspecting the
+      # compiled plugin). Remove this block — and the `moduleDepIncludes` use in
+      # the plugin backends — once every module exposes packages.<sys>.lidl.
+      legacyHeaderDepNames = lib.filter (name: !(depIsLidl name)) config.dependencies;
+
+      # Resolve the fallback deps from inputs. Each entry is exposed
       # as a struct so the plugin builder can pick BOTH the dep's
       # plugin .dylib AND the right header variant for its own
       # --api-style without re-running the codegen at consume time.
       # Backward-compatible fallbacks let older deps (which only
       # expose `default`) still work — they get treated as Qt-typed.
-      moduleInputs = lib.filterAttrs (n: _: builtins.elem n config.dependencies) flakeInputs;
+      moduleInputs = lib.filterAttrs (n: _: builtins.elem n legacyHeaderDepNames) flakeInputs;
       resolvedModuleDeps = lib.mapAttrs (_: input:
         let
           ps = input.packages.${system} or null;
@@ -226,6 +264,12 @@ let
         # interface-dependencies feature (graceful degradation).
         // lib.optionalAttrs (config.interface_dependencies != []) {
           interfaceDeps = resolvedInterfaceDeps;
+        }
+        # LIDL-based concrete deps → `--dep` flags (generate from the dep's
+        # published LIDL, no dep plugin build). Gated so a backend that predates
+        # this feature still builds (such deps then fall through unresolved).
+        // lib.optionalAttrs (staticDeps != []) {
+          inherit staticDeps;
         });
 
       moduleLib = buildVariant "default";
@@ -247,6 +291,28 @@ let
         pluginLib = moduleLib;
         apiStyle = "std";
       };
+
+      # Publish this module's interface as LIDL — the language-neutral contract
+      # a consumer turns into typed `modules().<name>` bindings WITHOUT building
+      # this module's plugin (source → LIDL → C++). Cheap: runs only the C++
+      # frontend (`--header-to-lidl`) over the impl header; no Qt/plugin compile.
+      # Produced for universal modules; the impl header + class come from the
+      # same convention `universalCodegen` uses (`codegen.impl_*` or defaults).
+      lidlImplClass = config.codegen.impl_class or (modulePreConfigure.defaultImplClassFromName config.name);
+      lidlIhRaw = config.codegen.impl_header or "${config.name}_impl.h";
+      lidlImplHeaderRel = if lib.hasInfix "/" lidlIhRaw then lidlIhRaw else "src/${lidlIhRaw}";
+      moduleLidl =
+        if config.interface == "universal"
+        then pkgs.runCommand "logos-${config.name}-lidl" {
+               nativeBuildInputs = [ logosSdk ];
+             } ''
+               mkdir -p $out
+               logos-cpp-generator --header-to-lidl "${src}/${lidlImplHeaderRel}" \
+                 --impl-class "${lidlImplClass}" \
+                 --metadata "${configFile}" \
+                 -o "$out/${config.name}.lidl"
+             ''
+        else null;
 
       # Combined package — copies the Qt-typed headers (backward
       # compat). The `//` merge exposes src + version on the derivation
@@ -283,6 +349,12 @@ let
     } // lib.optionalAttrs (moduleLibPortable != null) {
       "${config.name}-lib-portable" = moduleLibPortable;
       lib-portable = moduleLibPortable;
+    } // lib.optionalAttrs (moduleLidl != null) {
+      # Published LIDL contract — consumers generate bindings from this without
+      # building the plugin. Cheap (frontend only). Absent for non-universal
+      # modules, so consumers fall back to the header-copy path for those.
+      "${config.name}-lidl" = moduleLidl;
+      lidl = moduleLidl;
     }
   );
 

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -90,10 +90,16 @@ let
       # dep's plugin. Deps that don't expose a `lidl` output yet take the
       # TRANSITIONAL header-copy fallback (`legacyHeaderDepNames`), which DOES
       # build them — identical to today's behavior.
+      # Returns the dep's published LIDL output, or null if the input isn't a
+      # flake exposing packages.<system>.lidl (e.g. a raw-derivation dep, or a
+      # module built by a builder that predates this feature) — those fall
+      # through to the TRANSITIONAL header-copy path. Guard every level so a
+      # non-flake input never throws.
       depLidlOf = name:
-        if flakeInputs ? ${name}
-        then (flakeInputs.${name}.packages.${system}.lidl or null)
-        else null;
+        let i = flakeInputs.${name} or null;
+        in if i != null && i ? packages && i.packages ? ${system}
+           then (i.packages.${system}.lidl or null)
+           else null;
       depIsLidl = name: (config.dependency_overrides ? ${name}) || (depLidlOf name != null);
 
       # LIDL-based deps → `--dep <name>=<lidl>` for the generator. An override

--- a/lib/parseMetadata.nix
+++ b/lib/parseMetadata.nix
@@ -20,7 +20,14 @@
       main        = raw.main        or null;
       icon        = raw.icon        or null;
       view        = raw.view        or null;
-      dependencies = safeList (raw.dependencies or []);
+      # Concrete module dependencies, as a list of NAME strings. Entries may be
+      # bare strings (the common form) or objects `{ name, ... }`; either way we
+      # keep just the name here so every existing consumer of `config.dependencies`
+      # (the umbrella, collectAllModuleDeps, the header-copy fallback) is unchanged.
+      dependencies = map (e:
+        if builtins.isString e then e
+        else (e.name or (throw "dependencies entry must be a string name or { name, ... }, got: ${builtins.toJSON e}"))
+      ) (safeList (raw.dependencies or []));
       include      = safeList (raw.include      or []);
 
       # Interface dependencies — method/event contracts decoupled from any
@@ -56,6 +63,26 @@
             impl_class = implClass;
           }
       ) (safeList (raw.interface_dependencies or []));
+
+      # Optional per-dependency LIDL-source overrides. Normally a dependency's
+      # interface LIDL is auto-resolved from its `packages.<sys>.lidl` flake
+      # output (no plugin build); an override forces a specific definition —
+      # e.g. a committed `.lidl`, a header in another input, or pinning to the
+      # old header-copy path. Keyed by dependency name → { file, input?, impl_class? }:
+      #   file       — path to the .lidl/.h. Relative to this repo (no `input`)
+      #                or to the named flake input.
+      #   input      — (optional) flake-input attr name hosting the file.
+      #   impl_class — (required for a .h file) the class whose API defines the dep.
+      dependency_overrides = lib.mapAttrs (name: ov:
+        let
+          file = ov.file or (throw "dependency_overrides.${name} must specify 'file'");
+          implClass = ov.impl_class or null;
+          isHeader = lib.hasSuffix ".h" file || lib.hasSuffix ".hpp" file;
+        in
+          if isHeader && implClass == null
+          then throw "dependency_overrides.${name} is a C++ header (${file}) and must specify 'impl_class'"
+          else { inherit file; input = ov.input or null; impl_class = implClass; }
+      ) (if builtins.isAttrs (raw.dependency_overrides or {}) then (raw.dependency_overrides or {}) else {});
 
       # Nix/build-only fields (nested under "nix" in metadata.json)
       nix_packages = {

--- a/tests/test-parse-metadata.nix
+++ b/tests/test-parse-metadata.nix
@@ -189,4 +189,48 @@ in [
       ];
     });
   in assertEq "go_static_lib_names picks go_build entries" goNames.go_static_lib_names [ "go1" ])
+
+  # --- dependencies: object entries normalized to name strings ---
+  (assertEq "dependency object/string entries normalized to names"
+    (parse (builtins.toJSON {
+      name = "x";
+      dependencies = [ "a" { name = "b"; } { name = "c"; } ];
+    })).dependencies
+    [ "a" "b" "c" ])
+
+  # --- dependency_overrides: defaults to empty attrset ---
+  (assertEq "dependency_overrides defaults to {}"
+    (parse ''{ "name": "x" }'').dependency_overrides {})
+
+  # --- dependency_overrides: .lidl entry (no impl_class needed) ---
+  (assertEq "dependency_overrides .lidl entry parsed"
+    (parse (builtins.toJSON {
+      name = "x";
+      dependency_overrides = { dep_a = { file = "iface/dep_a.lidl"; }; };
+    })).dependency_overrides
+    { dep_a = { file = "iface/dep_a.lidl"; input = null; impl_class = null; }; })
+
+  # --- dependency_overrides: .h entry with impl_class + input ---
+  (assertEq "dependency_overrides .h entry parsed"
+    (parse (builtins.toJSON {
+      name = "x";
+      dependency_overrides = {
+        dep_b = { file = "src/dep_b_impl.h"; impl_class = "DepBImpl"; input = "dep_b_src"; };
+      };
+    })).dependency_overrides
+    { dep_b = { file = "src/dep_b_impl.h"; impl_class = "DepBImpl"; input = "dep_b_src"; }; })
+
+  # --- dependency_overrides: .h without impl_class throws ---
+  (assertThrows "dependency_overrides .h without impl_class throws"
+    (parse (builtins.toJSON {
+      name = "x";
+      dependency_overrides = { d = { file = "d.h"; }; };
+    })))
+
+  # --- dependency_overrides: entry without file throws ---
+  (assertThrows "dependency_overrides without file throws"
+    (parse (builtins.toJSON {
+      name = "x";
+      dependency_overrides = { d = { input = "z"; }; };
+    })))
 ]


### PR DESCRIPTION
## Consume concrete dependencies via LIDL — no dep plugin build

The core of the feature: building (and packaging) a module no longer builds its **universal** dependency modules. Each module publishes a cheap LIDL contract; consumers generate the typed `modules().<dep>` bindings from it. The **only** thing that still builds/bundles dep *plugins* is the standalone app run (`apps.default` / `#run`), which must — it loads them.

```cpp
// unchanged consumer code — modules().<dep> still works, just no dep build
modules().calc_module.add(3, 5);
modules().calc_module.onVersionReady([](const std::string& v){ ... });
```

### This PR
- **`mkLogosModule.nix`** — new `packages.<sys>.lidl` output: a cheap `runCommand` that runs `logos-cpp-generator --header-to-lidl` over the universal impl header (no Qt/plugin compile). Per-dependency classification: a dep exposing a `lidl` output (or a `dependency_overrides` entry) is LIDL-based → threaded to the backend as `staticDeps` (generated via `--dep`, **no dep plugin build**); otherwise it takes the **TRANSITIONAL** header-copy fallback (`legacyHeaderDepNames`), identical to today.
- **`parseMetadata.nix`** — `dependencies` normalized to name strings (accepts object entries); new optional `dependency_overrides` (`{ file, input?, impl_class? }`) to force a dep's LIDL/header source.
- **`buildCppPlugin.nix`** — same classification + `staticDeps` threading for QML C++-backend (UI) modules.

The header-copy fallback is isolated and banner-commented (`# TRANSITIONAL … Remove once all modules expose packages.<sys>.lidl`) so it can be deleted as a localized change once modules migrate.

### Cross-repo chain (merge order)
1. logos-co/logos-cpp-sdk#77 — `--header-to-lidl` + `--dep`
2. logos-co/logos-plugin-qt#9 — pass `--dep` flags
3. **logos-module-builder** ← this PR
   - follow-up: a flake.lock bump pins #77/#9 once merged (mirrors the interface-deps plugin-core bump #109)

### Verification (all with `--auto-local`)
- **No dep plugin build:** building the mixed consumer `test_context_module_cpp`, the universal dep `test_basic_module_cpp`'s closure contains only `…-lidl.drv` — **no `-module-lib`/`-headers-std`**; the legacy dep `test_basic_module` builds via the fallback (as intended).
- **`lidl` output is cheap:** no module-plugin compile in its build closure (just the generator).
- **Runtime:** the integration suite passes **168/1/25** — including `test_context_module_cpp`'s cross-module calls and the typed event round-trip (`subscribeToBasicCppEvents` → `triggerTestEvent` → `getLastTestEventData`) through the **LIDL-generated** wrapper. (The 1 failure is a pre-existing flaky SIGSEGV in `test_ipc_new_api_module → test_extlib_module`, a legacy/fallback path untouched by this change.)
- `ws test logos-module-builder --auto-local` passes (incl. `test-parse-metadata`, QML + framework integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
