### PR TITLE
Bump logos-cpp-sdk to thread-safe inter-module calls

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780929790,
-        "narHash": "sha256-lYhDm9E47IUNJwtSFVrdoOkLu/3bnaFzGx3agLPuXlQ=",
+        "lastModified": 1780948044,
+        "narHash": "sha256-LJF2BvGhDCX10tKjwp7FRCFtZgeC/N9egRqIszOqoX0=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "42a8b9ed5c5deb29b984f86d7736c3c25a380655",
+        "rev": "40e7631402d2082664a146a9fb9de33cf35cd299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `logos-cpp-sdk` input from `42a8b9e` to `40e7631`, picking up
[logos-cpp-sdk#79](https://github.com/logos-co/logos-cpp-sdk/pull/79).

That change makes `LogosAPIClient` marshal `getClient` / `invokeRemoteMethod` /
`requestObject` / `onEvent` onto the module's owner (event-loop) thread when
they're called from another thread. It lets a module built by this builder call
**other** modules from a worker thread — e.g. an embedded HTTP server serving
`/metrics` — without hanging on Qt Remote Objects replica acquisition, and
without the module touching Qt.

The change is additive (no new data members, ABI-safe for statically-linked
plugins). Building modules against this SDK commit is already exercised by the
cpp-sdk doc-tests (including a worker-thread HTTP scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)