### PR TITLE
Qt split: inject logos-qt-sdk + logos-protocol, stamp logos_protocol_version into module metadata

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -95,15 +95,13 @@ function(logos_find_dependencies)
     if(EXISTS "${LOGOS_QT_SDK_ROOT}/cpp/logos_api.h")
         set(_qt_sdk_found TRUE)
         set(LOGOS_QT_SDK_IS_SOURCE TRUE PARENT_SCOPE)
-        set(LOGOS_QT_SDK_IS_SOURCE TRUE)
     elseif(EXISTS "${LOGOS_QT_SDK_ROOT}/include/cpp/logos_api.h")
         set(_qt_sdk_found TRUE)
         set(LOGOS_QT_SDK_IS_SOURCE FALSE PARENT_SCOPE)
-        set(LOGOS_QT_SDK_IS_SOURCE FALSE)
     endif()
 
     # logos-protocol — transports + lp_* C ABI (linked by logos-qt-sdk; also
-    # needed directly for its headers and, in source layouts, its sources).
+    # needed directly for its headers and, in source layouts, its library).
     if(NOT DEFINED LOGOS_PROTOCOL_ROOT)
         set(_parent_protocol "${CMAKE_SOURCE_DIR}/../logos-protocol")
         if(DEFINED ENV{LOGOS_PROTOCOL_ROOT})
@@ -186,25 +184,12 @@ Usage:
     [LINK_TARGETS <target_names...>]
     [AUTOGEN_DEPENDS <target_names...>]
     [INCLUDE_DIRS <directories...>]
-    [PROVIDER_HEADER <relative_path>]
-    [REP_FILE <path_to_rep_file>]
-    [QML_URI <uri>]
-    [QML_TYPE_NAME <type_name>]
   )
-
-Parameters:
-  NAME            - (required) Module name
-  SOURCES         - (required) Source files for the plugin
-  PROVIDER_HEADER - Header file for LogosProviderBase dispatch code generation
-  REP_FILE        - Qt .rep file; builds a typed ``<name>_replica_factory`` plugin
-                    and adds repc source/replica targets automatically
-  QML_URI         - QML import URI for the replica factory (default: Logos.<ClassName>)
-  QML_TYPE_NAME   - QML type name for the replica (default: <ClassName> from .rep)
 
 Example:
   logos_module(
     NAME my_module
-    SOURCES
+    SOURCES 
       my_module_plugin.cpp
       my_module_plugin.h
       my_module_interface.h
@@ -216,15 +201,13 @@ Example:
       my_custom_lib
     INCLUDE_DIRS
       ${CMAKE_CURRENT_BINARY_DIR}/generated
-    REP_FILE
-      my_module.rep
   )
 #]=======================================================================]
 function(logos_module)
     cmake_parse_arguments(
         MODULE
         ""
-        "NAME;PROVIDER_HEADER;REP_FILE;QML_URI;QML_TYPE_NAME"
+        "NAME;PROVIDER_HEADER"
         "SOURCES;EXTERNAL_LIBS;FIND_PACKAGES;LINK_LIBRARIES;LINK_TARGETS;AUTOGEN_DEPENDS;INCLUDE_DIRS"
         ${ARGN}
     )
@@ -236,6 +219,15 @@ function(logos_module)
     # Find dependencies
     logos_find_dependencies()
     logos_find_qt()
+
+    # Embed metadata next to plugin sources (AUTOMOC / Q_PLUGIN_METADATA)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/metadata.json")
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/metadata.json"
+            "${CMAKE_CURRENT_BINARY_DIR}/metadata.json"
+            COPYONLY
+        )
+    endif()
 
     # Root for dependencies
     get_filename_component(LOGOS_DEPS_ROOT "${LOGOS_CPP_SDK_ROOT}" DIRECTORY)
@@ -269,9 +261,10 @@ function(logos_module)
         list(APPEND PLUGIN_SOURCES ${LOGOS_MODULE_ROOT}/include/module_lib/interface.h)
     endif()
 
-    # Add SDK sources (only if source layout). The Qt developer layer lives
-    # in logos-qt-sdk; the transport/protocol layer is linked below (installed
-    # find_package, or add_subdirectory for a protocol source checkout).
+    # Add Qt-SDK sources (only if source layout). The Qt developer layer
+    # lives in logos-qt-sdk since the qt split; the transport/consumer core
+    # (token_manager, module_proxy, api_client/consumer) moved into the
+    # logos-protocol LIBRARY and is linked below instead of compiled in.
     if(LOGOS_QT_SDK_IS_SOURCE)
         list(APPEND PLUGIN_SOURCES
             ${LOGOS_QT_SDK_ROOT}/cpp/logos_api.cpp
@@ -285,7 +278,6 @@ function(logos_module)
         )
     endif()
     if(LOGOS_CPP_SDK_IS_SOURCE)
-        
         # Add generated logos_sdk.cpp
         list(APPEND PLUGIN_SOURCES ${PLUGINS_OUTPUT_DIR}/logos_sdk.cpp)
         set_source_files_properties(
@@ -306,11 +298,21 @@ function(logos_module)
             )
         endif()
         
+        # LOGOS_API_STYLE selects between Qt-typed and std-typed
+        # wrapper signatures on the generated `<Module>` client class.
+        # Defaults to "qt" — every existing handcrafted module keeps
+        # its Qt-typed LogosModules. Universal modules (those declaring
+        # `interface: "universal"` in metadata.json) get this set to
+        # "std" automatically by mkLogosModule.nix.
+        if(NOT DEFINED LOGOS_API_STYLE OR LOGOS_API_STYLE STREQUAL "")
+            set(LOGOS_API_STYLE "qt")
+        endif()
         add_custom_target(run_cpp_generator_${MODULE_NAME}
-            COMMAND "${CPP_GENERATOR}" --metadata "${METADATA_FILE}" 
-                    --general-only --output-dir "${PLUGINS_OUTPUT_DIR}"
+            COMMAND "${CPP_GENERATOR}" --metadata "${METADATA_FILE}"
+                    --general-only --api-style "${LOGOS_API_STYLE}"
+                    --output-dir "${PLUGINS_OUTPUT_DIR}"
             WORKING_DIRECTORY "${LOGOS_DEPS_ROOT}"
-            COMMENT "Running logos-cpp-generator for ${MODULE_NAME}"
+            COMMENT "Running logos-cpp-generator for ${MODULE_NAME} (api-style=${LOGOS_API_STYLE})"
             VERBATIM
         )
         add_dependencies(run_cpp_generator_${MODULE_NAME} cpp_generator_build)
@@ -349,6 +351,23 @@ function(logos_module)
     # Create the plugin library
     add_library(${MODULE_NAME}_module_plugin SHARED ${PLUGIN_SOURCES})
 
+    # Pre-generated sources from logos-cpp-generator (Nix preConfigure, universal/provider modules)
+    set(_LOGOS_GEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/generated_code")
+    if(IS_DIRECTORY "${_LOGOS_GEN_DIR}")
+        file(GLOB _LOGOS_GEN_CPPS CONFIGURE_DEPENDS "${_LOGOS_GEN_DIR}/*.cpp")
+        file(GLOB _LOGOS_GEN_HS CONFIGURE_DEPENDS "${_LOGOS_GEN_DIR}/*.h")
+        # Exclude files that are #include'd by logos_sdk.cpp (not compiled separately):
+        # logos_sdk.cpp and per-dependency *_api.cpp files. core_manager
+        # is no longer generated (universal modules expose only their
+        # declared dependencies; apps that need to manage the core use
+        # liblogos' C API directly).
+        list(FILTER _LOGOS_GEN_CPPS EXCLUDE REGEX ".*/(logos_sdk|.*_api)\\.cpp$")
+        if(_LOGOS_GEN_CPPS OR _LOGOS_GEN_HS)
+            target_sources(${MODULE_NAME}_module_plugin PRIVATE ${_LOGOS_GEN_CPPS} ${_LOGOS_GEN_HS})
+            target_include_directories(${MODULE_NAME}_module_plugin PRIVATE "${_LOGOS_GEN_DIR}")
+        endif()
+    endif()
+
     # Set output name without lib prefix
     set_target_properties(${MODULE_NAME}_module_plugin PROPERTIES
         PREFIX ""
@@ -365,7 +384,11 @@ function(logos_module)
         if(TARGET ${target})
             target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${target})
         else()
-            message(WARNING "Target ${target} not found for linking")
+            message(FATAL_ERROR
+                "LINK_TARGETS target '${target}' was not defined before "
+                "logos_module(). Define it (e.g. add_library(${target} ...)) or "
+                "remove it from LINK_TARGETS. Refusing to silently drop a "
+                "configured link target.")
         endif()
     endforeach()
 
@@ -392,18 +415,19 @@ function(logos_module)
     endif()
 
     if(LOGOS_CPP_SDK_IS_SOURCE)
-        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE 
+        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
             ${LOGOS_CPP_SDK_ROOT}/cpp
             ${LOGOS_CPP_SDK_ROOT}/cpp/generated
         )
     else()
-        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE 
+        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
             ${LOGOS_CPP_SDK_ROOT}/include
             ${LOGOS_CPP_SDK_ROOT}/include/cpp
             ${PLUGINS_OUTPUT_DIR}/include
         )
     endif()
-    # Qt developer layer (LogosAPI, provider glue, legacy PluginInterface)
+    # Qt developer layer (LogosAPI, provider glue, legacy PluginInterface —
+    # include/core moved here from logos-cpp-sdk in the qt split)
     if(LOGOS_QT_SDK_IS_SOURCE)
         target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
             ${LOGOS_QT_SDK_ROOT}/cpp
@@ -488,11 +512,11 @@ function(logos_module)
     foreach(ext_lib ${MODULE_EXTERNAL_LIBS})
         set(EXT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
         
-        # Find the library
+        # Find the library (prefer shared, fall back to static)
         if(APPLE)
-            set(EXT_LIB_NAMES lib${ext_lib}.dylib lib${ext_lib}.so ${ext_lib}.dylib ${ext_lib}.so)
+            set(EXT_LIB_NAMES lib${ext_lib}.dylib lib${ext_lib}.so ${ext_lib}.dylib ${ext_lib}.so lib${ext_lib}.a ${ext_lib}.a)
         else()
-            set(EXT_LIB_NAMES lib${ext_lib}.so lib${ext_lib}.dylib ${ext_lib}.so ${ext_lib}.dylib)
+            set(EXT_LIB_NAMES lib${ext_lib}.so lib${ext_lib}.dylib ${ext_lib}.so ${ext_lib}.dylib lib${ext_lib}.a ${ext_lib}.a)
         endif()
         
         find_library(${ext_lib}_PATH NAMES ${EXT_LIB_NAMES} PATHS ${EXT_LIB_DIR} NO_DEFAULT_PATH)
@@ -501,18 +525,55 @@ function(logos_module)
             target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${${ext_lib}_PATH})
             target_include_directories(${MODULE_NAME}_module_plugin PRIVATE ${EXT_LIB_DIR})
             
-            # Copy to output directory
+            # Copy shared libraries to output directory (static archives are linked in, no runtime copy needed)
             get_filename_component(EXT_LIB_FILENAME "${${ext_lib}_PATH}" NAME)
-            add_custom_command(TARGET ${MODULE_NAME}_module_plugin PRE_LINK
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                    ${${ext_lib}_PATH}
-                    ${CMAKE_BINARY_DIR}/modules/${EXT_LIB_FILENAME}
-                COMMENT "Copying ${EXT_LIB_FILENAME} to modules directory"
-            )
+            if(NOT EXT_LIB_FILENAME MATCHES "\\.a$")
+                add_custom_command(TARGET ${MODULE_NAME}_module_plugin PRE_LINK
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        ${${ext_lib}_PATH}
+                        ${CMAKE_BINARY_DIR}/modules/${EXT_LIB_FILENAME}
+                    COMMENT "Copying ${EXT_LIB_FILENAME} to modules directory"
+                )
+            endif()
         else()
-            message(WARNING "External library ${ext_lib} not found in ${EXT_LIB_DIR}")
+            message(FATAL_ERROR
+                "External library '${ext_lib}' (declared in EXTERNAL_LIBS / "
+                "metadata.json nix.external_libraries) was not found in "
+                "${EXT_LIB_DIR}. A configured external library must be present at "
+                "build time — check its vendor_path, externalLibInputs, or "
+                "build_command/output_pattern. Refusing to build a plugin with a "
+                "missing dependency.")
         endif()
     endforeach()
+
+    # Go/cgo static archives (whole-archive link). Set by mkLogosModule when metadata lists go_build externals.
+    if(DEFINED LOGOS_MODULE_GO_STATIC_LIBS AND NOT LOGOS_MODULE_GO_STATIC_LIBS STREQUAL "")
+        set(EXT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+        foreach(_golib IN LISTS LOGOS_MODULE_GO_STATIC_LIBS)
+            if(_golib STREQUAL "")
+                continue()
+            endif()
+            find_library(_LOGOS_GO_${_golib}
+                NAMES lib${_golib}.a lib${_golib}.lib ${_golib}.a ${_golib}.lib
+                PATHS ${EXT_LIB_DIR} NO_DEFAULT_PATH)
+            if(_LOGOS_GO_${_golib})
+                target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${_LOGOS_GO_${_golib}})
+                if(APPLE)
+                    target_link_options(${MODULE_NAME}_module_plugin PRIVATE -Wl,-force_load ${_LOGOS_GO_${_golib}})
+                    target_link_libraries(${MODULE_NAME}_module_plugin PUBLIC "-framework CoreFoundation" "-framework Security")
+                else()
+                    target_link_options(${MODULE_NAME}_module_plugin PRIVATE
+                        -Wl,--whole-archive ${_LOGOS_GO_${_golib}} -Wl,--no-whole-archive)
+                endif()
+            else()
+                message(FATAL_ERROR
+                    "Go static library '${_golib}' (a go_build external library) "
+                    "was not found in ${EXT_LIB_DIR}. Check the external build "
+                    "produced lib${_golib}.a. Refusing to build a plugin with a "
+                    "missing dependency.")
+            endif()
+        endforeach()
+    endif()
 
     # Link additional libraries
     foreach(lib ${MODULE_LINK_LIBRARIES})
@@ -561,146 +622,5 @@ function(logos_module)
         OPTIONAL
     )
 
-    # ── Optional: typed replica factory plugin from a .rep file ─────────────
-    if(MODULE_REP_FILE)
-        _logos_module_add_replica_factory(${MODULE_NAME} "${MODULE_REP_FILE}"
-            "${MODULE_QML_URI}" "${MODULE_QML_TYPE_NAME}")
-    endif()
-
     message(STATUS "Logos module ${MODULE_NAME} configured successfully")
-endfunction()
-
-# ── Internal: build a <name>_replica_factory Qt plugin from a .rep file ─────
-function(_logos_module_add_replica_factory MODULE_NAME REP_FILE QML_URI QML_TYPE_NAME)
-    # Need repc replica generation + Qml for qmlRegisterUncreatableMetaObject
-    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core RemoteObjects Qml)
-
-    # Also attach the source-side repc to the plugin target so the backend has
-    # the generated SimpleSource base class available.
-    if(QT_VERSION_MAJOR EQUAL 6)
-        qt6_add_repc_sources(${MODULE_NAME}_module_plugin ${REP_FILE})
-    else()
-        qt5_add_repc_sources(${MODULE_NAME}_module_plugin ${REP_FILE})
-    endif()
-
-    # Parse class name out of the .rep (first `class Foo` line).
-    set(_REP_FILE_ABS "${REP_FILE}")
-    if(NOT IS_ABSOLUTE "${_REP_FILE_ABS}")
-        set(_REP_FILE_ABS "${CMAKE_CURRENT_SOURCE_DIR}/${REP_FILE}")
-    endif()
-    file(READ "${_REP_FILE_ABS}" _REP_CONTENTS)
-    string(REGEX MATCH "class[ \t]+([A-Za-z_][A-Za-z0-9_]*)" _ "${_REP_CONTENTS}")
-    set(LOGOS_REP_CLASS "${CMAKE_MATCH_1}")
-    if(NOT LOGOS_REP_CLASS)
-        message(FATAL_ERROR "logos_module: could not parse class name from ${REP_FILE}")
-    endif()
-
-    get_filename_component(LOGOS_REP_BASE "${REP_FILE}" NAME_WE)
-    set(LOGOS_FACTORY_CLASS "${LOGOS_REP_CLASS}ReplicaFactoryPlugin")
-
-    if(NOT QML_URI)
-        set(QML_URI "Logos.${LOGOS_REP_CLASS}")
-    endif()
-    if(NOT QML_TYPE_NAME)
-        set(QML_TYPE_NAME "${LOGOS_REP_CLASS}")
-    endif()
-    set(LOGOS_QML_URI "${QML_URI}")
-    set(LOGOS_QML_TYPE_NAME "${QML_TYPE_NAME}")
-
-    # Locate the factory h/cpp templates (sibling of this .cmake file).
-    set(_TEMPLATE_DIR "${CMAKE_CURRENT_FUNCTION_LIST_DIR}")
-    if(NOT EXISTS "${_TEMPLATE_DIR}/LogosViewReplicaFactory.h.in")
-        set(_TEMPLATE_DIR "${CMAKE_CURRENT_LIST_DIR}")
-    endif()
-
-    set(_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/replica_factory_${MODULE_NAME}")
-    file(MAKE_DIRECTORY "${_GEN_DIR}")
-    configure_file("${_TEMPLATE_DIR}/LogosViewReplicaFactory.h.in"
-                   "${_GEN_DIR}/LogosViewReplicaFactory.h" @ONLY)
-    configure_file("${_TEMPLATE_DIR}/LogosViewReplicaFactory.cpp.in"
-                   "${_GEN_DIR}/LogosViewReplicaFactory.cpp" @ONLY)
-
-    # Generate the per-module LogosViewPlugin base that plugins inherit
-    # from. It implements viewObject() + enableRemoting() so ui-host can
-    # drive the plugin via a plain qobject_cast<LogosViewPlugin*> instead
-    # of QMetaObject::invokeMethod reflection.
-    set(_VIEW_PLUGIN_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/view_plugin_base_${MODULE_NAME}")
-    file(MAKE_DIRECTORY "${_VIEW_PLUGIN_GEN_DIR}")
-    configure_file("${_TEMPLATE_DIR}/LogosViewPluginBase.h.in"
-                   "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.h" @ONLY)
-    configure_file("${_TEMPLATE_DIR}/LogosViewPluginBase.cpp.in"
-                   "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.cpp" @ONLY)
-    target_sources(${MODULE_NAME}_module_plugin PRIVATE
-        "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.h"
-        "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.cpp"
-    )
-    target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
-        "${_VIEW_PLUGIN_GEN_DIR}"
-    )
-    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE
-        Qt${QT_VERSION_MAJOR}::RemoteObjects
-    )
-
-    set(_FACTORY_TARGET ${MODULE_NAME}_replica_factory)
-    add_library(${_FACTORY_TARGET} SHARED
-        "${_GEN_DIR}/LogosViewReplicaFactory.h"
-        "${_GEN_DIR}/LogosViewReplicaFactory.cpp"
-    )
-
-    set_target_properties(${_FACTORY_TARGET} PROPERTIES
-        AUTOMOC ON
-        PREFIX ""
-        OUTPUT_NAME "${MODULE_NAME}_replica_factory"
-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
-        BUILD_WITH_INSTALL_RPATH TRUE
-        SKIP_BUILD_RPATH FALSE
-        INSTALL_NAME_DIR "@rpath"
-    )
-    if(APPLE)
-        target_link_options(${_FACTORY_TARGET} PRIVATE "-Wl,-headerpad_max_install_names")
-    endif()
-
-    target_include_directories(${_FACTORY_TARGET} PRIVATE
-        "${_GEN_DIR}"
-        "${CMAKE_CURRENT_BINARY_DIR}"
-    )
-    if(QT_VERSION_MAJOR EQUAL 6)
-        qt6_add_repc_replicas(${_FACTORY_TARGET} ${REP_FILE})
-    else()
-        qt5_add_repc_replicas(${_FACTORY_TARGET} ${REP_FILE})
-    endif()
-
-    target_link_libraries(${_FACTORY_TARGET} PRIVATE
-        Qt${QT_VERSION_MAJOR}::Core
-        Qt${QT_VERSION_MAJOR}::RemoteObjects
-        Qt${QT_VERSION_MAJOR}::Qml
-    )
-
-    if(APPLE)
-        set_target_properties(${_FACTORY_TARGET} PROPERTIES
-            INSTALL_RPATH "@loader_path"
-            INSTALL_NAME_DIR "@rpath"
-            BUILD_WITH_INSTALL_NAME_DIR TRUE
-        )
-        add_custom_command(TARGET ${_FACTORY_TARGET} POST_BUILD
-            COMMAND install_name_tool -id "@rpath/${MODULE_NAME}_replica_factory.dylib"
-                    $<TARGET_FILE:${_FACTORY_TARGET}>
-            COMMENT "Updating library paths for macOS"
-        )
-    else()
-        set_target_properties(${_FACTORY_TARGET} PROPERTIES
-            INSTALL_RPATH "$ORIGIN"
-            INSTALL_RPATH_USE_LINK_PATH FALSE
-        )
-    endif()
-
-    install(TARGETS ${_FACTORY_TARGET}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/logos/modules
-        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/logos/modules
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/logos/modules
-    )
-
-    message(STATUS "Logos module ${MODULE_NAME}: replica factory plugin from ${REP_FILE} "
-                   "(class ${LOGOS_REP_CLASS}, QML ${LOGOS_QML_URI}.${LOGOS_QML_TYPE_NAME})")
 endfunction()

--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -46,7 +46,7 @@ function(logos_find_dependencies)
         if(DEFINED ENV{LOGOS_CPP_SDK_ROOT})
             set(LOGOS_CPP_SDK_ROOT "$ENV{LOGOS_CPP_SDK_ROOT}" PARENT_SCOPE)
             set(LOGOS_CPP_SDK_ROOT "$ENV{LOGOS_CPP_SDK_ROOT}")
-        elseif(EXISTS "${_parent_cpp_sdk}/cpp/logos_api.h")
+        elseif(EXISTS "${_parent_cpp_sdk}/cpp/logos_module_context.h")
             set(LOGOS_CPP_SDK_ROOT "${_parent_cpp_sdk}" PARENT_SCOPE)
             set(LOGOS_CPP_SDK_ROOT "${_parent_cpp_sdk}")
         else()
@@ -66,12 +66,60 @@ function(logos_find_dependencies)
     endif()
 
     set(_cpp_sdk_found FALSE)
-    if(EXISTS "${LOGOS_CPP_SDK_ROOT}/cpp/logos_api.h")
+    # The base SDK is Qt-free/header-only since the qt split — detect it by
+    # logos_module_context.h (logos_api.h moved to logos-qt-sdk).
+    if(EXISTS "${LOGOS_CPP_SDK_ROOT}/cpp/logos_module_context.h")
         set(_cpp_sdk_found TRUE)
         set(LOGOS_CPP_SDK_IS_SOURCE TRUE PARENT_SCOPE)
-    elseif(EXISTS "${LOGOS_CPP_SDK_ROOT}/include/cpp/logos_api.h")
+    elseif(EXISTS "${LOGOS_CPP_SDK_ROOT}/include/cpp/logos_module_context.h")
         set(_cpp_sdk_found TRUE)
         set(LOGOS_CPP_SDK_IS_SOURCE FALSE PARENT_SCOPE)
+    endif()
+
+    # logos-qt-sdk — the Qt developer layer (LogosAPI, provider glue) every
+    # Qt plugin links.
+    if(NOT DEFINED LOGOS_QT_SDK_ROOT)
+        set(_parent_qt_sdk "${CMAKE_SOURCE_DIR}/../logos-qt-sdk")
+        if(DEFINED ENV{LOGOS_QT_SDK_ROOT})
+            set(LOGOS_QT_SDK_ROOT "$ENV{LOGOS_QT_SDK_ROOT}" PARENT_SCOPE)
+            set(LOGOS_QT_SDK_ROOT "$ENV{LOGOS_QT_SDK_ROOT}")
+        elseif(EXISTS "${_parent_qt_sdk}/cpp/logos_api.h")
+            set(LOGOS_QT_SDK_ROOT "${_parent_qt_sdk}" PARENT_SCOPE)
+            set(LOGOS_QT_SDK_ROOT "${_parent_qt_sdk}")
+        else()
+            set(LOGOS_QT_SDK_ROOT "${CMAKE_SOURCE_DIR}/vendor/logos-qt-sdk" PARENT_SCOPE)
+            set(LOGOS_QT_SDK_ROOT "${CMAKE_SOURCE_DIR}/vendor/logos-qt-sdk")
+        endif()
+    endif()
+    set(_qt_sdk_found FALSE)
+    if(EXISTS "${LOGOS_QT_SDK_ROOT}/cpp/logos_api.h")
+        set(_qt_sdk_found TRUE)
+        set(LOGOS_QT_SDK_IS_SOURCE TRUE PARENT_SCOPE)
+        set(LOGOS_QT_SDK_IS_SOURCE TRUE)
+    elseif(EXISTS "${LOGOS_QT_SDK_ROOT}/include/cpp/logos_api.h")
+        set(_qt_sdk_found TRUE)
+        set(LOGOS_QT_SDK_IS_SOURCE FALSE PARENT_SCOPE)
+        set(LOGOS_QT_SDK_IS_SOURCE FALSE)
+    endif()
+
+    # logos-protocol — transports + lp_* C ABI (linked by logos-qt-sdk; also
+    # needed directly for its headers and, in source layouts, its sources).
+    if(NOT DEFINED LOGOS_PROTOCOL_ROOT)
+        set(_parent_protocol "${CMAKE_SOURCE_DIR}/../logos-protocol")
+        if(DEFINED ENV{LOGOS_PROTOCOL_ROOT})
+            set(LOGOS_PROTOCOL_ROOT "$ENV{LOGOS_PROTOCOL_ROOT}" PARENT_SCOPE)
+            set(LOGOS_PROTOCOL_ROOT "$ENV{LOGOS_PROTOCOL_ROOT}")
+        elseif(EXISTS "${_parent_protocol}/cpp/logos_protocol.h")
+            set(LOGOS_PROTOCOL_ROOT "${_parent_protocol}" PARENT_SCOPE)
+            set(LOGOS_PROTOCOL_ROOT "${_parent_protocol}")
+        else()
+            set(LOGOS_PROTOCOL_ROOT "${CMAKE_SOURCE_DIR}/vendor/logos-protocol" PARENT_SCOPE)
+            set(LOGOS_PROTOCOL_ROOT "${CMAKE_SOURCE_DIR}/vendor/logos-protocol")
+        endif()
+    endif()
+    set(_protocol_found FALSE)
+    if(EXISTS "${LOGOS_PROTOCOL_ROOT}/cpp/logos_protocol.h" OR EXISTS "${LOGOS_PROTOCOL_ROOT}/include/cpp/logos_protocol.h")
+        set(_protocol_found TRUE)
     endif()
 
     if(NOT _module_found)
@@ -83,9 +131,19 @@ function(logos_find_dependencies)
         message(FATAL_ERROR "logos-cpp-sdk not found at ${LOGOS_CPP_SDK_ROOT}. "
                             "Set LOGOS_CPP_SDK_ROOT environment variable or CMake variable.")
     endif()
+    if(NOT _qt_sdk_found)
+        message(FATAL_ERROR "logos-qt-sdk not found at ${LOGOS_QT_SDK_ROOT}. "
+                            "Set LOGOS_QT_SDK_ROOT environment variable or CMake variable.")
+    endif()
+    if(NOT _protocol_found)
+        message(FATAL_ERROR "logos-protocol not found at ${LOGOS_PROTOCOL_ROOT}. "
+                            "Set LOGOS_PROTOCOL_ROOT environment variable or CMake variable.")
+    endif()
 
     message(STATUS "Found logos-module at: ${LOGOS_MODULE_ROOT}")
     message(STATUS "Found logos-cpp-sdk at: ${LOGOS_CPP_SDK_ROOT}")
+    message(STATUS "Found logos-qt-sdk at: ${LOGOS_QT_SDK_ROOT}")
+    message(STATUS "Found logos-protocol at: ${LOGOS_PROTOCOL_ROOT}")
 endfunction()
 
 #[=======================================================================[.rst:
@@ -128,12 +186,25 @@ Usage:
     [LINK_TARGETS <target_names...>]
     [AUTOGEN_DEPENDS <target_names...>]
     [INCLUDE_DIRS <directories...>]
+    [PROVIDER_HEADER <relative_path>]
+    [REP_FILE <path_to_rep_file>]
+    [QML_URI <uri>]
+    [QML_TYPE_NAME <type_name>]
   )
+
+Parameters:
+  NAME            - (required) Module name
+  SOURCES         - (required) Source files for the plugin
+  PROVIDER_HEADER - Header file for LogosProviderBase dispatch code generation
+  REP_FILE        - Qt .rep file; builds a typed ``<name>_replica_factory`` plugin
+                    and adds repc source/replica targets automatically
+  QML_URI         - QML import URI for the replica factory (default: Logos.<ClassName>)
+  QML_TYPE_NAME   - QML type name for the replica (default: <ClassName> from .rep)
 
 Example:
   logos_module(
     NAME my_module
-    SOURCES 
+    SOURCES
       my_module_plugin.cpp
       my_module_plugin.h
       my_module_interface.h
@@ -145,13 +216,15 @@ Example:
       my_custom_lib
     INCLUDE_DIRS
       ${CMAKE_CURRENT_BINARY_DIR}/generated
+    REP_FILE
+      my_module.rep
   )
 #]=======================================================================]
 function(logos_module)
     cmake_parse_arguments(
         MODULE
         ""
-        "NAME;PROVIDER_HEADER"
+        "NAME;PROVIDER_HEADER;REP_FILE;QML_URI;QML_TYPE_NAME"
         "SOURCES;EXTERNAL_LIBS;FIND_PACKAGES;LINK_LIBRARIES;LINK_TARGETS;AUTOGEN_DEPENDS;INCLUDE_DIRS"
         ${ARGN}
     )
@@ -163,15 +236,6 @@ function(logos_module)
     # Find dependencies
     logos_find_dependencies()
     logos_find_qt()
-
-    # Embed metadata next to plugin sources (AUTOMOC / Q_PLUGIN_METADATA)
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/metadata.json")
-        configure_file(
-            "${CMAKE_CURRENT_SOURCE_DIR}/metadata.json"
-            "${CMAKE_CURRENT_BINARY_DIR}/metadata.json"
-            COPYONLY
-        )
-    endif()
 
     # Root for dependencies
     get_filename_component(LOGOS_DEPS_ROOT "${LOGOS_CPP_SDK_ROOT}" DIRECTORY)
@@ -205,26 +269,22 @@ function(logos_module)
         list(APPEND PLUGIN_SOURCES ${LOGOS_MODULE_ROOT}/include/module_lib/interface.h)
     endif()
 
-    # Add SDK sources (only if source layout)
-    if(LOGOS_CPP_SDK_IS_SOURCE)
+    # Add SDK sources (only if source layout). The Qt developer layer lives
+    # in logos-qt-sdk; the transport/protocol layer is linked below (installed
+    # find_package, or add_subdirectory for a protocol source checkout).
+    if(LOGOS_QT_SDK_IS_SOURCE)
         list(APPEND PLUGIN_SOURCES
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api.h
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_client.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_client.h
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_consumer.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_consumer.h
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_provider.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_api_provider.h
-            ${LOGOS_CPP_SDK_ROOT}/cpp/token_manager.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/token_manager.h
-            ${LOGOS_CPP_SDK_ROOT}/cpp/module_proxy.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/module_proxy.h
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_provider_object.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/logos_provider_object.h
-            ${LOGOS_CPP_SDK_ROOT}/cpp/qt_provider_object.cpp
-            ${LOGOS_CPP_SDK_ROOT}/cpp/qt_provider_object.h
+            ${LOGOS_QT_SDK_ROOT}/cpp/logos_api.cpp
+            ${LOGOS_QT_SDK_ROOT}/cpp/logos_api.h
+            ${LOGOS_QT_SDK_ROOT}/cpp/logos_api_provider.cpp
+            ${LOGOS_QT_SDK_ROOT}/cpp/logos_api_provider.h
+            ${LOGOS_QT_SDK_ROOT}/cpp/logos_provider_object.cpp
+            ${LOGOS_QT_SDK_ROOT}/cpp/logos_provider_object.h
+            ${LOGOS_QT_SDK_ROOT}/cpp/qt_provider_object.cpp
+            ${LOGOS_QT_SDK_ROOT}/cpp/qt_provider_object.h
         )
+    endif()
+    if(LOGOS_CPP_SDK_IS_SOURCE)
         
         # Add generated logos_sdk.cpp
         list(APPEND PLUGIN_SOURCES ${PLUGINS_OUTPUT_DIR}/logos_sdk.cpp)
@@ -246,21 +306,11 @@ function(logos_module)
             )
         endif()
         
-        # LOGOS_API_STYLE selects between Qt-typed and std-typed
-        # wrapper signatures on the generated `<Module>` client class.
-        # Defaults to "qt" — every existing handcrafted module keeps
-        # its Qt-typed LogosModules. Universal modules (those declaring
-        # `interface: "universal"` in metadata.json) get this set to
-        # "std" automatically by mkLogosModule.nix.
-        if(NOT DEFINED LOGOS_API_STYLE OR LOGOS_API_STYLE STREQUAL "")
-            set(LOGOS_API_STYLE "qt")
-        endif()
         add_custom_target(run_cpp_generator_${MODULE_NAME}
-            COMMAND "${CPP_GENERATOR}" --metadata "${METADATA_FILE}"
-                    --general-only --api-style "${LOGOS_API_STYLE}"
-                    --output-dir "${PLUGINS_OUTPUT_DIR}"
+            COMMAND "${CPP_GENERATOR}" --metadata "${METADATA_FILE}" 
+                    --general-only --output-dir "${PLUGINS_OUTPUT_DIR}"
             WORKING_DIRECTORY "${LOGOS_DEPS_ROOT}"
-            COMMENT "Running logos-cpp-generator for ${MODULE_NAME} (api-style=${LOGOS_API_STYLE})"
+            COMMENT "Running logos-cpp-generator for ${MODULE_NAME}"
             VERBATIM
         )
         add_dependencies(run_cpp_generator_${MODULE_NAME} cpp_generator_build)
@@ -299,23 +349,6 @@ function(logos_module)
     # Create the plugin library
     add_library(${MODULE_NAME}_module_plugin SHARED ${PLUGIN_SOURCES})
 
-    # Pre-generated sources from logos-cpp-generator (Nix preConfigure, universal/provider modules)
-    set(_LOGOS_GEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/generated_code")
-    if(IS_DIRECTORY "${_LOGOS_GEN_DIR}")
-        file(GLOB _LOGOS_GEN_CPPS CONFIGURE_DEPENDS "${_LOGOS_GEN_DIR}/*.cpp")
-        file(GLOB _LOGOS_GEN_HS CONFIGURE_DEPENDS "${_LOGOS_GEN_DIR}/*.h")
-        # Exclude files that are #include'd by logos_sdk.cpp (not compiled separately):
-        # logos_sdk.cpp and per-dependency *_api.cpp files. core_manager
-        # is no longer generated (universal modules expose only their
-        # declared dependencies; apps that need to manage the core use
-        # liblogos' C API directly).
-        list(FILTER _LOGOS_GEN_CPPS EXCLUDE REGEX ".*/(logos_sdk|.*_api)\\.cpp$")
-        if(_LOGOS_GEN_CPPS OR _LOGOS_GEN_HS)
-            target_sources(${MODULE_NAME}_module_plugin PRIVATE ${_LOGOS_GEN_CPPS} ${_LOGOS_GEN_HS})
-            target_include_directories(${MODULE_NAME}_module_plugin PRIVATE "${_LOGOS_GEN_DIR}")
-        endif()
-    endif()
-
     # Set output name without lib prefix
     set_target_properties(${MODULE_NAME}_module_plugin PROPERTIES
         PREFIX ""
@@ -332,11 +365,7 @@ function(logos_module)
         if(TARGET ${target})
             target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${target})
         else()
-            message(FATAL_ERROR
-                "LINK_TARGETS target '${target}' was not defined before "
-                "logos_module(). Define it (e.g. add_library(${target} ...)) or "
-                "remove it from LINK_TARGETS. Refusing to silently drop a "
-                "configured link target.")
+            message(WARNING "Target ${target} not found for linking")
         endif()
     endforeach()
 
@@ -371,8 +400,31 @@ function(logos_module)
         target_include_directories(${MODULE_NAME}_module_plugin PRIVATE 
             ${LOGOS_CPP_SDK_ROOT}/include
             ${LOGOS_CPP_SDK_ROOT}/include/cpp
-            ${LOGOS_CPP_SDK_ROOT}/include/core
             ${PLUGINS_OUTPUT_DIR}/include
+        )
+    endif()
+    # Qt developer layer (LogosAPI, provider glue, legacy PluginInterface)
+    if(LOGOS_QT_SDK_IS_SOURCE)
+        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
+            ${LOGOS_QT_SDK_ROOT}/cpp
+            ${LOGOS_QT_SDK_ROOT}/core
+        )
+    else()
+        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
+            ${LOGOS_QT_SDK_ROOT}/include
+            ${LOGOS_QT_SDK_ROOT}/include/cpp
+            ${LOGOS_QT_SDK_ROOT}/include/core
+        )
+    endif()
+    # Protocol layer headers (transports, consumer core, lp_* C ABI)
+    if(EXISTS "${LOGOS_PROTOCOL_ROOT}/cpp/logos_protocol.h")
+        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
+            ${LOGOS_PROTOCOL_ROOT}/cpp
+        )
+    else()
+        target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
+            ${LOGOS_PROTOCOL_ROOT}/include
+            ${LOGOS_PROTOCOL_ROOT}/include/cpp
         )
     endif()
 
@@ -387,28 +439,60 @@ function(logos_module)
         Qt${QT_VERSION_MAJOR}::RemoteObjects
     )
 
-    # Link SDK library if using installed layout. The SDK ships a
-    # CMake Config file under lib/cmake/logos-cpp-sdk/ whose imported
-    # target already lists every transitive dep (OpenSSL / Boost /
-    # nlohmann_json / Qt) on its INTERFACE_LINK_LIBRARIES, so a single
-    # find_package + target_link_libraries gives this plugin
-    # everything it needs to link.
-    if(NOT LOGOS_CPP_SDK_IS_SOURCE)
-        find_package(logos-cpp-sdk REQUIRED
-            PATHS ${LOGOS_CPP_SDK_ROOT} NO_DEFAULT_PATH)
-        target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE
-            logos-cpp-sdk::logos_sdk)
+    # Link the Qt SDK via its exported CMake target so the consumer inherits
+    # the full transitive link interface (logos-protocol, and through it
+    # OpenSSL, Boost::system, nlohmann_json). The protocol layer must come
+    # from an exported target — a bare archive on the link line would leave
+    # every Boost.Asio TLS symbol undefined.
+    if(NOT LOGOS_QT_SDK_IS_SOURCE)
+        find_package(logos-protocol REQUIRED CONFIG
+            PATHS ${LOGOS_PROTOCOL_ROOT}/lib/cmake/logos-protocol
+            NO_DEFAULT_PATH)
+        find_package(logos-qt-sdk REQUIRED CONFIG
+            PATHS ${LOGOS_QT_SDK_ROOT}/lib/cmake/logos-qt-sdk
+            NO_DEFAULT_PATH)
+        target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos-qt-sdk::logos_qt_sdk)
+    else()
+        # Source-layout qt-sdk: its sources are compiled into the plugin
+        # above; the protocol layer is linked installed-or-source here.
+        if(EXISTS "${LOGOS_PROTOCOL_ROOT}/lib/cmake/logos-protocol")
+            find_package(logos-protocol REQUIRED CONFIG
+                PATHS ${LOGOS_PROTOCOL_ROOT}/lib/cmake/logos-protocol
+                NO_DEFAULT_PATH)
+            target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos-protocol::logos_protocol)
+        elseif(EXISTS "${LOGOS_PROTOCOL_ROOT}/cpp/CMakeLists.txt")
+            if(NOT TARGET logos_protocol)
+                add_subdirectory("${LOGOS_PROTOCOL_ROOT}/cpp"
+                                 "${CMAKE_BINARY_DIR}/logos-protocol-build")
+            endif()
+            target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos_protocol)
+        else()
+            message(FATAL_ERROR "logos-protocol not usable at ${LOGOS_PROTOCOL_ROOT} "
+                                "(need an installed prefix or a source checkout).")
+        endif()
+    endif()
+
+    # Qt-free base SDK headers (logos_module_context.h / logos_json.h /
+    # logos_result.h → nlohmann_json include path).
+    if(EXISTS "${LOGOS_CPP_SDK_ROOT}/lib/cmake/logos-cpp-sdk")
+        find_package(logos-cpp-sdk REQUIRED CONFIG
+            PATHS ${LOGOS_CPP_SDK_ROOT}/lib/cmake/logos-cpp-sdk
+            NO_DEFAULT_PATH)
+        target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos-cpp-sdk::logos_headers)
+    else()
+        find_package(nlohmann_json REQUIRED)
+        target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE nlohmann_json::nlohmann_json)
     endif()
 
     # Handle external libraries
     foreach(ext_lib ${MODULE_EXTERNAL_LIBS})
         set(EXT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
         
-        # Find the library (prefer shared, fall back to static)
+        # Find the library
         if(APPLE)
-            set(EXT_LIB_NAMES lib${ext_lib}.dylib lib${ext_lib}.so ${ext_lib}.dylib ${ext_lib}.so lib${ext_lib}.a ${ext_lib}.a)
+            set(EXT_LIB_NAMES lib${ext_lib}.dylib lib${ext_lib}.so ${ext_lib}.dylib ${ext_lib}.so)
         else()
-            set(EXT_LIB_NAMES lib${ext_lib}.so lib${ext_lib}.dylib ${ext_lib}.so ${ext_lib}.dylib lib${ext_lib}.a ${ext_lib}.a)
+            set(EXT_LIB_NAMES lib${ext_lib}.so lib${ext_lib}.dylib ${ext_lib}.so ${ext_lib}.dylib)
         endif()
         
         find_library(${ext_lib}_PATH NAMES ${EXT_LIB_NAMES} PATHS ${EXT_LIB_DIR} NO_DEFAULT_PATH)
@@ -417,55 +501,18 @@ function(logos_module)
             target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${${ext_lib}_PATH})
             target_include_directories(${MODULE_NAME}_module_plugin PRIVATE ${EXT_LIB_DIR})
             
-            # Copy shared libraries to output directory (static archives are linked in, no runtime copy needed)
+            # Copy to output directory
             get_filename_component(EXT_LIB_FILENAME "${${ext_lib}_PATH}" NAME)
-            if(NOT EXT_LIB_FILENAME MATCHES "\\.a$")
-                add_custom_command(TARGET ${MODULE_NAME}_module_plugin PRE_LINK
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                        ${${ext_lib}_PATH}
-                        ${CMAKE_BINARY_DIR}/modules/${EXT_LIB_FILENAME}
-                    COMMENT "Copying ${EXT_LIB_FILENAME} to modules directory"
-                )
-            endif()
+            add_custom_command(TARGET ${MODULE_NAME}_module_plugin PRE_LINK
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${${ext_lib}_PATH}
+                    ${CMAKE_BINARY_DIR}/modules/${EXT_LIB_FILENAME}
+                COMMENT "Copying ${EXT_LIB_FILENAME} to modules directory"
+            )
         else()
-            message(FATAL_ERROR
-                "External library '${ext_lib}' (declared in EXTERNAL_LIBS / "
-                "metadata.json nix.external_libraries) was not found in "
-                "${EXT_LIB_DIR}. A configured external library must be present at "
-                "build time — check its vendor_path, externalLibInputs, or "
-                "build_command/output_pattern. Refusing to build a plugin with a "
-                "missing dependency.")
+            message(WARNING "External library ${ext_lib} not found in ${EXT_LIB_DIR}")
         endif()
     endforeach()
-
-    # Go/cgo static archives (whole-archive link). Set by mkLogosModule when metadata lists go_build externals.
-    if(DEFINED LOGOS_MODULE_GO_STATIC_LIBS AND NOT LOGOS_MODULE_GO_STATIC_LIBS STREQUAL "")
-        set(EXT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
-        foreach(_golib IN LISTS LOGOS_MODULE_GO_STATIC_LIBS)
-            if(_golib STREQUAL "")
-                continue()
-            endif()
-            find_library(_LOGOS_GO_${_golib}
-                NAMES lib${_golib}.a lib${_golib}.lib ${_golib}.a ${_golib}.lib
-                PATHS ${EXT_LIB_DIR} NO_DEFAULT_PATH)
-            if(_LOGOS_GO_${_golib})
-                target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${_LOGOS_GO_${_golib}})
-                if(APPLE)
-                    target_link_options(${MODULE_NAME}_module_plugin PRIVATE -Wl,-force_load ${_LOGOS_GO_${_golib}})
-                    target_link_libraries(${MODULE_NAME}_module_plugin PUBLIC "-framework CoreFoundation" "-framework Security")
-                else()
-                    target_link_options(${MODULE_NAME}_module_plugin PRIVATE
-                        -Wl,--whole-archive ${_LOGOS_GO_${_golib}} -Wl,--no-whole-archive)
-                endif()
-            else()
-                message(FATAL_ERROR
-                    "Go static library '${_golib}' (a go_build external library) "
-                    "was not found in ${EXT_LIB_DIR}. Check the external build "
-                    "produced lib${_golib}.a. Refusing to build a plugin with a "
-                    "missing dependency.")
-            endif()
-        endforeach()
-    endif()
 
     # Link additional libraries
     foreach(lib ${MODULE_LINK_LIBRARIES})
@@ -514,5 +561,146 @@ function(logos_module)
         OPTIONAL
     )
 
+    # ── Optional: typed replica factory plugin from a .rep file ─────────────
+    if(MODULE_REP_FILE)
+        _logos_module_add_replica_factory(${MODULE_NAME} "${MODULE_REP_FILE}"
+            "${MODULE_QML_URI}" "${MODULE_QML_TYPE_NAME}")
+    endif()
+
     message(STATUS "Logos module ${MODULE_NAME} configured successfully")
+endfunction()
+
+# ── Internal: build a <name>_replica_factory Qt plugin from a .rep file ─────
+function(_logos_module_add_replica_factory MODULE_NAME REP_FILE QML_URI QML_TYPE_NAME)
+    # Need repc replica generation + Qml for qmlRegisterUncreatableMetaObject
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core RemoteObjects Qml)
+
+    # Also attach the source-side repc to the plugin target so the backend has
+    # the generated SimpleSource base class available.
+    if(QT_VERSION_MAJOR EQUAL 6)
+        qt6_add_repc_sources(${MODULE_NAME}_module_plugin ${REP_FILE})
+    else()
+        qt5_add_repc_sources(${MODULE_NAME}_module_plugin ${REP_FILE})
+    endif()
+
+    # Parse class name out of the .rep (first `class Foo` line).
+    set(_REP_FILE_ABS "${REP_FILE}")
+    if(NOT IS_ABSOLUTE "${_REP_FILE_ABS}")
+        set(_REP_FILE_ABS "${CMAKE_CURRENT_SOURCE_DIR}/${REP_FILE}")
+    endif()
+    file(READ "${_REP_FILE_ABS}" _REP_CONTENTS)
+    string(REGEX MATCH "class[ \t]+([A-Za-z_][A-Za-z0-9_]*)" _ "${_REP_CONTENTS}")
+    set(LOGOS_REP_CLASS "${CMAKE_MATCH_1}")
+    if(NOT LOGOS_REP_CLASS)
+        message(FATAL_ERROR "logos_module: could not parse class name from ${REP_FILE}")
+    endif()
+
+    get_filename_component(LOGOS_REP_BASE "${REP_FILE}" NAME_WE)
+    set(LOGOS_FACTORY_CLASS "${LOGOS_REP_CLASS}ReplicaFactoryPlugin")
+
+    if(NOT QML_URI)
+        set(QML_URI "Logos.${LOGOS_REP_CLASS}")
+    endif()
+    if(NOT QML_TYPE_NAME)
+        set(QML_TYPE_NAME "${LOGOS_REP_CLASS}")
+    endif()
+    set(LOGOS_QML_URI "${QML_URI}")
+    set(LOGOS_QML_TYPE_NAME "${QML_TYPE_NAME}")
+
+    # Locate the factory h/cpp templates (sibling of this .cmake file).
+    set(_TEMPLATE_DIR "${CMAKE_CURRENT_FUNCTION_LIST_DIR}")
+    if(NOT EXISTS "${_TEMPLATE_DIR}/LogosViewReplicaFactory.h.in")
+        set(_TEMPLATE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+    endif()
+
+    set(_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/replica_factory_${MODULE_NAME}")
+    file(MAKE_DIRECTORY "${_GEN_DIR}")
+    configure_file("${_TEMPLATE_DIR}/LogosViewReplicaFactory.h.in"
+                   "${_GEN_DIR}/LogosViewReplicaFactory.h" @ONLY)
+    configure_file("${_TEMPLATE_DIR}/LogosViewReplicaFactory.cpp.in"
+                   "${_GEN_DIR}/LogosViewReplicaFactory.cpp" @ONLY)
+
+    # Generate the per-module LogosViewPlugin base that plugins inherit
+    # from. It implements viewObject() + enableRemoting() so ui-host can
+    # drive the plugin via a plain qobject_cast<LogosViewPlugin*> instead
+    # of QMetaObject::invokeMethod reflection.
+    set(_VIEW_PLUGIN_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/view_plugin_base_${MODULE_NAME}")
+    file(MAKE_DIRECTORY "${_VIEW_PLUGIN_GEN_DIR}")
+    configure_file("${_TEMPLATE_DIR}/LogosViewPluginBase.h.in"
+                   "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.h" @ONLY)
+    configure_file("${_TEMPLATE_DIR}/LogosViewPluginBase.cpp.in"
+                   "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.cpp" @ONLY)
+    target_sources(${MODULE_NAME}_module_plugin PRIVATE
+        "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.h"
+        "${_VIEW_PLUGIN_GEN_DIR}/LogosViewPluginBase.cpp"
+    )
+    target_include_directories(${MODULE_NAME}_module_plugin PRIVATE
+        "${_VIEW_PLUGIN_GEN_DIR}"
+    )
+    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE
+        Qt${QT_VERSION_MAJOR}::RemoteObjects
+    )
+
+    set(_FACTORY_TARGET ${MODULE_NAME}_replica_factory)
+    add_library(${_FACTORY_TARGET} SHARED
+        "${_GEN_DIR}/LogosViewReplicaFactory.h"
+        "${_GEN_DIR}/LogosViewReplicaFactory.cpp"
+    )
+
+    set_target_properties(${_FACTORY_TARGET} PROPERTIES
+        AUTOMOC ON
+        PREFIX ""
+        OUTPUT_NAME "${MODULE_NAME}_replica_factory"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/modules"
+        BUILD_WITH_INSTALL_RPATH TRUE
+        SKIP_BUILD_RPATH FALSE
+        INSTALL_NAME_DIR "@rpath"
+    )
+    if(APPLE)
+        target_link_options(${_FACTORY_TARGET} PRIVATE "-Wl,-headerpad_max_install_names")
+    endif()
+
+    target_include_directories(${_FACTORY_TARGET} PRIVATE
+        "${_GEN_DIR}"
+        "${CMAKE_CURRENT_BINARY_DIR}"
+    )
+    if(QT_VERSION_MAJOR EQUAL 6)
+        qt6_add_repc_replicas(${_FACTORY_TARGET} ${REP_FILE})
+    else()
+        qt5_add_repc_replicas(${_FACTORY_TARGET} ${REP_FILE})
+    endif()
+
+    target_link_libraries(${_FACTORY_TARGET} PRIVATE
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::RemoteObjects
+        Qt${QT_VERSION_MAJOR}::Qml
+    )
+
+    if(APPLE)
+        set_target_properties(${_FACTORY_TARGET} PROPERTIES
+            INSTALL_RPATH "@loader_path"
+            INSTALL_NAME_DIR "@rpath"
+            BUILD_WITH_INSTALL_NAME_DIR TRUE
+        )
+        add_custom_command(TARGET ${_FACTORY_TARGET} POST_BUILD
+            COMMAND install_name_tool -id "@rpath/${MODULE_NAME}_replica_factory.dylib"
+                    $<TARGET_FILE:${_FACTORY_TARGET}>
+            COMMENT "Updating library paths for macOS"
+        )
+    else()
+        set_target_properties(${_FACTORY_TARGET} PROPERTIES
+            INSTALL_RPATH "$ORIGIN"
+            INSTALL_RPATH_USE_LINK_PATH FALSE
+        )
+    endif()
+
+    install(TARGETS ${_FACTORY_TARGET}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/logos/modules
+        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/logos/modules
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/logos/modules
+    )
+
+    message(STATUS "Logos module ${MODULE_NAME}: replica factory plugin from ${REP_FILE} "
+                   "(class ${LOGOS_REP_CLASS}, QML ${LOGOS_QML_URI}.${LOGOS_QML_TYPE_NAME})")
 endfunction()

--- a/flake.lock
+++ b/flake.lock
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781062507,
-        "narHash": "sha256-GuYeKF6Ii4ShcxlHsytY0AYfVtOtV9r3bORU6UG7lxA=",
+        "lastModified": 1781267527,
+        "narHash": "sha256-NBHwMtSQNQabOqkl0Z4POh/FhR4WNqDV85/aCaVtKbQ=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "b86ff877f36b7f8e7d0b051fca0a6cf5940a20bd",
+        "rev": "bd24fb61ea015c13149bcaee20ea2bbc1b9b70cb",
         "type": "github"
       },
       "original": {
@@ -4136,11 +4136,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781065710,
-        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
+        "lastModified": 1781267326,
+        "narHash": "sha256-n3CHoCFn16up4q3RieFrcS4GgneTO7wqTFjABo0AGKw=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
+        "rev": "6492494a7c6ee1de531c25aeac86d0ea05f17d94",
         "type": "github"
       },
       "original": {
@@ -4267,11 +4267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781066423,
-        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
+        "lastModified": 1781268354,
+        "narHash": "sha256-TGMBm0EKE2YmsNebwJGkc6b9bbDusNR5pzLicim71AI=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "355774603877637b486ea0aeefbf7828ae321868",
+        "rev": "71be6e91217ea5da9061d7abeccf1e3c4db6027d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -4149,6 +4149,31 @@
         "type": "github"
       }
     },
+    "logos-protocol_2": {
+      "inputs": {
+        "logos-nix": [
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781065710,
+        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-qt-mcp": {
       "inputs": {
         "logos-nix": "logos-nix_34",
@@ -4238,6 +4263,39 @@
         "nixpkgs": [
           "logos-qt-sdk",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781066423,
+        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "355774603877637b486ea0aeefbf7828ae321868",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_2": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -4424,6 +4482,8 @@
           "logos-cpp-sdk"
         ],
         "logos-nix": "logos-nix_111",
+        "logos-protocol": "logos-protocol_2",
+        "logos-qt-sdk": "logos-qt-sdk_2",
         "nixpkgs": [
           "logos-test-framework",
           "logos-nix",
@@ -4431,11 +4491,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780432542,
-        "narHash": "sha256-LcZnXuNTCyFQS7rhOHF3sy+oF6PNq/H1MLPHch08XrU=",
+        "lastModified": 1781118884,
+        "narHash": "sha256-bM8Deqf6soZeUqWy3RdyY0APRKLWmjD/78g1fbEObaY=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "ee081954096f602b47308c6dc7d00fb71d5dcdc7",
+        "rev": "5b8fcc9ffdc5c66511a95a6bf6b41dd74fbbacc9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781267527,
-        "narHash": "sha256-NBHwMtSQNQabOqkl0Z4POh/FhR4WNqDV85/aCaVtKbQ=",
+        "lastModified": 1781304979,
+        "narHash": "sha256-uCCoJJRVCUUO6j03GO6/02+uuLd9GaAi/0dHaiW2bXs=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "bd24fb61ea015c13149bcaee20ea2bbc1b9b70cb",
+        "rev": "f0fe8cbfeb1fe62d934b4abf8c300047a49420c9",
         "type": "github"
       },
       "original": {
@@ -4136,11 +4136,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781267326,
-        "narHash": "sha256-n3CHoCFn16up4q3RieFrcS4GgneTO7wqTFjABo0AGKw=",
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6492494a7c6ee1de531c25aeac86d0ea05f17d94",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -4267,11 +4267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781268354,
-        "narHash": "sha256-TGMBm0EKE2YmsNebwJGkc6b9bbDusNR5pzLicim71AI=",
+        "lastModified": 1781305265,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "71be6e91217ea5da9061d7abeccf1e3c4db6027d",
+        "rev": "722e5908ea4e2f5abdffda221d7b7aba55725609",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -28,7 +28,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_7",
-        "logos-nix": "logos-nix_16",
+        "logos-nix": "logos-nix_18",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -56,7 +56,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_4",
         "logos-module": "logos-module_8",
-        "logos-nix": "logos-nix_21",
+        "logos-nix": "logos-nix_23",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -111,7 +111,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_13",
-        "logos-nix": "logos-nix_60",
+        "logos-nix": "logos-nix_62",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -140,7 +140,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_9",
         "logos-module": "logos-module_14",
-        "logos-nix": "logos-nix_65",
+        "logos-nix": "logos-nix_67",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -170,6 +170,9 @@
     "logos-cpp-sdk": {
       "inputs": {
         "logos-nix": "logos-nix",
+        "logos-protocol": [
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-cpp-sdk",
           "logos-nix",
@@ -177,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780948044,
-        "narHash": "sha256-LJF2BvGhDCX10tKjwp7FRCFtZgeC/N9egRqIszOqoX0=",
+        "lastModified": 1781062507,
+        "narHash": "sha256-GuYeKF6Ii4ShcxlHsytY0AYfVtOtV9r3bORU6UG7lxA=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "40e7631402d2082664a146a9fb9de33cf35cd299",
+        "rev": "b86ff877f36b7f8e7d0b051fca0a6cf5940a20bd",
         "type": "github"
       },
       "original": {
@@ -192,7 +195,7 @@
     },
     "logos-cpp-sdk_10": {
       "inputs": {
-        "logos-nix": "logos-nix_66",
+        "logos-nix": "logos-nix_68",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -221,7 +224,7 @@
     },
     "logos-cpp-sdk_11": {
       "inputs": {
-        "logos-nix": "logos-nix_94",
+        "logos-nix": "logos-nix_96",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -275,7 +278,7 @@
     },
     "logos-cpp-sdk_2": {
       "inputs": {
-        "logos-nix": "logos-nix_8",
+        "logos-nix": "logos-nix_10",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -301,7 +304,7 @@
     },
     "logos-cpp-sdk_3": {
       "inputs": {
-        "logos-nix": "logos-nix_17",
+        "logos-nix": "logos-nix_19",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -328,7 +331,7 @@
     },
     "logos-cpp-sdk_4": {
       "inputs": {
-        "logos-nix": "logos-nix_19",
+        "logos-nix": "logos-nix_21",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -357,7 +360,7 @@
     },
     "logos-cpp-sdk_5": {
       "inputs": {
-        "logos-nix": "logos-nix_22",
+        "logos-nix": "logos-nix_24",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -385,7 +388,7 @@
     },
     "logos-cpp-sdk_6": {
       "inputs": {
-        "logos-nix": "logos-nix_50",
+        "logos-nix": "logos-nix_52",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -409,7 +412,7 @@
     },
     "logos-cpp-sdk_7": {
       "inputs": {
-        "logos-nix": "logos-nix_52",
+        "logos-nix": "logos-nix_54",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -436,7 +439,7 @@
     },
     "logos-cpp-sdk_8": {
       "inputs": {
-        "logos-nix": "logos-nix_61",
+        "logos-nix": "logos-nix_63",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -464,7 +467,7 @@
     },
     "logos-cpp-sdk_9": {
       "inputs": {
-        "logos-nix": "logos-nix_63",
+        "logos-nix": "logos-nix_65",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -494,7 +497,7 @@
     },
     "logos-design-system": {
       "inputs": {
-        "logos-nix": "logos-nix_18",
+        "logos-nix": "logos-nix_20",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -521,7 +524,7 @@
     },
     "logos-design-system_2": {
       "inputs": {
-        "logos-nix": "logos-nix_51",
+        "logos-nix": "logos-nix_53",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-design-system",
@@ -545,7 +548,7 @@
     },
     "logos-design-system_3": {
       "inputs": {
-        "logos-nix": "logos-nix_62",
+        "logos-nix": "logos-nix_64",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -576,7 +579,7 @@
         "logos-capability-module": "logos-capability-module_3",
         "logos-cpp-sdk": "logos-cpp-sdk_5",
         "logos-module": "logos-module_9",
-        "logos-nix": "logos-nix_24",
+        "logos-nix": "logos-nix_26",
         "logos-package-manager": "logos-package-manager",
         "nixpkgs": [
           "logos-standalone-app",
@@ -607,7 +610,7 @@
         "logos-capability-module": "logos-capability-module_4",
         "logos-cpp-sdk": "logos-cpp-sdk_11",
         "logos-module": "logos-module_16",
-        "logos-nix": "logos-nix_96",
+        "logos-nix": "logos-nix_98",
         "logos-package-manager": "logos-package-manager_5",
         "nixpkgs": [
           "logos-standalone-app",
@@ -636,7 +639,7 @@
         "logos-capability-module": "logos-capability-module_6",
         "logos-cpp-sdk": "logos-cpp-sdk_10",
         "logos-module": "logos-module_15",
-        "logos-nix": "logos-nix_68",
+        "logos-nix": "logos-nix_70",
         "logos-package-manager": "logos-package-manager_3",
         "nixpkgs": [
           "logos-standalone-app",
@@ -690,7 +693,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_2",
         "logos-module": "logos-module_4",
-        "logos-nix": "logos-nix_10",
+        "logos-nix": "logos-nix_12",
         "logos-plugin-core": "logos-plugin-core_2",
         "logos-plugin-qt": "logos-plugin-qt_2",
         "logos-standalone-app": "logos-standalone-app_2",
@@ -723,7 +726,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_7",
         "logos-module": "logos-module_10",
-        "logos-nix": "logos-nix_54",
+        "logos-nix": "logos-nix_56",
         "logos-plugin-core": "logos-plugin-core_3",
         "logos-plugin-qt": "logos-plugin-qt_3",
         "logos-standalone-app": "logos-standalone-app_3",
@@ -755,7 +758,7 @@
     },
     "logos-module_10": {
       "inputs": {
-        "logos-nix": "logos-nix_53",
+        "logos-nix": "logos-nix_55",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -782,7 +785,7 @@
     },
     "logos-module_11": {
       "inputs": {
-        "logos-nix": "logos-nix_55",
+        "logos-nix": "logos-nix_57",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -810,7 +813,7 @@
     },
     "logos-module_12": {
       "inputs": {
-        "logos-nix": "logos-nix_57",
+        "logos-nix": "logos-nix_59",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -838,7 +841,7 @@
     },
     "logos-module_13": {
       "inputs": {
-        "logos-nix": "logos-nix_59",
+        "logos-nix": "logos-nix_61",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -867,7 +870,7 @@
     },
     "logos-module_14": {
       "inputs": {
-        "logos-nix": "logos-nix_64",
+        "logos-nix": "logos-nix_66",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -897,7 +900,7 @@
     },
     "logos-module_15": {
       "inputs": {
-        "logos-nix": "logos-nix_67",
+        "logos-nix": "logos-nix_69",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -926,7 +929,7 @@
     },
     "logos-module_16": {
       "inputs": {
-        "logos-nix": "logos-nix_95",
+        "logos-nix": "logos-nix_97",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -999,7 +1002,7 @@
     },
     "logos-module_4": {
       "inputs": {
-        "logos-nix": "logos-nix_9",
+        "logos-nix": "logos-nix_11",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -1025,7 +1028,7 @@
     },
     "logos-module_5": {
       "inputs": {
-        "logos-nix": "logos-nix_11",
+        "logos-nix": "logos-nix_13",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -1052,7 +1055,7 @@
     },
     "logos-module_6": {
       "inputs": {
-        "logos-nix": "logos-nix_13",
+        "logos-nix": "logos-nix_15",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -1079,7 +1082,7 @@
     },
     "logos-module_7": {
       "inputs": {
-        "logos-nix": "logos-nix_15",
+        "logos-nix": "logos-nix_17",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -1107,7 +1110,7 @@
     },
     "logos-module_8": {
       "inputs": {
-        "logos-nix": "logos-nix_20",
+        "logos-nix": "logos-nix_22",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -1136,7 +1139,7 @@
     },
     "logos-module_9": {
       "inputs": {
-        "logos-nix": "logos-nix_23",
+        "logos-nix": "logos-nix_25",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -1257,11 +1260,11 @@
         "nixpkgs": "nixpkgs_103"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1311,11 +1314,11 @@
         "nixpkgs": "nixpkgs_106"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1329,11 +1332,11 @@
         "nixpkgs": "nixpkgs_107"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1347,11 +1350,11 @@
         "nixpkgs": "nixpkgs_108"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1365,11 +1368,11 @@
         "nixpkgs": "nixpkgs_109"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1401,11 +1404,11 @@
         "nixpkgs": "nixpkgs_110"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1419,11 +1422,11 @@
         "nixpkgs": "nixpkgs_111"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1437,11 +1440,11 @@
         "nixpkgs": "nixpkgs_112"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1455,11 +1458,11 @@
         "nixpkgs": "nixpkgs_113"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1473,11 +1476,11 @@
         "nixpkgs": "nixpkgs_114"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1491,11 +1494,11 @@
         "nixpkgs": "nixpkgs_115"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1509,11 +1512,11 @@
         "nixpkgs": "nixpkgs_116"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1563,11 +1566,11 @@
         "nixpkgs": "nixpkgs_119"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1615,6 +1618,42 @@
     "logos-nix_121": {
       "inputs": {
         "nixpkgs": "nixpkgs_121"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_122": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_122"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_123": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_123"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -1689,11 +1728,11 @@
         "nixpkgs": "nixpkgs_16"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1707,11 +1746,11 @@
         "nixpkgs": "nixpkgs_17"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1743,11 +1782,11 @@
         "nixpkgs": "nixpkgs_19"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1815,11 +1854,11 @@
         "nixpkgs": "nixpkgs_22"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1869,11 +1908,11 @@
         "nixpkgs": "nixpkgs_25"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -1887,11 +1926,11 @@
         "nixpkgs": "nixpkgs_26"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1905,11 +1944,11 @@
         "nixpkgs": "nixpkgs_27"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -1995,11 +2034,11 @@
         "nixpkgs": "nixpkgs_31"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2049,11 +2088,11 @@
         "nixpkgs": "nixpkgs_34"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2067,11 +2106,11 @@
         "nixpkgs": "nixpkgs_35"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2085,11 +2124,11 @@
         "nixpkgs": "nixpkgs_36"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2103,11 +2142,11 @@
         "nixpkgs": "nixpkgs_37"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2121,11 +2160,11 @@
         "nixpkgs": "nixpkgs_38"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2139,11 +2178,11 @@
         "nixpkgs": "nixpkgs_39"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2175,11 +2214,11 @@
         "nixpkgs": "nixpkgs_40"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2193,11 +2232,11 @@
         "nixpkgs": "nixpkgs_41"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2211,11 +2250,11 @@
         "nixpkgs": "nixpkgs_42"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2229,11 +2268,11 @@
         "nixpkgs": "nixpkgs_43"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2247,11 +2286,11 @@
         "nixpkgs": "nixpkgs_44"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2301,11 +2340,11 @@
         "nixpkgs": "nixpkgs_47"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2337,11 +2376,11 @@
         "nixpkgs": "nixpkgs_49"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2373,11 +2412,11 @@
         "nixpkgs": "nixpkgs_50"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2571,11 +2610,11 @@
         "nixpkgs": "nixpkgs_60"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2589,11 +2628,11 @@
         "nixpkgs": "nixpkgs_61"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2625,11 +2664,11 @@
         "nixpkgs": "nixpkgs_63"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2679,11 +2718,11 @@
         "nixpkgs": "nixpkgs_66"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2733,11 +2772,11 @@
         "nixpkgs": "nixpkgs_69"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2769,11 +2808,11 @@
         "nixpkgs": "nixpkgs_70"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2787,11 +2826,11 @@
         "nixpkgs": "nixpkgs_71"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2859,11 +2898,11 @@
         "nixpkgs": "nixpkgs_75"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2913,11 +2952,11 @@
         "nixpkgs": "nixpkgs_78"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -2931,11 +2970,11 @@
         "nixpkgs": "nixpkgs_79"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2967,11 +3006,11 @@
         "nixpkgs": "nixpkgs_80"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -2985,11 +3024,11 @@
         "nixpkgs": "nixpkgs_81"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -3003,11 +3042,11 @@
         "nixpkgs": "nixpkgs_82"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -3021,11 +3060,11 @@
         "nixpkgs": "nixpkgs_83"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3039,11 +3078,11 @@
         "nixpkgs": "nixpkgs_84"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3057,11 +3096,11 @@
         "nixpkgs": "nixpkgs_85"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -3075,11 +3114,11 @@
         "nixpkgs": "nixpkgs_86"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -3093,11 +3132,11 @@
         "nixpkgs": "nixpkgs_87"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3111,11 +3150,11 @@
         "nixpkgs": "nixpkgs_88"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3147,11 +3186,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3183,11 +3222,11 @@
         "nixpkgs": "nixpkgs_91"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -3219,11 +3258,11 @@
         "nixpkgs": "nixpkgs_93"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3237,11 +3276,11 @@
         "nixpkgs": "nixpkgs_94"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -3291,11 +3330,11 @@
         "nixpkgs": "nixpkgs_97"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -3309,11 +3348,11 @@
         "nixpkgs": "nixpkgs_98"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3327,11 +3366,11 @@
         "nixpkgs": "nixpkgs_99"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -3342,7 +3381,7 @@
     },
     "logos-package": {
       "inputs": {
-        "logos-nix": "logos-nix_26",
+        "logos-nix": "logos-nix_28",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -3371,7 +3410,7 @@
     },
     "logos-package-manager": {
       "inputs": {
-        "logos-nix": "logos-nix_25",
+        "logos-nix": "logos-nix_27",
         "logos-package": "logos-package",
         "nix-bundle-appimage": "nix-bundle-appimage",
         "nix-bundle-dir": "nix-bundle-dir_2",
@@ -3402,7 +3441,7 @@
     },
     "logos-package-manager_2": {
       "inputs": {
-        "logos-nix": "logos-nix_42",
+        "logos-nix": "logos-nix_44",
         "logos-package": "logos-package_4",
         "nix-bundle-appimage": "nix-bundle-appimage_2",
         "nix-bundle-dir": "nix-bundle-dir_6",
@@ -3432,7 +3471,7 @@
     },
     "logos-package-manager_3": {
       "inputs": {
-        "logos-nix": "logos-nix_69",
+        "logos-nix": "logos-nix_71",
         "logos-package": "logos-package_6",
         "nix-bundle-appimage": "nix-bundle-appimage_3",
         "nix-bundle-dir": "nix-bundle-dir_9",
@@ -3464,7 +3503,7 @@
     },
     "logos-package-manager_4": {
       "inputs": {
-        "logos-nix": "logos-nix_86",
+        "logos-nix": "logos-nix_88",
         "logos-package": "logos-package_9",
         "nix-bundle-appimage": "nix-bundle-appimage_4",
         "nix-bundle-dir": "nix-bundle-dir_13",
@@ -3495,7 +3534,7 @@
     },
     "logos-package-manager_5": {
       "inputs": {
-        "logos-nix": "logos-nix_97",
+        "logos-nix": "logos-nix_99",
         "logos-package": "logos-package_11",
         "nix-bundle-appimage": "nix-bundle-appimage_5",
         "nix-bundle-dir": "nix-bundle-dir_16",
@@ -3523,7 +3562,7 @@
     },
     "logos-package-manager_6": {
       "inputs": {
-        "logos-nix": "logos-nix_114",
+        "logos-nix": "logos-nix_116",
         "logos-package": "logos-package_14",
         "nix-bundle-appimage": "nix-bundle-appimage_6",
         "nix-bundle-dir": "nix-bundle-dir_20",
@@ -3550,7 +3589,7 @@
     },
     "logos-package_10": {
       "inputs": {
-        "logos-nix": "logos-nix_92",
+        "logos-nix": "logos-nix_94",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3579,7 +3618,7 @@
     },
     "logos-package_11": {
       "inputs": {
-        "logos-nix": "logos-nix_98",
+        "logos-nix": "logos-nix_100",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3605,7 +3644,7 @@
     },
     "logos-package_12": {
       "inputs": {
-        "logos-nix": "logos-nix_107",
+        "logos-nix": "logos-nix_109",
         "nixpkgs": [
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -3630,7 +3669,7 @@
     },
     "logos-package_13": {
       "inputs": {
-        "logos-nix": "logos-nix_111",
+        "logos-nix": "logos-nix_113",
         "nixpkgs": [
           "nix-bundle-lgx",
           "logos-package",
@@ -3654,7 +3693,7 @@
     },
     "logos-package_14": {
       "inputs": {
-        "logos-nix": "logos-nix_115",
+        "logos-nix": "logos-nix_117",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -3679,7 +3718,7 @@
     },
     "logos-package_15": {
       "inputs": {
-        "logos-nix": "logos-nix_120",
+        "logos-nix": "logos-nix_122",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -3704,7 +3743,7 @@
     },
     "logos-package_2": {
       "inputs": {
-        "logos-nix": "logos-nix_35",
+        "logos-nix": "logos-nix_37",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -3732,7 +3771,7 @@
     },
     "logos-package_3": {
       "inputs": {
-        "logos-nix": "logos-nix_39",
+        "logos-nix": "logos-nix_41",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -3759,7 +3798,7 @@
     },
     "logos-package_4": {
       "inputs": {
-        "logos-nix": "logos-nix_43",
+        "logos-nix": "logos-nix_45",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -3787,7 +3826,7 @@
     },
     "logos-package_5": {
       "inputs": {
-        "logos-nix": "logos-nix_48",
+        "logos-nix": "logos-nix_50",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -3815,7 +3854,7 @@
     },
     "logos-package_6": {
       "inputs": {
-        "logos-nix": "logos-nix_70",
+        "logos-nix": "logos-nix_72",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3845,7 +3884,7 @@
     },
     "logos-package_7": {
       "inputs": {
-        "logos-nix": "logos-nix_79",
+        "logos-nix": "logos-nix_81",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3874,7 +3913,7 @@
     },
     "logos-package_8": {
       "inputs": {
-        "logos-nix": "logos-nix_83",
+        "logos-nix": "logos-nix_85",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3902,7 +3941,7 @@
     },
     "logos-package_9": {
       "inputs": {
-        "logos-nix": "logos-nix_87",
+        "logos-nix": "logos-nix_89",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3956,7 +3995,7 @@
     "logos-plugin-core_2": {
       "inputs": {
         "logos-module": "logos-module_5",
-        "logos-nix": "logos-nix_12",
+        "logos-nix": "logos-nix_14",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -3983,7 +4022,7 @@
     "logos-plugin-core_3": {
       "inputs": {
         "logos-module": "logos-module_11",
-        "logos-nix": "logos-nix_56",
+        "logos-nix": "logos-nix_58",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4019,11 +4058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780929868,
-        "narHash": "sha256-yDxv9Cv5VEJDVqHz9qYCU3UXv+kCIjRoD90A7uGYuGU=",
+        "lastModified": 1781062772,
+        "narHash": "sha256-zFKaS/rGWEnjiiNVVrgRBvy//j3AG0mEBBdgcd9zWSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "68090d0a976224ca1c3c606c486a9ac3dd7a4559",
+        "rev": "d73cb870a6e234f7ffadc92bdc94bc0d4b6d3f7d",
         "type": "github"
       },
       "original": {
@@ -4035,7 +4074,7 @@
     "logos-plugin-qt_2": {
       "inputs": {
         "logos-module": "logos-module_6",
-        "logos-nix": "logos-nix_14",
+        "logos-nix": "logos-nix_16",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -4062,7 +4101,7 @@
     "logos-plugin-qt_3": {
       "inputs": {
         "logos-module": "logos-module_12",
-        "logos-nix": "logos-nix_58",
+        "logos-nix": "logos-nix_60",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4087,9 +4126,32 @@
         "type": "github"
       }
     },
+    "logos-protocol": {
+      "inputs": {
+        "logos-nix": "logos-nix_8",
+        "nixpkgs": [
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781065710,
+        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-qt-mcp": {
       "inputs": {
-        "logos-nix": "logos-nix_32",
+        "logos-nix": "logos-nix_34",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -4115,7 +4177,7 @@
     },
     "logos-qt-mcp_2": {
       "inputs": {
-        "logos-nix": "logos-nix_76",
+        "logos-nix": "logos-nix_78",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4142,7 +4204,7 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-        "logos-nix": "logos-nix_104",
+        "logos-nix": "logos-nix_106",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -4164,13 +4226,42 @@
         "type": "github"
       }
     },
+    "logos-qt-sdk": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_9",
+        "logos-protocol": [
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781066423,
+        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "355774603877637b486ea0aeefbf7828ae321868",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
     "logos-standalone-app": {
       "inputs": {
         "logos-capability-module": "logos-capability-module",
         "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-design-system": "logos-design-system_2",
         "logos-liblogos": "logos-liblogos_2",
-        "logos-nix": "logos-nix_103",
+        "logos-nix": "logos-nix_105",
         "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": "logos-view-module-runtime_3",
         "nix-bundle-lgx": "nix-bundle-lgx_7",
@@ -4200,7 +4291,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_3",
         "logos-design-system": "logos-design-system",
         "logos-liblogos": "logos-liblogos",
-        "logos-nix": "logos-nix_31",
+        "logos-nix": "logos-nix_33",
         "logos-qt-mcp": "logos-qt-mcp",
         "logos-view-module-runtime": "logos-view-module-runtime",
         "nix-bundle-lgx": "nix-bundle-lgx",
@@ -4233,7 +4324,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_8",
         "logos-design-system": "logos-design-system_3",
         "logos-liblogos": "logos-liblogos_3",
-        "logos-nix": "logos-nix_75",
+        "logos-nix": "logos-nix_77",
         "logos-qt-mcp": "logos-qt-mcp_2",
         "logos-view-module-runtime": "logos-view-module-runtime_2",
         "nix-bundle-lgx": "nix-bundle-lgx_4",
@@ -4269,7 +4360,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_37",
+        "logos-nix": "logos-nix_39",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -4302,7 +4393,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_81",
+        "logos-nix": "logos-nix_83",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4332,7 +4423,7 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_109",
+        "logos-nix": "logos-nix_111",
         "nixpkgs": [
           "logos-test-framework",
           "logos-nix",
@@ -4362,7 +4453,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_33",
+        "logos-nix": "logos-nix_35",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -4396,7 +4487,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_77",
+        "logos-nix": "logos-nix_79",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4424,7 +4515,7 @@
     "logos-view-module-runtime_3": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_12",
-        "logos-nix": "logos-nix_105",
+        "logos-nix": "logos-nix_107",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-view-module-runtime",
@@ -4448,7 +4539,7 @@
     },
     "nix-bundle-appimage": {
       "inputs": {
-        "logos-nix": "logos-nix_27",
+        "logos-nix": "logos-nix_29",
         "nix-bundle-dir": "nix-bundle-dir",
         "nixpkgs": [
           "logos-standalone-app",
@@ -4478,7 +4569,7 @@
     },
     "nix-bundle-appimage_2": {
       "inputs": {
-        "logos-nix": "logos-nix_44",
+        "logos-nix": "logos-nix_46",
         "nix-bundle-dir": "nix-bundle-dir_5",
         "nixpkgs": [
           "logos-standalone-app",
@@ -4507,7 +4598,7 @@
     },
     "nix-bundle-appimage_3": {
       "inputs": {
-        "logos-nix": "logos-nix_71",
+        "logos-nix": "logos-nix_73",
         "nix-bundle-dir": "nix-bundle-dir_8",
         "nixpkgs": [
           "logos-standalone-app",
@@ -4538,7 +4629,7 @@
     },
     "nix-bundle-appimage_4": {
       "inputs": {
-        "logos-nix": "logos-nix_88",
+        "logos-nix": "logos-nix_90",
         "nix-bundle-dir": "nix-bundle-dir_12",
         "nixpkgs": [
           "logos-standalone-app",
@@ -4568,7 +4659,7 @@
     },
     "nix-bundle-appimage_5": {
       "inputs": {
-        "logos-nix": "logos-nix_99",
+        "logos-nix": "logos-nix_101",
         "nix-bundle-dir": "nix-bundle-dir_15",
         "nixpkgs": [
           "logos-standalone-app",
@@ -4595,7 +4686,7 @@
     },
     "nix-bundle-appimage_6": {
       "inputs": {
-        "logos-nix": "logos-nix_116",
+        "logos-nix": "logos-nix_118",
         "nix-bundle-dir": "nix-bundle-dir_19",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -4621,7 +4712,7 @@
     },
     "nix-bundle-dir": {
       "inputs": {
-        "logos-nix": "logos-nix_28",
+        "logos-nix": "logos-nix_30",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -4649,7 +4740,7 @@
     },
     "nix-bundle-dir_10": {
       "inputs": {
-        "logos-nix": "logos-nix_80",
+        "logos-nix": "logos-nix_82",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4678,7 +4769,7 @@
     },
     "nix-bundle-dir_11": {
       "inputs": {
-        "logos-nix": "logos-nix_84",
+        "logos-nix": "logos-nix_86",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4706,7 +4797,7 @@
     },
     "nix-bundle-dir_12": {
       "inputs": {
-        "logos-nix": "logos-nix_89",
+        "logos-nix": "logos-nix_91",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4734,7 +4825,7 @@
     },
     "nix-bundle-dir_13": {
       "inputs": {
-        "logos-nix": "logos-nix_90",
+        "logos-nix": "logos-nix_92",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4763,7 +4854,7 @@
     },
     "nix-bundle-dir_14": {
       "inputs": {
-        "logos-nix": "logos-nix_93",
+        "logos-nix": "logos-nix_95",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4792,7 +4883,7 @@
     },
     "nix-bundle-dir_15": {
       "inputs": {
-        "logos-nix": "logos-nix_100",
+        "logos-nix": "logos-nix_102",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4817,7 +4908,7 @@
     },
     "nix-bundle-dir_16": {
       "inputs": {
-        "logos-nix": "logos-nix_101",
+        "logos-nix": "logos-nix_103",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4843,7 +4934,7 @@
     },
     "nix-bundle-dir_17": {
       "inputs": {
-        "logos-nix": "logos-nix_108",
+        "logos-nix": "logos-nix_110",
         "nixpkgs": [
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -4868,7 +4959,7 @@
     },
     "nix-bundle-dir_18": {
       "inputs": {
-        "logos-nix": "logos-nix_112",
+        "logos-nix": "logos-nix_114",
         "nixpkgs": [
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -4892,7 +4983,7 @@
     },
     "nix-bundle-dir_19": {
       "inputs": {
-        "logos-nix": "logos-nix_117",
+        "logos-nix": "logos-nix_119",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -4916,7 +5007,7 @@
     },
     "nix-bundle-dir_2": {
       "inputs": {
-        "logos-nix": "logos-nix_29",
+        "logos-nix": "logos-nix_31",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -4945,7 +5036,7 @@
     },
     "nix-bundle-dir_20": {
       "inputs": {
-        "logos-nix": "logos-nix_118",
+        "logos-nix": "logos-nix_120",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -4970,7 +5061,7 @@
     },
     "nix-bundle-dir_21": {
       "inputs": {
-        "logos-nix": "logos-nix_121",
+        "logos-nix": "logos-nix_123",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -4995,7 +5086,7 @@
     },
     "nix-bundle-dir_3": {
       "inputs": {
-        "logos-nix": "logos-nix_36",
+        "logos-nix": "logos-nix_38",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -5023,7 +5114,7 @@
     },
     "nix-bundle-dir_4": {
       "inputs": {
-        "logos-nix": "logos-nix_40",
+        "logos-nix": "logos-nix_42",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -5050,7 +5141,7 @@
     },
     "nix-bundle-dir_5": {
       "inputs": {
-        "logos-nix": "logos-nix_45",
+        "logos-nix": "logos-nix_47",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -5077,7 +5168,7 @@
     },
     "nix-bundle-dir_6": {
       "inputs": {
-        "logos-nix": "logos-nix_46",
+        "logos-nix": "logos-nix_48",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -5105,7 +5196,7 @@
     },
     "nix-bundle-dir_7": {
       "inputs": {
-        "logos-nix": "logos-nix_49",
+        "logos-nix": "logos-nix_51",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -5133,7 +5224,7 @@
     },
     "nix-bundle-dir_8": {
       "inputs": {
-        "logos-nix": "logos-nix_72",
+        "logos-nix": "logos-nix_74",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -5162,7 +5253,7 @@
     },
     "nix-bundle-dir_9": {
       "inputs": {
-        "logos-nix": "logos-nix_73",
+        "logos-nix": "logos-nix_75",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -5192,7 +5283,7 @@
     },
     "nix-bundle-lgx": {
       "inputs": {
-        "logos-nix": "logos-nix_34",
+        "logos-nix": "logos-nix_36",
         "logos-package": "logos-package_2",
         "nix-bundle-dir": "nix-bundle-dir_3",
         "nixpkgs": [
@@ -5220,7 +5311,7 @@
     },
     "nix-bundle-lgx_2": {
       "inputs": {
-        "logos-nix": "logos-nix_38",
+        "logos-nix": "logos-nix_40",
         "logos-package": "logos-package_3",
         "nix-bundle-dir": "nix-bundle-dir_4",
         "nixpkgs": [
@@ -5248,7 +5339,7 @@
     },
     "nix-bundle-lgx_3": {
       "inputs": {
-        "logos-nix": "logos-nix_47",
+        "logos-nix": "logos-nix_49",
         "logos-package": "logos-package_5",
         "nix-bundle-dir": "nix-bundle-dir_7",
         "nixpkgs": [
@@ -5277,7 +5368,7 @@
     },
     "nix-bundle-lgx_4": {
       "inputs": {
-        "logos-nix": "logos-nix_78",
+        "logos-nix": "logos-nix_80",
         "logos-package": "logos-package_7",
         "nix-bundle-dir": "nix-bundle-dir_10",
         "nixpkgs": [
@@ -5306,7 +5397,7 @@
     },
     "nix-bundle-lgx_5": {
       "inputs": {
-        "logos-nix": "logos-nix_82",
+        "logos-nix": "logos-nix_84",
         "logos-package": "logos-package_8",
         "nix-bundle-dir": "nix-bundle-dir_11",
         "nixpkgs": [
@@ -5335,7 +5426,7 @@
     },
     "nix-bundle-lgx_6": {
       "inputs": {
-        "logos-nix": "logos-nix_91",
+        "logos-nix": "logos-nix_93",
         "logos-package": "logos-package_10",
         "nix-bundle-dir": "nix-bundle-dir_14",
         "nixpkgs": [
@@ -5365,7 +5456,7 @@
     },
     "nix-bundle-lgx_7": {
       "inputs": {
-        "logos-nix": "logos-nix_106",
+        "logos-nix": "logos-nix_108",
         "logos-package": "logos-package_12",
         "nix-bundle-dir": "nix-bundle-dir_17",
         "nixpkgs": [
@@ -5391,7 +5482,7 @@
     },
     "nix-bundle-lgx_8": {
       "inputs": {
-        "logos-nix": "logos-nix_110",
+        "logos-nix": "logos-nix_112",
         "logos-package": "logos-package_13",
         "nix-bundle-dir": "nix-bundle-dir_18",
         "nixpkgs": [
@@ -5416,7 +5507,7 @@
     },
     "nix-bundle-lgx_9": {
       "inputs": {
-        "logos-nix": "logos-nix_119",
+        "logos-nix": "logos-nix_121",
         "logos-package": "logos-package_15",
         "nix-bundle-dir": "nix-bundle-dir_21",
         "nixpkgs": [
@@ -5442,7 +5533,7 @@
     },
     "nix-bundle-logos-module-install": {
       "inputs": {
-        "logos-nix": "logos-nix_41",
+        "logos-nix": "logos-nix_43",
         "logos-package-manager": "logos-package-manager_2",
         "nix-bundle-lgx": "nix-bundle-lgx_3",
         "nixpkgs": [
@@ -5470,7 +5561,7 @@
     },
     "nix-bundle-logos-module-install_2": {
       "inputs": {
-        "logos-nix": "logos-nix_85",
+        "logos-nix": "logos-nix_87",
         "logos-package-manager": "logos-package-manager_4",
         "nix-bundle-lgx": "nix-bundle-lgx_6",
         "nixpkgs": [
@@ -5499,7 +5590,7 @@
     },
     "nix-bundle-logos-module-install_3": {
       "inputs": {
-        "logos-nix": "logos-nix_113",
+        "logos-nix": "logos-nix_115",
         "logos-package-manager": "logos-package-manager_6",
         "nix-bundle-lgx": "nix-bundle-lgx_9",
         "nixpkgs": [
@@ -5923,6 +6014,38 @@
       }
     },
     "nixpkgs_121": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_122": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_123": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -7460,7 +7583,7 @@
     },
     "process-stats": {
       "inputs": {
-        "logos-nix": "logos-nix_30",
+        "logos-nix": "logos-nix_32",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-capability-module",
@@ -7488,7 +7611,7 @@
     },
     "process-stats_2": {
       "inputs": {
-        "logos-nix": "logos-nix_74",
+        "logos-nix": "logos-nix_76",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7517,7 +7640,7 @@
     },
     "process-stats_3": {
       "inputs": {
-        "logos-nix": "logos-nix_102",
+        "logos-nix": "logos-nix_104",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7547,6 +7670,8 @@
         "logos-nix": "logos-nix_3",
         "logos-plugin-core": "logos-plugin-core",
         "logos-plugin-qt": "logos-plugin-qt",
+        "logos-protocol": "logos-protocol",
+        "logos-qt-sdk": "logos-qt-sdk",
         "logos-standalone-app": "logos-standalone-app",
         "logos-test-framework": "logos-test-framework_3",
         "nix-bundle-lgx": "nix-bundle-lgx_8",

--- a/flake.lock
+++ b/flake.lock
@@ -4267,11 +4267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305265,
+        "lastModified": 1781306785,
         "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "722e5908ea4e2f5abdffda221d7b7aba55725609",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,13 @@
     logos-nix.url = "github:logos-co/logos-nix";
     # SDK and module deps — owned by this builder, injected into backends
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
+    logos-cpp-sdk.inputs.logos-protocol.follows = "logos-protocol";
+    # Protocol layer (transports + lp_* C ABI + the protocol semver every
+    # module gets stamped with) and the Qt developer layer modules link.
+    logos-protocol.url = "github:logos-co/logos-protocol";
+    logos-qt-sdk.url = "github:logos-co/logos-qt-sdk";
+    logos-qt-sdk.inputs.logos-protocol.follows = "logos-protocol";
+    logos-qt-sdk.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
     logos-module.url = "github:logos-co/logos-module";
     # UI modules (type: ui, ui_qml) always use Qt
     logos-plugin-qt.url = "github:logos-co/logos-plugin-qt";
@@ -19,7 +26,7 @@
     nixpkgs.follows = "logos-nix/nixpkgs";
   };
 
-  outputs = { self, nixpkgs, logos-cpp-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, ... }:
+  outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, ... }:
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
 
@@ -32,7 +39,7 @@
       # Use rawLib from backends — we inject logos-cpp-sdk/logos-module ourselves
       lib = import ./lib {
         inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app;
-        inherit logos-cpp-sdk logos-module logos-test-framework;
+        inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework;
         inherit (nixpkgs) lib;
         uiBackend = logos-plugin-qt.rawLib or logos-plugin-qt.lib;
         coreBackend = logos-plugin-core.rawLib or logos-plugin-core.lib;

--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -2,7 +2,7 @@
 # resolution, plugin compilation (via backend), header generation, dev shells,
 # and LGX bundling.  Callers (mkLogosModule, mkLogosQmlModule) compose final
 # `packages` and `apps` outputs differently.
-{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-module, uiBackend, coreBackend, nix-bundle-lgx, nix-bundle-logos-module-install }:
+{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, uiBackend, coreBackend, nix-bundle-lgx, nix-bundle-logos-module-install }:
 
 {
   src,
@@ -120,7 +120,23 @@ let
 
       # Resolve SDK deps for this system — injected into the backend
       logosSdk = logos-cpp-sdk.packages.${system}.default;
+      logosQtSdk = logos-qt-sdk.packages.${system}.default;
+      logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
+
+      # The logos-protocol semver — parsed from the protocol header the
+      # whole stack links. Stamped into every module's embedded metadata
+      # (see modulePreConfigure.stampProtocolVersion). null (no stamp) only
+      # if the input is somehow absent — modules then load as "legacy".
+      protocolVersion =
+        if logos-protocol == null then null
+        else
+          let
+            header = builtins.readFile "${logos-protocol}/cpp/logos_protocol.h";
+            parts = builtins.split "LOGOS_PROTOCOL_VERSION_STRING \"([^\"]*)\"" header;
+          in if builtins.length parts < 2 then null
+             else builtins.head (builtins.elemAt parts 1);
+
 
       modulePreConfigure = import ./modulePreConfigure.nix { inherit lib; };
 
@@ -157,7 +173,7 @@ let
             else preConfigure;
 
           preConfigureStr = modulePreConfigure.compose {
-            inherit config externalLibs;
+            inherit config externalLibs protocolVersion;
             userPre = userPreConfigure;
             fixDarwin = false;
             copyExternals = false;
@@ -167,11 +183,17 @@ let
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
           inherit externalLibs;
-          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdk ];
-          extraBuildInputs = extraBuildInputs ++ runtimePkgs;
-          extraCmakeFlags = [ "-DLOGOS_CPP_SDK_ROOT=${logosSdk}" ] ++ goCmakeFlags;
+          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdk pkgs.jq ];
+          extraBuildInputs = extraBuildInputs ++ runtimePkgs ++ [ logosQtSdk logosProtocolPkg ];
+          extraCmakeFlags = [
+            "-DLOGOS_CPP_SDK_ROOT=${logosSdk}"
+            "-DLOGOS_QT_SDK_ROOT=${logosQtSdk}"
+            "-DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg}"
+          ] ++ goCmakeFlags;
           extraEnv = {
             LOGOS_CPP_SDK_ROOT = "${logosSdk}";
+            LOGOS_QT_SDK_ROOT = "${logosQtSdk}";
+            LOGOS_PROTOCOL_ROOT = "${logosProtocolPkg}";
           } // lib.optionalAttrs hasBuilderCmake {
             LOGOS_MODULE_BUILDER_ROOT = "${src}";
           };
@@ -200,7 +222,23 @@ let
     let
       pkgs = import nixpkgs { inherit system; };
       logosSdk = logos-cpp-sdk.packages.${system}.default;
+      logosQtSdk = logos-qt-sdk.packages.${system}.default;
+      logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
+
+      # The logos-protocol semver — parsed from the protocol header the
+      # whole stack links. Stamped into every module's embedded metadata
+      # (see modulePreConfigure.stampProtocolVersion). null (no stamp) only
+      # if the input is somehow absent — modules then load as "legacy".
+      protocolVersion =
+        if logos-protocol == null then null
+        else
+          let
+            header = builtins.readFile "${logos-protocol}/cpp/logos_protocol.h";
+            parts = builtins.split "LOGOS_PROTOCOL_VERSION_STRING \"([^\"]*)\"" header;
+          in if builtins.length parts < 2 then null
+             else builtins.head (builtins.elemAt parts 1);
+
       backendShell = selectedBackend.devShellInputs pkgs { inherit logosModule; };
       buildPkgs = map (getPkg pkgs) config.nix_packages.build;
       runtimePkgs = map (getPkg pkgs) config.nix_packages.runtime;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,7 @@
 #
 # logos-cpp-sdk and logos-module are owned by this builder and injected into
 # backends — backends never resolve these deps themselves.
-{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-module, logos-test-framework, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, builderRoot }:
+{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, builderRoot }:
 
 let
   # Import common utilities (backend-agnostic)
@@ -17,13 +17,13 @@ let
   mkLogosModule = import ./mkLogosModule.nix {
     inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app lib;
     inherit common parseMetadata builderRoot uiBackend coreBackend;
-    inherit logos-cpp-sdk logos-module logos-test-framework;
+    inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework;
   };
 
   # Import the shared C++ plugin build pipeline (used by mkLogosQmlModule for backend builds)
   buildCppPlugin = import ./buildCppPlugin.nix {
     inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install lib;
-    inherit common parseMetadata logos-cpp-sdk logos-module uiBackend coreBackend;
+    inherit common parseMetadata logos-cpp-sdk logos-protocol logos-qt-sdk logos-module uiBackend coreBackend;
   };
 
   # Import the ui_qml module builder (QML view + optional C++ backend)

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -39,7 +39,7 @@ let
   # Import the test builder
   mkLogosModuleTests = import ./mkLogosModuleTests.nix {
     inherit nixpkgs lib common parseMetadata;
-    inherit logos-cpp-sdk logos-test-framework;
+    inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-test-framework;
   };
 
 in {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -29,7 +29,7 @@ let
   # Import the ui_qml module builder (QML view + optional C++ backend)
   mkLogosQmlModule = import ./mkLogosQmlModule.nix {
     inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app lib;
-    inherit common parseMetadata logos-cpp-sdk logos-module uiBackend coreBackend;
+    inherit common parseMetadata logos-cpp-sdk logos-protocol logos-qt-sdk logos-module uiBackend coreBackend;
   };
 
   # Import sub-builders that remain backend-agnostic

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -2,7 +2,7 @@
 # This is the main entry point for building Logos modules.
 # Plugin compilation and header generation are delegated to a backend selected
 # by metadata.json "type": core modules use coreBackend, UI modules use uiBackend.
-{ nixpkgs, lib, common, parseMetadata, builderRoot, uiBackend, coreBackend, logos-cpp-sdk, logos-module, logos-test-framework, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
+{ nixpkgs, lib, common, parseMetadata, builderRoot, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
 
 {
   # Required: Path to the module source
@@ -208,7 +208,23 @@ let
 
       # Resolve SDK deps for this system — injected into the backend
       logosSdk = logos-cpp-sdk.packages.${system}.default;
+      logosQtSdk = logos-qt-sdk.packages.${system}.default;
+      logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
+
+      # The logos-protocol semver — parsed from the protocol header the
+      # whole stack links. Stamped into every module's embedded metadata
+      # (see modulePreConfigure.stampProtocolVersion). null (no stamp) only
+      # if the input is somehow absent — modules then load as "legacy".
+      protocolVersion =
+        if logos-protocol == null then null
+        else
+          let
+            header = builtins.readFile "${logos-protocol}/cpp/logos_protocol.h";
+            parts = builtins.split "LOGOS_PROTOCOL_VERSION_STRING \"([^\"]*)\"" header;
+          in if builtins.length parts < 2 then null
+             else builtins.head (builtins.elemAt parts 1);
+
 
       # Build the plugin for a given external-lib variant ("default" or "portable")
       buildVariant = variant:
@@ -226,7 +242,7 @@ let
             else preConfigure;
 
           preConfigureStr = modulePreConfigure.compose {
-            inherit config externalLibs;
+            inherit config externalLibs protocolVersion;
             userPre = userPreConfigure;
             fixDarwin = false;
             # logos-plugin-qt buildPlugin already stages external libs into lib/
@@ -256,11 +272,17 @@ let
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
           inherit externalLibs;
-          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdk ];
-          extraBuildInputs = extraBuildInputs ++ runtimePkgs;
-          extraCmakeFlags = [ "-DLOGOS_CPP_SDK_ROOT=${logosSdk}" ] ++ goCmakeFlags ++ apiStyleCmakeFlags;
+          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdk pkgs.jq ];
+          extraBuildInputs = extraBuildInputs ++ runtimePkgs ++ [ logosQtSdk logosProtocolPkg ];
+          extraCmakeFlags = [
+            "-DLOGOS_CPP_SDK_ROOT=${logosSdk}"
+            "-DLOGOS_QT_SDK_ROOT=${logosQtSdk}"
+            "-DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg}"
+          ] ++ goCmakeFlags ++ apiStyleCmakeFlags;
           extraEnv = {
             LOGOS_CPP_SDK_ROOT = "${logosSdk}";
+            LOGOS_QT_SDK_ROOT = "${logosQtSdk}";
+            LOGOS_PROTOCOL_ROOT = "${logosProtocolPkg}";
           } // lib.optionalAttrs hasBuilderCmake {
             LOGOS_MODULE_BUILDER_ROOT = "${builderRoot}";
           };
@@ -369,7 +391,23 @@ let
     let
       pkgs = import nixpkgs { inherit system; };
       logosSdk = logos-cpp-sdk.packages.${system}.default;
+      logosQtSdk = logos-qt-sdk.packages.${system}.default;
+      logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
+
+      # The logos-protocol semver — parsed from the protocol header the
+      # whole stack links. Stamped into every module's embedded metadata
+      # (see modulePreConfigure.stampProtocolVersion). null (no stamp) only
+      # if the input is somehow absent — modules then load as "legacy".
+      protocolVersion =
+        if logos-protocol == null then null
+        else
+          let
+            header = builtins.readFile "${logos-protocol}/cpp/logos_protocol.h";
+            parts = builtins.split "LOGOS_PROTOCOL_VERSION_STRING \"([^\"]*)\"" header;
+          in if builtins.length parts < 2 then null
+             else builtins.head (builtins.elemAt parts 1);
+
       backendShell = selectedBackend.devShellInputs pkgs { inherit logosModule; };
       buildPkgs = map (getPkg pkgs) config.nix_packages.build;
       runtimePkgs = map (getPkg pkgs) config.nix_packages.runtime;
@@ -380,6 +418,8 @@ let
         shellHook = ''
           ${backendShell.shellHook}
           export LOGOS_CPP_SDK_ROOT="${logosSdk}"
+          export LOGOS_QT_SDK_ROOT="${logos-qt-sdk.packages.${system}.default}"
+          export LOGOS_PROTOCOL_ROOT="${logos-protocol.packages.${system}.default}"
           ${lib.optionalString hasBuilderCmake ''export LOGOS_MODULE_BUILDER_ROOT="${builderRoot}"''}
           echo "Logos ${config.name} module development environment"
           echo "LOGOS_CPP_SDK_ROOT: $LOGOS_CPP_SDK_ROOT"

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -490,7 +490,7 @@ let
   # Build unit tests — explicit config wins, otherwise auto-detect tests/CMakeLists.txt
   mkTests = import ./mkLogosModuleTests.nix {
     inherit nixpkgs lib common parseMetadata;
-    inherit logos-cpp-sdk;
+    inherit logos-cpp-sdk logos-protocol logos-qt-sdk;
     logos-test-framework = logos-test-framework;
   };
 

--- a/lib/mkLogosModuleTests.nix
+++ b/lib/mkLogosModuleTests.nix
@@ -13,7 +13,7 @@
 #     flakeInputs = inputs;
 #     mockCLibs = ["gowalletsdk"];  # optional
 #   };
-{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-test-framework }:
+{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-test-framework }:
 
 let
   modulePreConfigure = import ./modulePreConfigure.nix { inherit lib; };
@@ -60,6 +60,8 @@ let
     let
       pkgs = import nixpkgs { inherit system; };
       logosSdk = logos-cpp-sdk.packages.${system}.default;
+      logosQtSdk = logos-qt-sdk.packages.${system}.default;
+      logosProtocolPkg = logos-protocol.packages.${system}.default;
       testFramework = logos-test-framework.packages.${system}.default;
 
       # Resolve runtime packages from metadata (e.g. nlohmann_json)
@@ -147,6 +149,8 @@ let
           qt6.qtbase
           qt6.qtremoteobjects
           logosSdk
+          logosQtSdk
+          logosProtocolPkg
           testFramework
         ] ++ runtimePkgs;
 
@@ -176,6 +180,8 @@ let
           mkdir -p build && cd build
           cmake ../${testDirName} \
             -DLOGOS_CPP_SDK_ROOT=${logosSdk} \
+            -DLOGOS_QT_SDK_ROOT=${logosQtSdk} \
+            -DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg} \
             -DLOGOS_TEST_FRAMEWORK_ROOT=${testFramework} \
             -DCMAKE_MODULE_PATH=${testFramework}/cmake \
             ${lib.optionalString (externalLibRpath != "") "-DCMAKE_INSTALL_RPATH=${externalLibRpath} -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"} \

--- a/lib/mkLogosQmlModule.nix
+++ b/lib/mkLogosQmlModule.nix
@@ -1,7 +1,7 @@
 # ui_qml module builder — QML view + optional C++ backend (process-isolated).
 # Calls buildCppPlugin only when config.main is set; the resulting `combined`
 # output bundles the plugin .so (when present) with the QML view directory.
-{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-module, uiBackend, coreBackend, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
+{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, uiBackend, coreBackend, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
 
 {
   # Required: Path to the module source
@@ -54,7 +54,7 @@ let
 
   # Delegate compilation to the shared build pipeline (only when there's a backend).
   buildCppPlugin = import ./buildCppPlugin.nix {
-    inherit nixpkgs lib common parseMetadata logos-cpp-sdk logos-module uiBackend coreBackend nix-bundle-lgx nix-bundle-logos-module-install;
+    inherit nixpkgs lib common parseMetadata logos-cpp-sdk logos-protocol logos-qt-sdk logos-module uiBackend coreBackend nix-bundle-lgx nix-bundle-logos-module-install;
   };
 
   built =

--- a/lib/modulePreConfigure.nix
+++ b/lib/modulePreConfigure.nix
@@ -93,14 +93,29 @@ let
   # Order: optional ext copy -> optional darwin fixup -> codegen -> user hook
   # Note: mkLogosModule main builds already copy externals in logos-plugin-qt buildPlugin
   # (externalLibCopies). Use copyExternals=true only for contexts without that (e.g. unit tests).
-  compose = { config, externalLibs, userPre, fixDarwin ? false, copyExternals ? false }:
+  # Stamp the logos-protocol semver the module is being built against into
+  # the metadata.json the plugin embeds (Q_PLUGIN_METADATA). One number
+  # governs Logos load/call compatibility (same MAJOR <=> compatible);
+  # liblogos reads it pre-load. Runs before cmake/moc so the embedded copy
+  # carries the field; modules built by older builders simply lack it and
+  # load permissively ("legacy").
+  stampProtocolVersion = protocolVersion:
+    if protocolVersion == null then "" else ''
+      if [ -f ./metadata.json ]; then
+        jq '. + {logos_protocol_version: "${protocolVersion}"}' ./metadata.json           > ./metadata.json.lp-stamp && mv ./metadata.json.lp-stamp ./metadata.json
+        echo "Stamped logos_protocol_version=${protocolVersion} into metadata.json"
+      fi
+    '';
+
+  compose = { config, externalLibs, userPre, fixDarwin ? false, copyExternals ? false, protocolVersion ? null }:
     let
+      stamp = stampProtocolVersion protocolVersion;
       copy = if copyExternals then copyExternalLibsToLib externalLibs else "";
       codegen = autoCodegen config;
       fix = if fixDarwin then fixupDarwinDylibs else "";
     in
-      copy + fix + codegen + userPre;
+      stamp + copy + fix + codegen + userPre;
 
 in {
-  inherit defaultImplClassFromName copyExternalLibsToLib fixupDarwinDylibs universalCodegen providerCodegen autoCodegen compose;
+  inherit defaultImplClassFromName copyExternalLibsToLib fixupDarwinDylibs universalCodegen providerCodegen autoCodegen compose stampProtocolVersion;
 }


### PR DESCRIPTION
Part of the logos-protocol extraction (phases 2–4). Stacked set — depends on:
- logos-co/logos-protocol#3 (LogosProviderPlugin + module-impl C ABI)
- logos-co/logos-cpp-sdk#83 (Qt-free base SDK)
- logos-co/logos-qt-sdk#1 (Qt developer layer)
- logos-co/logos-plugin-qt PR (three-root LogosModule.cmake)

## What

The builder absorbs the SDK split so modules don't: **builder-based modules keep full source-level compatibility and need only a flake.lock bump** — no `metadata.json`, source, or `flake.nix` edits.

- `flake.nix`: new inputs `logos-protocol` and `logos-qt-sdk`; `lib/{default,mkLogosModule,buildCppPlugin}.nix` inject `logosQtSdk`/`logosProtocolPkg` and export the three SDK roots to the module build (`LOGOS_CPP_SDK_ROOT` / `LOGOS_QT_SDK_ROOT` / `LOGOS_PROTOCOL_ROOT`).
- **Protocol-version stamp**: the protocol semver is parsed from `LOGOS_PROTOCOL_VERSION_STRING` in `logos_protocol.h` (nix `builtins.split` — single source of truth, never minted) and `lib/modulePreConfigure.nix` jq-injects it as `logos_protocol_version` into `metadata.json` *before* moc embeds it. Every freshly built module carries the stamp in its `Q_PLUGIN_METADATA`, readable without loading (`lm`, `lgx verify`, `lgpm info`).
- `cmake/LogosModule.cmake` synced from logos-plugin-qt's retargeted copy — this is the canonical copy modules actually include via `$LOGOS_MODULE_BUILDER_ROOT`.

## Verification

- `capability_module` built through the builder carries `logos_protocol_version=0.1.0` in its embedded metadata (verified by inspecting the built binary).
- Workspace-pinned check builds of the module fleet (capability/test-modules suites) pass with these inputs — results posted on the workspace PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)