### PR TITLE
feat: Qt-typed context for universal UI plugins (LogosUiPluginContext)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ real modules against the commit under test):
 - **ui-typed-backend** — the universal authoring model for UI modules
   (`type: "ui_qml"` + `interface: "universal"`): you write the `.rep` (the
   view contract — SLOTs, PROPs, SIGNALs) and a `*Backend` class deriving
-  `<RepClass>SimpleSource` + `LogosModuleContext`; the `*Plugin`/`*Interface`
+  `<RepClass>SimpleSource` + `LogosUiPluginContext`; the `*Plugin`/`*Interface`
   classes are generated. The backend gets typed dependency calls and typed
   event subscriptions (armed in `onContextReady()`), here feeding a `.rep`
   PROP that auto-syncs into QML.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -231,7 +231,7 @@ it to arm subscriptions once the module is wired).
 
 For a C++ UI module (`"type": "ui_qml"` + `"interface": "universal"`) you write a
 `.rep` view contract plus a `*Backend` class deriving the generated
-`<RepClass>SimpleSource` and `LogosModuleContext`. Point `codegen.rep` at the
+`<RepClass>SimpleSource` and `LogosUiPluginContext`. Point `codegen.rep` at the
 `.rep` and use `REP_FILE` in `CMakeLists.txt`:
 
 ```cpp
@@ -246,9 +246,9 @@ class MyUi {
 // src/my_ui_backend.h
 #pragma once
 #include "rep_my_ui_source.h"
-#include "logos_module_context.h"
+#include "logos_ui_plugin_context.h"
 
-class MyUiBackend : public MyUiSimpleSource, public LogosModuleContext {
+class MyUiBackend : public MyUiSimpleSource, public LogosUiPluginContext {
 public:
     int add(int a, int b) override;   // feed PROPs via setStatus(...)
 };

--- a/doctests/ui-typed-backend.test.yaml
+++ b/doctests/ui-typed-backend.test.yaml
@@ -14,7 +14,8 @@ intro: |
   `*Plugin` and `*Interface` classes and all the typed-SDK wiring are
   generated.
 
-  The backend gets the same surface a universal core module impl gets:
+  A UI plugin is a view, not a module, so its `LogosUiPluginContext` carries
+  only the dependency surface (Qt-typed, to match the `.rep` slots):
 
   - `modules()` — **typed method callers** for `dependencies`
   - typed **event subscriptions** (`modules().dep.on<Event>(...)`)
@@ -30,7 +31,7 @@ what_you_build: "A QML UI app whose C++ backend is a single clean impl class: ty
 
 what_you_learn:
   - "interface: universal for type: ui_qml — you write the .rep + a Backend class; the *Plugin and *Interface classes are generated"
-  - "The Backend derives <RepClass>SimpleSource + LogosModuleContext — typed method callers, typed event subscriptions, and onContextReady, identical to a universal core module impl"
+  - "The Backend derives <RepClass>SimpleSource + LogosUiPluginContext — Qt-typed method callers, typed event subscriptions, and onContextReady; a UI plugin is a view, not a module, so the context carries only these"
   - "A .rep PROP fed from a typed module-event subscription: the QML label updates with no polling and no manual relay"
   - "onContextReady() in a UI backend: fires when ui-host hands the plugin its LogosAPI — arm subscriptions there"
 
@@ -174,22 +175,23 @@ sections:
       - title: "The backend"
         text: |
           The backend derives the repc-generated `TickerPanelSimpleSource`
-          (so it implements the `.rep`) **and** `LogosModuleContext` — which
+          (so it implements the `.rep`) **and** `LogosUiPluginContext` — which
           is what supplies `onContextReady()` and the `modules()` typed
-          accessors, exactly like a universal core module impl:
+          accessors. A UI plugin is a view, not a module, so that is all the
+          context carries, and the dep wrappers are Qt-typed to match the `.rep`:
         file:
           path: ticker-panel/src/ticker_panel_backend.h
           language: cpp
           content: |
             #pragma once
             #include "rep_ticker_panel_source.h"
-            #include "logos_module_context.h"
+            #include "logos_ui_plugin_context.h"
 
             // The whole hand-written backend. The *Plugin and *Interface classes
             // (Q_PLUGIN_METADATA, initLogos wiring, QtRO registration) are
             // generated around it.
             class TickerPanelBackend : public TickerPanelSimpleSource,
-                                       public LogosModuleContext {
+                                       public LogosUiPluginContext {
             public:
                 /// Typed call into the core module; returns the new count.
                 qlonglong bump() override;
@@ -217,7 +219,8 @@ sections:
             {
                 // Typed module-event subscription feeding the .rep PROP: QtRO
                 // pushes every setLastTick to the QML replica automatically.
-                modules().tick_module.onTicked([this](int64_t count) {
+                // The callback arg is Qt-typed (int), matching the view.
+                modules().tick_module.onTicked([this](int count) {
                     setLastTick(count);
                 });
             }

--- a/flake.lock
+++ b/flake.lock
@@ -3979,11 +3979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781456993,
-        "narHash": "sha256-LMF7pJtmYNqeEjXiufLTEehGGGYoD5XVwT+jY9Gg5MM=",
+        "lastModified": 1781532038,
+        "narHash": "sha256-C6SXkO2efD7rNK5iIbxqLZKtOOsUVSNxw2m3DVEhijE=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "dca52b9fd508508bff396794636b8d2d2e007fd1",
+        "rev": "f33f264abb6d628cc78cf926f9f33c7cc8252151",
         "type": "github"
       },
       "original": {
@@ -4058,11 +4058,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781456993,
-        "narHash": "sha256-LMF7pJtmYNqeEjXiufLTEehGGGYoD5XVwT+jY9Gg5MM=",
+        "lastModified": 1781532038,
+        "narHash": "sha256-C6SXkO2efD7rNK5iIbxqLZKtOOsUVSNxw2m3DVEhijE=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "dca52b9fd508508bff396794636b8d2d2e007fd1",
+        "rev": "f33f264abb6d628cc78cf926f9f33c7cc8252151",
         "type": "github"
       },
       "original": {
@@ -4267,11 +4267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781306785,
-        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "lastModified": 1781532011,
+        "narHash": "sha256-1e1yWePqN33HAoKe8cl4vjRfBAty25FldoneDwiFgX0=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "rev": "872db459cc46c30f38b74783cd1136c6f28f082d",
         "type": "github"
       },
       "original": {

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -267,15 +267,17 @@ let
           # picks which type surface the generated <Module> client wrappers
           # (and the umbrella LogosModules struct) expose. Mirrors the
           # backend's apiStyle (logos-plugin-qt buildPlugin.nix): core
-          # universal modules are header-first cdylibs → Qt-free lp_* wrappers;
-          # UI universal backends (type: ui_qml) derive a Qt SimpleSource so
-          # they keep std-typed wrappers; every other interface keeps qt.
+          # universal modules are header-first cdylibs → Qt-free lp_* wrappers.
+          # UI universal backends (type: ui_qml) are NOT modules — they derive a
+          # Qt SimpleSource whose .rep slots are Qt-typed, so their
+          # LogosUiPluginContext.modules() dep wrappers are Qt-typed too (the
+          # generator default — no flag). Every other interface keeps qt.
           # (Only consulted in the source layout; nix builds get apiStyle from
           # the backend's --general-only call.)
           apiStyleCmakeFlags =
             if config.interface == "universal" && (config.type or "core") != "ui_qml"
             then [ "-DLOGOS_API_STYLE=lp" ]
-            else lib.optionals (config.interface == "universal") [ "-DLOGOS_API_STYLE=std" ];
+            else [];
         # The backend only knows about Qt + logosModule (interface.h).
         # SDK (generator, lib, headers) is injected via extra* args.
         in ({

--- a/lib/modulePreConfigure.nix
+++ b/lib/modulePreConfigure.nix
@@ -146,9 +146,9 @@ let
 
   # UI plugin backends (type=ui_qml + interface=universal): the USER
   # writes the .rep (the view contract) and the *Backend class (deriving
-  # <RepClass>SimpleSource + LogosModuleContext); the qt generator emits
-  # only the *Interface.h and the *Plugin glue that wires
-  # LogosModules/context into the backend on initLogos.
+  # <RepClass>SimpleSource + LogosUiPluginContext); the qt generator emits
+  # only the *Interface.h and the *Plugin glue that wires the (Qt-typed)
+  # LogosModules aggregate into the backend on initLogos.
   uiCodegen = config:
     let
       cg = config.codegen or {};

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -121,14 +121,14 @@ logos-{name}-module/
 ├── CMakeLists.txt         # Build config — REP_FILE + backend sources
 └── src/
     ├── {name}.rep         # QtRO view contract — SLOTs, PROPs, SIGNALs
-    ├── {name}_backend.h   # class {Name}Backend : {Rep}SimpleSource, LogosModuleContext
+    ├── {name}_backend.h   # class {Name}Backend : {Rep}SimpleSource, LogosUiPluginContext
     ├── {name}_backend.cpp
     └── qml/
         └── Main.qml       # QML view — logos.module() / logos.watch()
 ```
 You write only the `.rep` + the `*Backend` class; the `*Plugin`/`*Interface`
-classes are generated. The backend gets typed `modules()` callers + event
-subscriptions via `LogosModuleContext`.
+classes are generated. The backend gets Qt-typed `modules()` callers + event
+subscriptions via `LogosUiPluginContext`.
 
 ### QML module structure
 ```

--- a/skills/create-ui-module.md
+++ b/skills/create-ui-module.md
@@ -200,16 +200,19 @@ The backend is the only C++ class you write. It derives:
 
 - `{RepClass}SimpleSource` — generated from your `.rep` by repc, pulled in via
   `"rep_{module_name}_source.h"`. Implement its SLOTs and feed its PROPs.
-- `LogosModuleContext` — from `"logos_module_context.h"`. Gives the backend the
-  typed-SDK surface of a universal core module: `modules()` (typed callers for
-  `dependencies`), typed event subscriptions (`modules().dep.on<Event>(...)`),
-  and `onContextReady()`.
+- `LogosUiPluginContext` — from `"logos_ui_plugin_context.h"` (logos-qt-sdk).
+  Gives the backend `modules()` (Qt-typed callers for `dependencies`), typed
+  event subscriptions (`modules().dep.on<Event>(...)`), and `onContextReady()`.
+  A UI plugin is a view, not a module — it has no host identity
+  (modulePath/instanceId/persistence) and emits no events of its own, so the
+  context carries nothing else. The dep wrappers are **Qt-typed** (`QString`,
+  `int`, ...), matching the `.rep` slots — no std<->Qt conversions in the view.
 
 ```cpp
 #pragma once
 
 #include "rep_{module_name}_source.h"
-#include "logos_module_context.h"
+#include "logos_ui_plugin_context.h"
 
 // The whole hand-written backend. The *Plugin and *Interface classes
 // (Q_PLUGIN_METADATA, initLogos wiring, QtRO registration, setBackend) are
@@ -219,10 +222,11 @@ The backend is the only C++ class you write. It derives:
 //   - {RepClass}SimpleSource — generated from {module_name}.rep; implement its
 //     SLOTs and feed its PROPs (e.g. setStatus(...)), which auto-sync to every
 //     QML replica over QtRO.
-//   - LogosModuleContext — supplies onContextReady() plus modules(), the typed
-//     callers and event subscriptions for any "dependencies" you declare.
+//   - LogosUiPluginContext — supplies onContextReady() plus modules(), the
+//     Qt-typed callers and event subscriptions for any "dependencies" you
+//     declare. A UI plugin is a view, not a module, so that is all it carries.
 class {ModuleName}Backend : public {RepClass}SimpleSource,
-                            public LogosModuleContext
+                            public LogosUiPluginContext
 {
 public:
     int add(int a, int b) override;
@@ -463,10 +467,10 @@ to its typed `ticked` event.
    ```cpp
    #pragma once
    #include "rep_{module_name}_source.h"
-   #include "logos_module_context.h"
+   #include "logos_ui_plugin_context.h"
 
    class {ModuleName}Backend : public {RepClass}SimpleSource,
-                               public LogosModuleContext
+                               public LogosUiPluginContext
    {
    public:
        qlonglong bump() override;
@@ -494,8 +498,9 @@ to its typed `ticked` event.
    void {ModuleName}Backend::onContextReady()
    {
        // Typed module-event subscription feeding the .rep PROP: QtRO
-       // pushes every setLastTick to the QML replica automatically.
-       modules().tick_module.onTicked([this](int64_t count) {
+       // pushes every setLastTick to the QML replica automatically. The
+       // callback arg is Qt-typed (int), matching the rest of the view.
+       modules().tick_module.onTicked([this](int count) {
            setLastTick(count);
        });
    }
@@ -537,7 +542,7 @@ never had.
 - [ ] `metadata.json` has `"codegen": { "rep": "src/{module_name}.rep" }`
 - [ ] `metadata.json` keeps `"main": "{module_name}_plugin"` (names the generated plugin)
 - [ ] `src/{module_name}.rep` declares the view contract (SLOTs / PROPs / SIGNALs, Qt types)
-- [ ] `src/{module_name}_backend.{h,cpp}` derives `{RepClass}SimpleSource` + `LogosModuleContext` and implements the `.rep` SLOTs
+- [ ] `src/{module_name}_backend.{h,cpp}` derives `{RepClass}SimpleSource` + `LogosUiPluginContext` and implements the `.rep` SLOTs
 - [ ] PROPs are fed via the repc-generated setters (e.g. `setStatus(...)`)
 - [ ] NO hand-written `{module_name}_interface.h` or `{module_name}_plugin.{h,cpp}` — the *Plugin and *Interface classes are generated
 - [ ] Backend `.cpp` includes `"logos_sdk.h"` only if it uses `modules()`

--- a/templates/ui-qml-backend/src/ui_example_backend.h
+++ b/templates/ui-qml-backend/src/ui_example_backend.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "rep_ui_example_source.h"
-#include "logos_module_context.h"
+#include "logos_ui_plugin_context.h"
 
 /**
  * @brief The hand-written UI backend (universal authoring model).
@@ -14,12 +14,13 @@
  *   - `UiExampleSimpleSource` — generated from ui_example.rep; implement its
  *     slots and feed its PROPs (e.g. `setStatus(...)`), which auto-sync to
  *     every QML replica.
- *   - `LogosModuleContext` — gives `onContextReady()` plus `modules()`, the
- *     typed callers and event subscriptions for any `dependencies` you declare
- *     (none here; see the typed-backend doc-test for a worked example).
+ *   - `LogosUiPluginContext` — gives `onContextReady()` plus `modules()`, the
+ *     Qt-typed callers and event subscriptions for any `dependencies` you
+ *     declare (none here; see the typed-backend doc-test for a worked example).
+ *     A UI plugin is a view, not a module, so that is all the context carries.
  */
 class UiExampleBackend : public UiExampleSimpleSource,
-                         public LogosModuleContext
+                         public LogosUiPluginContext
 {
 public:
     int add(int a, int b) override;


### PR DESCRIPTION
## What

A universal UI plugin (`type: ui_qml`) is a **view, not a module** — its backend derives a QtRO `SimpleSource` whose `.rep` slots are Qt-typed. This switches the UI authoring model from the std-typed `LogosModuleContext` to the narrow Qt-layer **`LogosUiPluginContext`** (from logos-co/logos-qt-sdk#3) and mirrors the api-style flip:

- **lib/mkLogosModule.nix** — drop the `std` flag for `ui_qml` in the `generate` source-layout output (mirror of logos-plugin-qt#14; nix builds get api-style from the backend)
- **lib/modulePreConfigure.nix** — UI codegen comment
- **templates/ui-qml-backend** — backend derives `LogosUiPluginContext`
- **skills/create-ui-module, skills/SKILL, README, docs/quick-reference** — `LogosUiPluginContext` + Qt-typed `modules()` (e.g. event callbacks `int`, not `int64_t`)
- **doctests/ui-typed-backend** — backend derives `LogosUiPluginContext`; Qt-typed event callback

`LogosModuleContext` is unchanged and still serves core/cdylib modules. Legacy `ui_qml` (classic `LogosAPI*`) is unaffected — UI codegen is gated on `interface==universal && type==ui_qml`.

## Cross-repo set

Depends on:
- logos-co/logos-qt-sdk#3 — `LogosUiPluginContext` + UI glue
- logos-co/logos-plugin-qt#14 — api-style `std`→`qt` for `ui_qml`

Plus logos-tutorial (cpp-ui Part 3 sync).

## Verification

Built `logos-calc-ui-cpp` (this builder's universal-UI path, with a `calc_module` dep) against the four local repos: generated `logos_sdk.h`/`calc_module_api.h` are Qt-typed (`QString libVersion(...)`, `int add(int,int)`), the regenerated `_ui_glue.cpp` uses `maybeSetUiPluginModules`, and the backend compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)