### PR TITLE
feat: add a `generate` output to module-builder modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,22 @@ backward compatibility, but the templates and the recommended path are universal
 git init && git add -A   # Nix needs files tracked by git
 nix build                    # Build everything
 nix build .#lib              # Build just the library
+nix build .#generate         # Emit a ready-to-build codebase (all code generators run)
 nix build .#lgx              # Build .lgx package
 nix build .#lgx-portable     # Build portable .lgx package
 nix build .#install          # Build, package, and install (dev)
 nix build .#install-portable # Build, package, and install (portable)
 ```
+
+`nix build .#generate` runs every code generator that is part of the build —
+`logos-cpp-generator` (`--general-only` + dependency/interface wrappers) and the
+interface-specific glue (LIDL, Qt glue, C-ABI dispatch, UI plugin glue) — and
+leaves the result in `result/`: the module source plus a fully-populated
+`generated_code/`. Inspect the generated glue, or build it directly from the
+module's `nix develop` shell (which exports the `LOGOS_*_ROOT` vars) without
+re-running any generator. The output is exactly what a normal build compiles. It
+is produced for every C++ module and for UI modules with a C++ backend (QML-only
+modules have no generators to run).
 
 ### UI modules: `nix run` with logos-standalone-app
 
@@ -175,6 +186,7 @@ See the [logos-qt-mcp](https://github.com/logos-co/logos-qt-mcp) test framework 
 - **External library support** (vendor pre-built or flake-input source)
 - **Cross-platform** (macOS, Linux)
 - **Auto-resolved module dependencies** from `flakeInputs`
+- **Ready-to-build source output** — `nix build .#generate` runs every code generator and emits the module source + a fully-populated `generated_code/` in `result/`
 - **Built-in LGX packaging** — `nix build .#lgx` and `nix build .#lgx-portable` included automatically
 - **Built-in install outputs** — `nix build .#install` and `nix build .#install-portable` bundle and install via lgpm in one step
 - **Auto-detected UI integration tests** — put `.mjs` test files in `tests/` and get `nix build .#integration-test` for free

--- a/flake.lock
+++ b/flake.lock
@@ -3979,11 +3979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781409313,
-        "narHash": "sha256-2FXFInN5vgnjIhg1hI+S7eE4yFdEJMCoJXYrTQq42qY=",
+        "lastModified": 1781456993,
+        "narHash": "sha256-LMF7pJtmYNqeEjXiufLTEehGGGYoD5XVwT+jY9Gg5MM=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "3aefbc55b59488c04efa18cb2335af855bc19f7e",
+        "rev": "dca52b9fd508508bff396794636b8d2d2e007fd1",
         "type": "github"
       },
       "original": {
@@ -4058,11 +4058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781409313,
-        "narHash": "sha256-2FXFInN5vgnjIhg1hI+S7eE4yFdEJMCoJXYrTQq42qY=",
+        "lastModified": 1781456993,
+        "narHash": "sha256-LMF7pJtmYNqeEjXiufLTEehGGGYoD5XVwT+jY9Gg5MM=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "3aefbc55b59488c04efa18cb2335af855bc19f7e",
+        "rev": "dca52b9fd508508bff396794636b8d2d2e007fd1",
         "type": "github"
       },
       "original": {

--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -160,8 +160,10 @@ let
         "-DLOGOS_MODULE_GO_STATIC_LIBS=${lib.concatStringsSep ";" config.go_static_lib_names}"
       ];
 
-      # Build the plugin for a given external-lib variant ("default" or "portable")
-      buildVariant = variant:
+      # Backend arguments for a given external-lib variant ("default" or
+      # "portable"). Shared by buildVariant (compiles) and the generate output
+      # (snapshots the post-codegen source tree) so both use identical inputs.
+      mkPluginArgs = variant:
         let
           externalLibs =
             if variant == "default" then defaultExternalLibs
@@ -181,7 +183,7 @@ let
             fixDarwin = false;
             copyExternals = false;
           };
-        in selectedBackend.buildPlugin ({
+        in ({
           inherit pkgs src config postInstall logosModule;
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
@@ -206,8 +208,16 @@ let
           inherit staticDeps;
         });
 
+      # Compile the plugin for a variant (delegated to the backend).
+      buildVariant = variant: selectedBackend.buildPlugin (mkPluginArgs variant);
+
       moduleLib = buildVariant "default";
       moduleLibPortable = if hasVariants then buildVariant "portable" else null;
+
+      # Ready-to-build source tree: same backend args as the default plugin
+      # build, but the backend runs the generators and snapshots the result
+      # instead of compiling. Matches a real build.
+      moduleGenerate = selectedBackend.generate (mkPluginArgs "default");
 
       # Delegate header generation to the backend
       moduleInclude = selectedBackend.buildHeaders {
@@ -216,7 +226,7 @@ let
       };
 
     in {
-      inherit pkgs moduleLib moduleLibPortable moduleInclude hasVariants;
+      inherit pkgs moduleLib moduleLibPortable moduleInclude hasVariants moduleGenerate;
     }
   );
 

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -233,8 +233,11 @@ let
              else builtins.head (builtins.elemAt parts 1);
 
 
-      # Build the plugin for a given external-lib variant ("default" or "portable")
-      buildVariant = variant:
+      # Backend arguments for a given external-lib variant ("default" or
+      # "portable"). Shared by buildVariant (compiles the plugin) and the
+      # generate output (snapshots the post-codegen source tree) so both use the
+      # identical preConfigure / deps / env.
+      mkPluginArgs = variant:
         let
           externalLibs =
             if variant == "default" then defaultExternalLibs
@@ -273,10 +276,9 @@ let
             if config.interface == "universal" && (config.type or "core") != "ui_qml"
             then [ "-DLOGOS_API_STYLE=lp" ]
             else lib.optionals (config.interface == "universal") [ "-DLOGOS_API_STYLE=std" ];
-        # Delegate plugin compilation to the backend.
         # The backend only knows about Qt + logosModule (interface.h).
         # SDK (generator, lib, headers) is injected via extra* args.
-        in selectedBackend.buildPlugin ({
+        in ({
           inherit pkgs src config postInstall logosModule;
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
@@ -309,8 +311,18 @@ let
           inherit staticDeps;
         });
 
+      # Compile the plugin for a variant (delegated to the backend).
+      buildVariant = variant: selectedBackend.buildPlugin (mkPluginArgs variant);
+
       moduleLib = buildVariant "default";
       moduleLibPortable = if hasVariants then buildVariant "portable" else null;
+
+      # Ready-to-build source tree: the backend runs every generator the build
+      # runs, then snapshots the result (module source + generated_code/) instead
+      # of compiling. Same args as the default plugin build, so the emitted tree
+      # is exactly what a real build generates. Built from the module's
+      # `nix develop` shell (which exports LOGOS_*_ROOT) without re-running codegen.
+      moduleGenerate = selectedBackend.generate (mkPluginArgs "default");
 
       # Three header variants per module — Qt-typed, std-typed, and lp
       # (Qt-free, logos-protocol C ABI). Each is its own Nix derivation, so a
@@ -402,6 +414,12 @@ let
 
       # Default package - combined lib + include (nix build)
       default = combined;
+
+      # Ready-to-build codebase: all code generators run, emitted as a source
+      # tree (nix build .#generate). Build it from `nix develop` — no generator
+      # re-runs (LogosModule.cmake consumes the pre-populated generated_code/).
+      generate = moduleGenerate;
+      "${config.name}-generate" = moduleGenerate;
     } // lib.optionalAttrs (moduleLibPortable != null) {
       "${config.name}-lib-portable" = moduleLibPortable;
       lib-portable = moduleLibPortable;

--- a/lib/mkLogosQmlModule.nix
+++ b/lib/mkLogosQmlModule.nix
@@ -145,6 +145,12 @@ let
     } // lib.optionalAttrs hasBackend {
       "${config.name}-lib" = moduleLib;
       lib = moduleLib;
+
+      # Ready-to-build codebase: all code generators run, emitted as a source
+      # tree (nix build .#generate). Only for modules with a C++ backend —
+      # QML-only modules have no generators to run.
+      generate = built.perSystem.${system}.moduleGenerate;
+      "${config.name}-generate" = built.perSystem.${system}.moduleGenerate;
     } // lib.optionalAttrs (moduleLibPortable != null) {
       "${config.name}-lib-portable" = moduleLibPortable;
       lib-portable = moduleLibPortable;


### PR DESCRIPTION
## What

Every module-builder-generated module now exposes a **`generate`** flake output. `nix build .#generate` runs all the build's code generators and leaves a ready-to-build codebase in `result/`: the module source plus a fully-populated `generated_code/`. Inspect the generated glue, or build it directly from the module's `nix develop` shell (which exports the `LOGOS_*_ROOT` vars) without re-running any generator.

## How

- `lib/mkLogosModule.nix`: factor `buildVariant` into a shared `mkPluginArgs`, then `moduleGenerate = selectedBackend.generate (mkPluginArgs "default")`, exposed as `generate` / `<name>-generate`. Covers core / universal / cdylib / provider / external-lib.
- `lib/buildCppPlugin.nix` + `lib/mkLogosQmlModule.nix`: same wiring for UI modules — `generate` is emitted only when there's a C++ backend (QML-only modules have no generators to run).
- `README.md`: document the new output.

The backend (`selectedBackend.generate`, logos-plugin-qt) runs the **same** generator script as the real build and snapshots the tree instead of compiling, so the emitted source matches a real build exactly.

## Chain / merge order

Stacks on **logos-co/logos-plugin-qt#13** (adds `generate` to the backend). Merge order:
1. logos-plugin-qt#13
2. **this PR** — the flake.lock bump to the merged logos-plugin-qt commit lands with it (workspace pin step)
3. logos-tutorial — docs

Until the lock is bumped, build/review locally with the backend overridden:

```
nix build .#generate \
  --override-input logos-plugin-qt path:../logos-plugin-qt \
  --override-input logos-plugin-core path:../logos-plugin-qt
```

## Test

Validated against `logos-test-modules` (via `--override-input`): `…test_basic_module_cpp.generate` (universal) and `…test_qml_backend.generate` (ui_qml + C++ backend) emit correct `generated_code/` trees with the stamped `metadata.json`; `test_qml_only` correctly has no `generate`; the universal module's normal `.default` plugin still compiles and `lm` lists its methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)