### PR TITLE
Builder-driven Rust codegen: no build.rs, trivial flake

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -575,6 +575,47 @@ function(logos_module)
         endforeach()
     endif()
 
+    # Rust static archives. Set by mkLogosModule when a cdylib module is authored
+    # in Rust (metadata codegen.rust): the builder compiles the crate to a
+    # staticlib and stages it in lib/. The archive provides the logos_module_*
+    # exports the generated Qt glue calls; its own lp_* undefineds resolve against
+    # the logos-protocol archive already linked above (via logos-qt-sdk). Plain
+    # link (NOT whole-archive: the Rust install hook is pulled in lazily by a
+    # symbol reference), with the protocol target re-mentioned AFTER the archive
+    # so single-pass linkers (GNU ld) see it later on the line — one protocol
+    # stack shared by the glue and the Rust code.
+    if(DEFINED LOGOS_MODULE_RUST_STATIC_LIBS AND NOT LOGOS_MODULE_RUST_STATIC_LIBS STREQUAL "")
+        set(_LOGOS_RUST_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+        foreach(_rustlib IN LISTS LOGOS_MODULE_RUST_STATIC_LIBS)
+            if(_rustlib STREQUAL "")
+                continue()
+            endif()
+            find_library(_LOGOS_RUST_${_rustlib}
+                NAMES lib${_rustlib}.a ${_rustlib}
+                PATHS ${_LOGOS_RUST_LIB_DIR} NO_DEFAULT_PATH)
+            if(_LOGOS_RUST_${_rustlib})
+                target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${_LOGOS_RUST_${_rustlib}})
+                if(TARGET logos-protocol::logos_protocol)
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos-protocol::logos_protocol)
+                elseif(TARGET logos_protocol)
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos_protocol)
+                endif()
+                if(APPLE)
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE
+                        "-framework CoreFoundation" "-framework Security")
+                else()
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE pthread dl)
+                endif()
+            else()
+                message(FATAL_ERROR
+                    "Rust static library '${_rustlib}' (a codegen.rust module) was not "
+                    "found in ${_LOGOS_RUST_LIB_DIR}. The builder stages the compiled "
+                    "staticlib there before the plugin link; this usually means the "
+                    "crate build or staging step did not run.")
+            endif()
+        endforeach()
+    endif()
+
     # Link additional libraries
     foreach(lib ${MODULE_LINK_LIBRARIES})
         target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${lib})

--- a/doctests/cross-language-composition-reverse.test.yaml
+++ b/doctests/cross-language-composition-reverse.test.yaml
@@ -20,7 +20,7 @@ intro: |
 
   ```
   logoscore call rust_auditor_module record_via 7
-      └─ Rust auditor ── modules().gateway.record(7) ──▶ C++ gateway
+      └─ Rust auditor ── modules().cpp_gateway_module.record(7) ──▶ C++ gateway
                              └─ modules().rust_ledger_module.add_entry(7) ──▶ Rust ledger
                              └─ total_changed(7)  ──▶ typed event
       ◀─ captured by the Rust auditor's on_total_changed subscription
@@ -78,7 +78,7 @@ sections:
         run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
         check_file: "lgpm/bin/lgpm"
       - title: "Build logos-lidl-gen"
-        run: "nix build 'github:logos-co/logos-rust-sdk/1b8e669be92900f6786417024e63cfea7508d479#lidl-gen' -o lidl-gen"
+        run: "nix build 'github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7#lidl-gen' -o lidl-gen"
         check_file: "lidl-gen/bin/logos-lidl-gen"
 
   - title: "Module 1 — contract-first Rust (`rust_ledger_module`)"
@@ -87,8 +87,8 @@ sections:
       The ledger's interface is declared **in LIDL**; the implementation is
       Rust. This is the mirror of the forward composition's contract-first
       C++ counter: there the generator wrapped a hand-written C++ class; here
-      `build.rs` generates a **trait** from the contract and you implement it.
-      Same direction, other language.
+      the builder generates a **trait** from the contract and you implement it —
+      `codegen.rust`, no `build.rs`. Same direction, other language.
     steps:
       - title: "The contract"
         file:
@@ -106,11 +106,12 @@ sections:
           path: rust-ledger/rust-lib/src/lib.rs
           language: rust
           content: |
-            //! LIDL-FIRST Rust module: the .lidl is the contract; build.rs generates
-            //! the `RustLedgerModule` trait (and everything else) from it. The author
-            //! writes the impl and the install hook — nothing more.
+            //! LIDL-FIRST Rust module: the .lidl is the contract; the builder generates
+            //! the `RustLedgerModule` trait (and everything else) from it — no build.rs.
+            //! The author writes the impl and the install hook — nothing more.
 
-            include!(concat!(env!("OUT_DIR"), "/provider_gen.rs"));
+            // The builder injects the generated scaffold here (no build.rs, no OUT_DIR).
+            include!(concat!(env!("CARGO_MANIFEST_DIR"), "/generated/provider_gen.rs"));
 
             #[derive(Default)]
             struct Ledger {
@@ -132,30 +133,8 @@ sections:
             pub extern "Rust" fn logos_module_install() {
                 install::<Ledger>();
             }
-      - title: "build.rs — the contract drives the codegen"
-        file:
-          path: rust-ledger/rust-lib/build.rs
-          language: rust
-          content: |
-            //! Generates the module-impl C ABI scaffold — including the
-            //! `RustLedgerModule` trait itself — from the committed .lidl contract.
-
-            fn main() {
-                let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-                let lidl = std::path::Path::new(&manifest).join("rust_ledger_module.lidl");
-                println!("cargo:rerun-if-changed={}", lidl.display());
-
-                let source = std::fs::read_to_string(&lidl).expect("read .lidl contract");
-                let module = logos_lidl_gen::parse(&source).expect("parse .lidl contract");
-
-                let version =
-                    std::env::var("LOGOS_PROTOCOL_VERSION").unwrap_or_else(|_| "0.1.0".to_string());
-                let code = logos_lidl_gen::generate_provider(&module, &version);
-
-                let out = std::path::Path::new(&std::env::var("OUT_DIR").unwrap()).join("provider_gen.rs");
-                std::fs::write(&out, code).expect("write generated provider scaffold");
-            }
-      - title: "Cargo.toml"
+      - title: "Cargo.toml — no build-dependency"
+        text: "No `logos-lidl-gen` build-dependency and no `build.rs` — the builder runs the generator (`codegen.rust`)."
         file:
           path: rust-ledger/rust-lib/Cargo.toml
           language: toml
@@ -174,10 +153,7 @@ sections:
 
             [dependencies]
             serde_json = "1"
-            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "7ce12b9a9586f307a375ef646fbc5c9d14a0968e" }
-
-            [build-dependencies]
-            logos-lidl-gen = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "7ce12b9a9586f307a375ef646fbc5c9d14a0968e" }
+            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
       - title: "metadata.json + CMakeLists.txt + flake.nix"
         file:
           path: rust-ledger/metadata.json
@@ -196,7 +172,8 @@ sections:
               "include": [],
               "capabilities": [],
               "codegen": {
-                "lidl": "rust-lib/rust_ledger_module.lidl"
+                "lidl": "rust-lib/rust_ledger_module.lidl",
+                "rust": { "crate": "rust-lib", "staticlib": "rust_ledger" }
               },
               "nix": {
                 "external_libraries": [],
@@ -220,35 +197,7 @@ sections:
             configure_file(${CMAKE_CURRENT_SOURCE_DIR}/metadata.json
                            ${CMAKE_CURRENT_BINARY_DIR}/metadata.json COPYONLY)
 
-            logos_module(
-                NAME rust_ledger_module
-            )
-
-            find_library(LIBRUST_LEDGER
-                NAMES librust_ledger.a rust_ledger
-                PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib
-                NO_DEFAULT_PATH
-            )
-
-            if(NOT LIBRUST_LEDGER)
-                message(FATAL_ERROR "librust_ledger.a not found in lib/ — preConfigure must stage it.")
-            endif()
-
-            # One protocol stack shared by glue and Rust: re-mention the protocol target
-            # after the Rust archive so single-pass linkers resolve its lp_* references.
-            target_link_libraries(rust_ledger_module_module_plugin PRIVATE
-                ${LIBRUST_LEDGER}
-                logos-protocol::logos_protocol
-            )
-
-            if(APPLE)
-                target_link_libraries(rust_ledger_module_module_plugin PRIVATE
-                    "-framework CoreFoundation"
-                    "-framework Security"
-                )
-            else()
-                target_link_libraries(rust_ledger_module_module_plugin PRIVATE pthread dl)
-            endif()
+            logos_module(NAME rust_ledger_module)
       - file:
           path: rust-ledger/flake.nix
           language: nix
@@ -258,6 +207,9 @@ sections:
 
               inputs = {
                 logos-module-builder.url = "github:logos-co/logos-module-builder{release}";
+                # Provides logos-lidl-gen (the generator the builder runs) and the SDK
+                # the crate links — one extra input vs a C++ module.
+                logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7";
               };
 
               outputs = inputs@{ self, logos-module-builder, ... }:
@@ -265,37 +217,18 @@ sections:
                   nixpkgs = logos-module-builder.inputs.nixpkgs;
                   systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
                   forAllSystems = f: nixpkgs.lib.genAttrs systems f;
-
-                  rustLib = system:
-                    let pkgs = nixpkgs.legacyPackages.${system};
-                    in pkgs.rustPlatform.buildRustPackage {
-                      pname = "rust_ledger";
-                      version = "1.0.0";
-                      src = ./rust-lib;
-                      cargoLock = {
-                        lockFile = ./rust-lib/Cargo.lock;
-                        allowBuiltinFetchGit = true;
-                      };
-                      doCheck = false;
-                    };
-
-                  module = system:
-                    logos-module-builder.lib.mkLogosModule {
+                in
+                {
+                  packages = forAllSystems (system:
+                    (logos-module-builder.lib.mkLogosModule {
                       src = ./.;
                       configFile = ./metadata.json;
                       flakeInputs = inputs;
-                      preConfigure = ''
-                        mkdir -p lib
-                        cp ${rustLib system}/lib/librust_ledger.a lib/
-                      '';
-                    };
-                in
-                {
-                  packages = forAllSystems (system: (module system).packages.${system});
+                    }).packages.${system});
                 };
             }
       - title: "Build it"
-        run: "sh -c 'cd rust-ledger && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update && git add flake.lock && nix build .#lgx -o ledger-lgx'"
+        run: "sh -c 'cd rust-ledger && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update && git add flake.lock && nix build .#lgx -o ledger-lgx'"
         code_block: |
           cd rust-ledger
           (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile)
@@ -475,7 +408,8 @@ sections:
                 fn on_context_ready(&mut self, _ctx: &RustModuleContext) {}
             }
 
-            include!(concat!(env!("OUT_DIR"), "/provider_gen.rs"));
+            // The builder injects the generated scaffold here (no build.rs, no OUT_DIR).
+            include!(concat!(env!("CARGO_MANIFEST_DIR"), "/generated/provider_gen.rs"));
 
             /// Written by the event thread, read by the methods — statics because the
             /// subscription outlives any single dispatch.
@@ -488,7 +422,7 @@ sections:
             impl RustAuditorModule for Auditor {
                 /// Drive the full circle: Rust -> C++ record() -> C++ -> Rust ledger.
                 fn record_via(&mut self, amount: i64) -> i64 {
-                    match modules().gateway.record(amount) {
+                    match modules().cpp_gateway_module.record(amount) {
                         Ok(total) => total,
                         Err(e) => {
                             eprintln!("auditor: gateway.record failed: {}", e);
@@ -513,12 +447,12 @@ sections:
                 /// EventSubscription OWNS its client share — move it into a thread
                 /// and iterate; decode_total_changed turns each payload typed.
                 fn on_context_ready(&mut self, _ctx: &RustModuleContext) {
-                    match modules().gateway.on_total_changed() {
+                    match modules().cpp_gateway_module.on_total_changed() {
                         Ok(sub) => {
                             std::thread::spawn(move || {
                                 for ev in sub {
                                     if let Some(e) =
-                                        gateway::CppGatewayModuleClient::decode_total_changed(&ev)
+                                        cpp_gateway_module::CppGatewayModuleClient::decode_total_changed(&ev)
                                     {
                                         LAST_RECORDED.store(e.total, Ordering::SeqCst);
                                         AUDIT_COUNT.fetch_add(1, Ordering::SeqCst);
@@ -538,46 +472,8 @@ sections:
         post_text: |
           > The contract trait must carry `Send + 'static` — the generated
           > dispatch stores the implementation as a `Box<dyn Any + Send>`.
-      - title: "build.rs"
-        file:
-          path: rust-auditor/rust-lib/build.rs
-          language: rust
-          content: |
-            //! Generates from the COMMITTED .lidl (derived from src/lib.rs's trait by
-            //! `logos-lidl-gen --from-rust` — see the tour step): the module-impl
-            //! C ABI scaffold around the author's trait (emit_trait = false) plus the
-            //! typed gateway client (methods, on_total_changed, decode_total_changed)
-            //! from the dep's contract.
-
-            fn main() {
-                let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-                let root = std::path::Path::new(&manifest);
-                let lidl = root.join("rust_auditor_module.lidl");
-                let dep = root.join("deps/cpp_gateway_module.lidl");
-                println!("cargo:rerun-if-changed={}", lidl.display());
-                println!("cargo:rerun-if-changed={}", dep.display());
-
-                let module =
-                    logos_lidl_gen::parse(&std::fs::read_to_string(&lidl).expect("read contract"))
-                        .expect("parse contract");
-                let gateway =
-                    logos_lidl_gen::parse(&std::fs::read_to_string(&dep).expect("read dep contract"))
-                        .expect("parse dep contract");
-
-                let version =
-                    std::env::var("LOGOS_PROTOCOL_VERSION").unwrap_or_else(|_| "0.1.0".to_string());
-                let mut code =
-                    logos_lidl_gen::rustgen_provider::generate_provider_with(&module, &version, false);
-                code.push('\n');
-                code.push_str(&logos_lidl_gen::generate_deps(&[(
-                    "gateway".to_string(),
-                    gateway,
-                )]));
-
-                let out = std::path::Path::new(&std::env::var("OUT_DIR").unwrap()).join("provider_gen.rs");
-                std::fs::write(&out, code).expect("write generated scaffold");
-            }
-      - title: "Cargo.toml"
+      - title: "Cargo.toml — no build-dependency"
+        text: "No `logos-lidl-gen` build-dependency and no `build.rs` — the builder runs the generator with `--no-trait` (`codegen.rust.author_trait`)."
         file:
           path: rust-auditor/rust-lib/Cargo.toml
           language: toml
@@ -596,10 +492,7 @@ sections:
 
             [dependencies]
             serde_json = "1"
-            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "7ce12b9a9586f307a375ef646fbc5c9d14a0968e" }
-
-            [build-dependencies]
-            logos-lidl-gen = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "7ce12b9a9586f307a375ef646fbc5c9d14a0968e" }
+            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
       - title: "Derive the .lidl from the trait"
         run: "./lidl-gen/bin/logos-lidl-gen --from-rust rust-auditor/rust-lib/src/lib.rs --trait RustAuditorModule --module-version 1.0.0 -o rust-auditor/rust-lib/rust_auditor_module.lidl"
         code_block: |
@@ -610,24 +503,20 @@ sections:
           run: "cat rust-auditor/rust-lib/rust_auditor_module.lidl"
         expect_contains:
           - "Generated"
-      - title: "Fetch the dependency's PUBLISHED contract"
+      - title: "The dependency's published contract carries the typed event"
         text: |
           The gateway never committed a `.lidl` — its contract lives in its C++
           header. The builder *derives* it and publishes it as the flake output
-          `packages.<system>.lidl`, so a consumer in any language can build
-          typed bindings without ever parsing C++.
-        run: "sh -c 'nix build ./cpp-gateway#lidl -o gateway-lidl --override-input rust_ledger_module path:$PWD/rust-ledger && mkdir -p rust-auditor/rust-lib/deps && cp gateway-lidl/cpp_gateway_module.lidl rust-auditor/rust-lib/deps/'"
+          `packages.<system>.lidl`; the auditor's own build resolves that
+          published contract automatically (no manual copy) to generate the typed
+          `modules().cpp_gateway_module` client. We peek at it here only to show
+          the `logos_events:` block crossed the derivation as a first-class LIDL
+          `event` — the source of the Rust side's generated `on_total_changed()`
+          / `decode_total_changed()`:
+        run: "sh -c 'nix build ./cpp-gateway#lidl -o gateway-lidl --override-input rust_ledger_module path:$PWD/rust-ledger && cat gateway-lidl/cpp_gateway_module.lidl'"
         code_block: |
           nix build ./cpp-gateway#lidl -o gateway-lidl
-          mkdir -p rust-auditor/rust-lib/deps
-          cp gateway-lidl/cpp_gateway_module.lidl rust-auditor/rust-lib/deps/
-        check_file: "rust-auditor/rust-lib/deps/cpp_gateway_module.lidl"
-      - title: "The derived contract carries the typed event"
-        text: |
-          The `logos_events:` block crossed the derivation as a first-class
-          LIDL `event` — this is what the Rust side's generated
-          `on_total_changed()` / `decode_total_changed()` come from:
-        run: "cat rust-auditor/rust-lib/deps/cpp_gateway_module.lidl"
+          cat gateway-lidl/cpp_gateway_module.lidl
         expect_contains:
           - "event total_changed"
       - title: "metadata.json + CMakeLists.txt + flake.nix"
@@ -648,7 +537,8 @@ sections:
               "include": [],
               "capabilities": [],
               "codegen": {
-                "lidl": "rust-lib/rust_auditor_module.lidl"
+                "lidl": "rust-lib/rust_auditor_module.lidl",
+                "rust": { "crate": "rust-lib", "staticlib": "rust_auditor", "author_trait": true }
               },
               "nix": {
                 "external_libraries": [],
@@ -672,35 +562,7 @@ sections:
             configure_file(${CMAKE_CURRENT_SOURCE_DIR}/metadata.json
                            ${CMAKE_CURRENT_BINARY_DIR}/metadata.json COPYONLY)
 
-            logos_module(
-                NAME rust_auditor_module
-            )
-
-            find_library(LIBRUST_AUDITOR
-                NAMES librust_auditor.a rust_auditor
-                PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib
-                NO_DEFAULT_PATH
-            )
-
-            if(NOT LIBRUST_AUDITOR)
-                message(FATAL_ERROR "librust_auditor.a not found in lib/ — preConfigure must stage it.")
-            endif()
-
-            # One protocol stack shared by glue and Rust: re-mention the protocol target
-            # after the Rust archive so single-pass linkers resolve its lp_* references.
-            target_link_libraries(rust_auditor_module_module_plugin PRIVATE
-                ${LIBRUST_AUDITOR}
-                logos-protocol::logos_protocol
-            )
-
-            if(APPLE)
-                target_link_libraries(rust_auditor_module_module_plugin PRIVATE
-                    "-framework CoreFoundation"
-                    "-framework Security"
-                )
-            else()
-                target_link_libraries(rust_auditor_module_module_plugin PRIVATE pthread dl)
-            endif()
+            logos_module(NAME rust_auditor_module)
       - file:
           path: rust-auditor/flake.nix
           language: nix
@@ -710,47 +572,31 @@ sections:
 
               inputs = {
                 logos-module-builder.url = "github:logos-co/logos-module-builder{release}";
+                # Provides logos-lidl-gen (the generator the builder runs) and the SDK
+                # the crate links — one extra input vs a C++ module.
+                logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7";
                 # The dependency's flake. Placeholder — locked to the real checkout in
                 # the build step via --override-input (nix rejects relative paths here).
                 cpp_gateway_module.url = "path:/path/to/cpp-gateway";
               };
 
-              outputs = inputs@{ self, logos-module-builder, cpp_gateway_module, ... }:
+              outputs = inputs@{ self, logos-module-builder, ... }:
                 let
                   nixpkgs = logos-module-builder.inputs.nixpkgs;
                   systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
                   forAllSystems = f: nixpkgs.lib.genAttrs systems f;
-
-                  rustLib = system:
-                    let pkgs = nixpkgs.legacyPackages.${system};
-                    in pkgs.rustPlatform.buildRustPackage {
-                      pname = "rust_auditor";
-                      version = "1.0.0";
-                      src = ./rust-lib;
-                      cargoLock = {
-                        lockFile = ./rust-lib/Cargo.lock;
-                        allowBuiltinFetchGit = true;
-                      };
-                      doCheck = false;
-                    };
-
-                  module = system:
-                    logos-module-builder.lib.mkLogosModule {
+                in
+                {
+                  packages = forAllSystems (system:
+                    (logos-module-builder.lib.mkLogosModule {
                       src = ./.;
                       configFile = ./metadata.json;
                       flakeInputs = inputs;
-                      preConfigure = ''
-                        mkdir -p lib
-                        cp ${rustLib system}/lib/librust_auditor.a lib/
-                      '';
-                    };
-                in
-                {
-                  packages = forAllSystems (system: (module system).packages.${system});
+                    }).packages.${system});
                 };
             }
       - title: "Build it"
-        run: "sh -c 'cd rust-auditor && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_gateway_module path:$PWD/../cpp-gateway && git add flake.lock && nix build .#lgx -o auditor-lgx --override-input cpp_gateway_module path:$PWD/../cpp-gateway --override-input cpp_gateway_module/rust_ledger_module path:$PWD/../rust-ledger'"
+        run: "sh -c 'cd rust-auditor && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_gateway_module path:$PWD/../cpp-gateway && git add flake.lock && nix build .#lgx -o auditor-lgx --override-input cpp_gateway_module path:$PWD/../cpp-gateway --override-input cpp_gateway_module/rust_ledger_module path:$PWD/../rust-ledger'"
         code_block: |
           cd rust-auditor
           (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile)

--- a/doctests/cross-language-composition-reverse.test.yaml
+++ b/doctests/cross-language-composition-reverse.test.yaml
@@ -129,8 +129,12 @@ sections:
             pub extern "Rust" fn logos_module_install() {
                 install::<Ledger>();
             }
-      - title: "Cargo.toml — no build-dependency"
-        text: "No `logos-lidl-gen` build-dependency and no `build.rs` — the builder runs the generator (`codegen.rust`)."
+      - title: "Cargo.toml — the SDK is a path dep the builder provides"
+        text: |
+          No `logos-lidl-gen` build-dependency, no `build.rs`. The runtime SDK is
+          a **path dependency** on `../logos-rust-sdk-src`, which the builder
+          stages from the same rev its generator came from — so the module's
+          `flake.nix` needs no `logos-rust-sdk` input (identical to a C++ module).
         file:
           path: rust-ledger/rust-lib/Cargo.toml
           language: toml
@@ -149,7 +153,7 @@ sections:
 
             [dependencies]
             serde_json = "1"
-            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
+            logos-rust-sdk = { path = "../logos-rust-sdk-src" }
       - title: "metadata.json + CMakeLists.txt + flake.nix"
         file:
           path: rust-ledger/metadata.json
@@ -203,9 +207,6 @@ sections:
 
               inputs = {
                 logos-module-builder.url = "github:logos-co/logos-module-builder{release}";
-                # Provides logos-lidl-gen (the generator the builder runs) and the SDK
-                # the crate links — one extra input vs a C++ module.
-                logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7";
               };
 
               outputs = inputs@{ self, logos-module-builder, ... }:
@@ -224,7 +225,7 @@ sections:
                 };
             }
       - title: "Build it"
-        run: "sh -c 'cd rust-ledger && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update && git add flake.lock && nix build .#lgx -o ledger-lgx'"
+        run: "sh -c 'cd rust-ledger && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\nlogos-rust-sdk-src\\n\" > .gitignore && nix build \"github:logos-co/logos-module-builder{release}#rust-sdk-src\" -o logos-rust-sdk-src && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update && git add flake.lock && nix build .#lgx -o ledger-lgx'"
         code_block: |
           cd rust-ledger
           (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile)
@@ -468,8 +469,12 @@ sections:
         post_text: |
           > The contract trait must carry `Send + 'static` — the generated
           > dispatch stores the implementation as a `Box<dyn Any + Send>`.
-      - title: "Cargo.toml — no build-dependency"
-        text: "No `logos-lidl-gen` build-dependency and no `build.rs` — the builder derives the `.lidl` from the trait and runs the generator (`codegen.rust.trait`)."
+      - title: "Cargo.toml — the SDK is a path dep the builder provides"
+        text: |
+          No `logos-lidl-gen` build-dependency, no `build.rs`. The runtime SDK is
+          a **path dependency** on `../logos-rust-sdk-src`, which the builder
+          stages from the same rev its generator came from — so the module's
+          `flake.nix` needs no `logos-rust-sdk` input (identical to a C++ module).
         file:
           path: rust-auditor/rust-lib/Cargo.toml
           language: toml
@@ -488,7 +493,7 @@ sections:
 
             [dependencies]
             serde_json = "1"
-            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
+            logos-rust-sdk = { path = "../logos-rust-sdk-src" }
       - title: "The dependency's published contract carries the typed event"
         text: |
           The gateway never committed a `.lidl` — its contract lives in its C++
@@ -558,9 +563,6 @@ sections:
 
               inputs = {
                 logos-module-builder.url = "github:logos-co/logos-module-builder{release}";
-                # Provides logos-lidl-gen (the generator the builder runs) and the SDK
-                # the crate links — one extra input vs a C++ module.
-                logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7";
                 # The dependency's flake. Placeholder — locked to the real checkout in
                 # the build step via --override-input (nix rejects relative paths here).
                 cpp_gateway_module.url = "path:/path/to/cpp-gateway";
@@ -582,7 +584,7 @@ sections:
                 };
             }
       - title: "Build it"
-        run: "sh -c 'cd rust-auditor && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_gateway_module path:$PWD/../cpp-gateway && git add flake.lock && nix build .#lgx -o auditor-lgx --override-input cpp_gateway_module path:$PWD/../cpp-gateway --override-input cpp_gateway_module/rust_ledger_module path:$PWD/../rust-ledger'"
+        run: "sh -c 'cd rust-auditor && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\nlogos-rust-sdk-src\\n\" > .gitignore && nix build \"github:logos-co/logos-module-builder{release}#rust-sdk-src\" -o logos-rust-sdk-src && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_gateway_module path:$PWD/../cpp-gateway && git add flake.lock && nix build .#lgx -o auditor-lgx --override-input cpp_gateway_module path:$PWD/../cpp-gateway --override-input cpp_gateway_module/rust_ledger_module path:$PWD/../rust-ledger'"
         code_block: |
           cd rust-auditor
           (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile)

--- a/doctests/cross-language-composition-reverse.test.yaml
+++ b/doctests/cross-language-composition-reverse.test.yaml
@@ -60,16 +60,15 @@ sections:
   - title: "Build the tools"
     step: true
     text: |
-      The same three tools as the forward composition: `logoscore` (the
-      headless module runtime), `lgpm` (the package installer), and
-      `logos-lidl-gen` (used below to derive the auditor's `.lidl` from its
-      Rust trait).
+      The same two tools as the forward composition: `logoscore` (the headless
+      module runtime) and `lgpm` (the package installer). The module builder
+      runs every generator itself — including deriving the auditor's `.lidl`
+      from its Rust trait — so no separate generator build is needed.
 
       > The modules below build against THIS commit of logos-module-builder
       > (the `{release}` pin). The cdylib authoring path currently lives on the
-      > protocol-extraction branches, so `logoscore` and `lidl-gen` are pinned
-      > to the matching heads — once the chain merges, build them from plain
-      > master.
+      > protocol-extraction branches, so `logoscore` is pinned to the matching
+      > head — once the chain merges, build it from plain master.
     steps:
       - title: "Build logoscore"
         run: "nix build 'github:logos-co/logos-logoscore-cli/616cb079a5828caecfafd6d4e432519c864e3fb1' --out-link ./logos"
@@ -77,9 +76,6 @@ sections:
       - title: "Build lgpm"
         run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
         check_file: "lgpm/bin/lgpm"
-      - title: "Build logos-lidl-gen"
-        run: "nix build 'github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7#lidl-gen' -o lidl-gen"
-        check_file: "lidl-gen/bin/logos-lidl-gen"
 
   - title: "Module 1 — contract-first Rust (`rust_ledger_module`)"
     step: true
@@ -473,7 +469,7 @@ sections:
           > The contract trait must carry `Send + 'static` — the generated
           > dispatch stores the implementation as a `Box<dyn Any + Send>`.
       - title: "Cargo.toml — no build-dependency"
-        text: "No `logos-lidl-gen` build-dependency and no `build.rs` — the builder runs the generator with `--no-trait` (`codegen.rust.author_trait`)."
+        text: "No `logos-lidl-gen` build-dependency and no `build.rs` — the builder derives the `.lidl` from the trait and runs the generator (`codegen.rust.trait`)."
         file:
           path: rust-auditor/rust-lib/Cargo.toml
           language: toml
@@ -493,16 +489,6 @@ sections:
             [dependencies]
             serde_json = "1"
             logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
-      - title: "Derive the .lidl from the trait"
-        run: "./lidl-gen/bin/logos-lidl-gen --from-rust rust-auditor/rust-lib/src/lib.rs --trait RustAuditorModule --module-version 1.0.0 -o rust-auditor/rust-lib/rust_auditor_module.lidl"
-        code_block: |
-          logos-lidl-gen --from-rust rust-lib/src/lib.rs \
-            --trait RustAuditorModule --module-version 1.0.0 \
-            -o rust-lib/rust_auditor_module.lidl
-        extra_run:
-          run: "cat rust-auditor/rust-lib/rust_auditor_module.lidl"
-        expect_contains:
-          - "Generated"
       - title: "The dependency's published contract carries the typed event"
         text: |
           The gateway never committed a `.lidl` — its contract lives in its C++
@@ -538,7 +524,7 @@ sections:
               "capabilities": [],
               "codegen": {
                 "lidl": "rust-lib/rust_auditor_module.lidl",
-                "rust": { "crate": "rust-lib", "staticlib": "rust_auditor", "author_trait": true }
+                "rust": { "crate": "rust-lib", "staticlib": "rust_auditor", "trait": "RustAuditorModule" }
               },
               "nix": {
                 "external_libraries": [],

--- a/doctests/cross-language-composition-reverse.test.yaml
+++ b/doctests/cross-language-composition-reverse.test.yaml
@@ -173,7 +173,7 @@ sections:
               "capabilities": [],
               "codegen": {
                 "lidl": "rust-lib/rust_ledger_module.lidl",
-                "rust": { "crate": "rust-lib", "staticlib": "rust_ledger" }
+                "rust": { "crate": "rust-lib" }
               },
               "nix": {
                 "external_libraries": [],
@@ -528,8 +528,7 @@ sections:
               "include": [],
               "capabilities": [],
               "codegen": {
-                "lidl": "rust-lib/rust_auditor_module.lidl",
-                "rust": { "crate": "rust-lib", "staticlib": "rust_auditor", "trait": "RustAuditorModule" }
+                "rust": { "crate": "rust-lib", "trait": "RustAuditorModule" }
               },
               "nix": {
                 "external_libraries": [],

--- a/doctests/cross-language-composition.test.yaml
+++ b/doctests/cross-language-composition.test.yaml
@@ -277,11 +277,13 @@ sections:
         post_text: |
           > The contract trait must carry `Send + 'static` — the generated
           > dispatch stores the implementation as a `Box<dyn Any + Send>`.
-      - title: "Cargo.toml — no build-dependency"
+      - title: "Cargo.toml — the SDK is a path dep the builder provides"
         text: |
-          The crate depends only on the SDK and `serde_json`. There is **no
-          `logos-lidl-gen` build-dependency and no `build.rs`** — the builder
-          runs the generator (`codegen.rust`, below):
+          No `logos-lidl-gen` build-dependency and no `build.rs`. The runtime SDK
+          is a **path dependency** on `../logos-rust-sdk-src` — which the builder
+          stages from the SAME `logos-rust-sdk` rev its generator came from
+          (zero generator/runtime skew). So the module's `flake.nix` carries **no
+          `logos-rust-sdk` input at all** — it's identical to a C++ module's:
         file:
           path: rust-orchestrator/rust-lib/Cargo.toml
           language: toml
@@ -300,7 +302,7 @@ sections:
 
             [dependencies]
             serde_json = "1"
-            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
+            logos-rust-sdk = { path = "../logos-rust-sdk-src" }
       - title: "metadata.json + CMakeLists.txt + flake.nix"
         text: |
           `codegen.rust.trait` names the contract trait — the rust-first signal.
@@ -363,9 +365,6 @@ sections:
 
               inputs = {
                 logos-module-builder.url = "github:logos-co/logos-module-builder{release}";
-                # Provides logos-lidl-gen (the generator the builder runs) and the SDK
-                # the crate links — one extra input vs a C++ module.
-                logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7";
                 # The dependency's flake. Placeholder — locked to the real checkout in
                 # the build step via --override-input (nix rejects relative paths here).
                 cpp_counter_module.url = "path:/path/to/cpp-counter";
@@ -387,7 +386,7 @@ sections:
                 };
             }
       - title: "Build it"
-        run: "sh -c 'cd rust-orchestrator && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_counter_module path:$PWD/../cpp-counter && git add flake.lock && nix build .#lgx -o orch-lgx --override-input cpp_counter_module path:$PWD/../cpp-counter'"
+        run: "sh -c 'cd rust-orchestrator && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\nlogos-rust-sdk-src\\n\" > .gitignore && nix build \"github:logos-co/logos-module-builder{release}#rust-sdk-src\" -o logos-rust-sdk-src && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_counter_module path:$PWD/../cpp-counter && git add flake.lock && nix build .#lgx -o orch-lgx --override-input cpp_counter_module path:$PWD/../cpp-counter'"
         code_block: |
           cd rust-orchestrator
           (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile)

--- a/doctests/cross-language-composition.test.yaml
+++ b/doctests/cross-language-composition.test.yaml
@@ -330,8 +330,7 @@ sections:
               "include": [],
               "capabilities": [],
               "codegen": {
-                "lidl": "rust-lib/rust_orchestrator_module.lidl",
-                "rust": { "crate": "rust-lib", "staticlib": "rust_orchestrator", "trait": "RustOrchestratorModule" }
+                "rust": { "crate": "rust-lib", "trait": "RustOrchestratorModule" }
               },
               "nix": {
                 "external_libraries": [],

--- a/doctests/cross-language-composition.test.yaml
+++ b/doctests/cross-language-composition.test.yaml
@@ -37,7 +37,7 @@ what_you_build: "Three modules (contract-first C++, Rust-first Rust, universal C
 
 what_you_learn:
   - "Contract-first C++: declare a module in .lidl, hand-write a Qt-free class, let the generator build the C-ABI wrapper + glue (interface: cdylib + codegen.impl_class)"
-  - "Rust-first Rust: declare the contract as a plain trait, derive the .lidl from it (logos-lidl-gen --from-rust), and let the builder generate everything around your trait — no build.rs (codegen.rust.author_trait)"
+  - "Rust-first Rust: declare the contract as a plain trait and let the builder derive the .lidl from it and generate everything around it — single source of truth, no committed .lidl and no build.rs (codegen.rust.trait)"
   - Module context in both languages (instance id, persistence path) and the on-context-ready hook
   - Typed event emission (Rust) and typed event subscription (C++) across the language boundary
   - "Typed dependency calls both ways: Rust's modules().counter.increment() and C++'s modules().rust_orchestrator_module.tally()"
@@ -57,15 +57,15 @@ sections:
   - title: "Build the tools"
     step: true
     text: |
-      Three tools drive the tour: `logoscore` (the headless module runtime),
-      `lgpm` (the package installer), and `logos-lidl-gen` (the Rust SDK's
-      contract generator, used below to derive a `.lidl` from a Rust trait).
+      Two tools drive the tour: `logoscore` (the headless module runtime) and
+      `lgpm` (the package installer). No code-generator build is needed — the
+      module builder runs every generator itself, including deriving a Rust
+      module's `.lidl` from its trait.
 
       > The modules below build against THIS commit of logos-module-builder
       > (the `{release}` pin). The cdylib authoring path currently lives on the
-      > protocol-extraction branches, so `logoscore` and `lidl-gen` are pinned
-      > to the matching heads — once the chain merges, build them from plain
-      > master.
+      > protocol-extraction branches, so `logoscore` is pinned to the matching
+      > head — once the chain merges, build it from plain master.
     steps:
       - title: "Build logoscore"
         run: "nix build 'github:logos-co/logos-logoscore-cli/616cb079a5828caecfafd6d4e432519c864e3fb1' --out-link ./logos"
@@ -73,9 +73,6 @@ sections:
       - title: "Build lgpm"
         run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
         check_file: "lgpm/bin/lgpm"
-      - title: "Build logos-lidl-gen"
-        run: "nix build 'github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7#lidl-gen' -o lidl-gen"
-        check_file: "lidl-gen/bin/logos-lidl-gen"
 
   - title: "Module 1 — contract-first C++ (`cpp_counter_module`)"
     step: true
@@ -204,10 +201,11 @@ sections:
     text: |
       The orchestrator goes the other way: its contract is declared **in Rust**,
       as a plain trait (events on a `<Trait>Events` companion — the analog of
-      C++'s `logos_events:` section). The `.lidl` is *derived* from the trait
-      with `logos-lidl-gen --from-rust` and committed next to the crate; from
-      there, everything else is generated — for this module and for its
-      consumers in any language.
+      C++'s `logos_events:` section). The trait `.rs` file is the single source
+      of truth: the builder *derives* the `.lidl` from it at build time
+      (`codegen.rust.trait`), exactly as a universal C++ module derives its
+      contract from the impl header. Nothing is committed but the trait — no
+      `.lidl`, no `build.rs`, no manual derive step.
     steps:
       - title: "The contract and implementation, all in Rust"
         text: |
@@ -220,9 +218,9 @@ sections:
           path: rust-orchestrator/rust-lib/src/lib.rs
           language: rust
           content: |
-            //! Rust-FIRST module: the contract below is declared in Rust; the .lidl is
-            //! derived from it (logos-lidl-gen --from-rust) and committed next to the
-            //! crate — consumers in any language generate typed bindings from that.
+            //! Rust-FIRST module: the contract below is declared in Rust and IS the
+            //! single source of truth. The builder derives the .lidl from this trait
+            //! (codegen.rust.trait) — nothing else is committed.
 
             /// The module's IPC contract. Required methods are the contract; the
             /// defaulted on_context_ready hook is framework plumbing, not a method.
@@ -303,33 +301,16 @@ sections:
             [dependencies]
             serde_json = "1"
             logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
-      - title: "Derive the .lidl from the trait"
-        text: |
-          This is the Rust analog of the C++ generator's `--header-to-lidl`:
-          the trait IS the source of truth, the `.lidl` is its language-neutral
-          projection. Commit it next to the crate:
-        run: "./lidl-gen/bin/logos-lidl-gen --from-rust rust-orchestrator/rust-lib/src/lib.rs --trait RustOrchestratorModule --module-version 1.0.0 -o rust-orchestrator/rust-lib/rust_orchestrator_module.lidl"
-        code_block: |
-          logos-lidl-gen --from-rust rust-lib/src/lib.rs \
-            --trait RustOrchestratorModule --module-version 1.0.0 \
-            -o rust-lib/rust_orchestrator_module.lidl
-        extra_run:
-          run: "cat rust-orchestrator/rust-lib/rust_orchestrator_module.lidl"
-        expect_contains:
-          - "Generated"
-        post_text: |
-          Methods keep their Rust names; the defaulted `on_context_ready` hook
-          is correctly excluded (default-bodied trait methods are framework
-          plumbing, not contract).
       - title: "metadata.json + CMakeLists.txt + flake.nix"
         text: |
-          `codegen.rust` marks this as a builder-built Rust module:
-          `author_trait: true` is the rust-first signal — the contract trait is
-          in the crate, so the builder runs the generator with `--no-trait` and
-          wraps it. The dependency (`cpp_counter_module`) is declared in
-          `dependencies`, so the host auto-loads it AND the builder generates its
-          typed `modules().cpp_counter_module` client from its published
-          contract — no manual copy. No `buildRustPackage`, no `preConfigure`:
+          `codegen.rust.trait` names the contract trait — the rust-first signal.
+          The builder derives the `.lidl` from that trait at build time (the
+          analog of `--header-to-lidl` over a C++ impl header), generates the
+          scaffold with `--no-trait`, and wraps the author's trait. The
+          dependency (`cpp_counter_module`) is declared in `dependencies`, so the
+          host auto-loads it AND the builder generates its typed
+          `modules().cpp_counter_module` client from its published contract — no
+          manual copy. No `.lidl`, no `build.rs`, no `buildRustPackage`:
         file:
           path: rust-orchestrator/metadata.json
           language: json
@@ -348,7 +329,7 @@ sections:
               "capabilities": [],
               "codegen": {
                 "lidl": "rust-lib/rust_orchestrator_module.lidl",
-                "rust": { "crate": "rust-lib", "staticlib": "rust_orchestrator", "author_trait": true }
+                "rust": { "crate": "rust-lib", "staticlib": "rust_orchestrator", "trait": "RustOrchestratorModule" }
               },
               "nix": {
                 "external_libraries": [],

--- a/doctests/cross-language-composition.test.yaml
+++ b/doctests/cross-language-composition.test.yaml
@@ -37,7 +37,7 @@ what_you_build: "Three modules (contract-first C++, Rust-first Rust, universal C
 
 what_you_learn:
   - "Contract-first C++: declare a module in .lidl, hand-write a Qt-free class, let the generator build the C-ABI wrapper + glue (interface: cdylib + codegen.impl_class)"
-  - "Rust-first Rust: declare the contract as a plain trait, derive the .lidl from it (logos-lidl-gen --from-rust), and let build.rs generate everything around your trait"
+  - "Rust-first Rust: declare the contract as a plain trait, derive the .lidl from it (logos-lidl-gen --from-rust), and let the builder generate everything around your trait — no build.rs (codegen.rust.author_trait)"
   - Module context in both languages (instance id, persistence path) and the on-context-ready hook
   - Typed event emission (Rust) and typed event subscription (C++) across the language boundary
   - "Typed dependency calls both ways: Rust's modules().counter.increment() and C++'s modules().rust_orchestrator_module.tally()"
@@ -74,7 +74,7 @@ sections:
         run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
         check_file: "lgpm/bin/lgpm"
       - title: "Build logos-lidl-gen"
-        run: "nix build 'github:logos-co/logos-rust-sdk/1b8e669be92900f6786417024e63cfea7508d479#lidl-gen' -o lidl-gen"
+        run: "nix build 'github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7#lidl-gen' -o lidl-gen"
         check_file: "lidl-gen/bin/logos-lidl-gen"
 
   - title: "Module 1 — contract-first C++ (`cpp_counter_module`)"
@@ -214,8 +214,8 @@ sections:
           One file holds the trait (the contract), the events companion, and
           the implementation. Note the parity features in play: the
           `on_context_ready` hook, `context()` for the host-stamped instance
-          id, the typed `modules().counter` dependency client, and the typed
-          `emit_tally_changed` emitter:
+          id, the typed `modules().cpp_counter_module` dependency client, and the
+          typed `emit_tally_changed` emitter:
         file:
           path: rust-orchestrator/rust-lib/src/lib.rs
           language: rust
@@ -237,17 +237,18 @@ sections:
                 fn tally_changed(&self, total: i64);
             }
 
-            include!(concat!(env!("OUT_DIR"), "/provider_gen.rs"));
+            // The builder injects the generated scaffold here (no build.rs, no OUT_DIR).
+            include!(concat!(env!("CARGO_MANIFEST_DIR"), "/generated/provider_gen.rs"));
 
             #[derive(Default)]
             struct Orchestrator;
 
             impl RustOrchestratorModule for Orchestrator {
                 /// Forward to the C++ counter through the typed dependency client
-                /// (modules().counter — generated from cpp_counter_module's contract),
-                /// then emit the typed event with the new total.
+                /// (modules().cpp_counter_module — generated from the dependency's
+                /// published contract), then emit the typed event with the new total.
                 fn tally(&mut self, amount: i64) -> i64 {
-                    let total = match modules().counter.increment(amount) {
+                    let total = match modules().cpp_counter_module.increment(amount) {
                         Ok(v) => v,
                         Err(e) => {
                             eprintln!("orchestrator: counter.increment failed: {}", e);
@@ -278,51 +279,11 @@ sections:
         post_text: |
           > The contract trait must carry `Send + 'static` — the generated
           > dispatch stores the implementation as a `Box<dyn Any + Send>`.
-      - title: "build.rs — generate the scaffold around YOUR trait"
+      - title: "Cargo.toml — no build-dependency"
         text: |
-          `generate_provider_with(..., emit_trait = false)` skips trait
-          generation (yours is the contract) and emits everything else: the
-          C-ABI exports, `RustModuleContext`, typed emitters — plus the typed
-          dependency clients and the `Modules` aggregate from the deps'
-          committed contracts:
-        file:
-          path: rust-orchestrator/rust-lib/build.rs
-          language: rust
-          content: |
-            //! Generates from the COMMITTED .lidl (derived from src/lib.rs's trait by
-            //! `logos-lidl-gen --from-rust` — see the tour step): the module-impl
-            //! C ABI scaffold around the author's trait (emit_trait = false) plus the
-            //! typed dependency clients + Modules aggregate from the deps' contracts.
-
-            fn main() {
-                let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-                let root = std::path::Path::new(&manifest);
-                let lidl = root.join("rust_orchestrator_module.lidl");
-                let dep = root.join("deps/cpp_counter_module.lidl");
-                println!("cargo:rerun-if-changed={}", lidl.display());
-                println!("cargo:rerun-if-changed={}", dep.display());
-
-                let module =
-                    logos_lidl_gen::parse(&std::fs::read_to_string(&lidl).expect("read contract"))
-                        .expect("parse contract");
-                let counter =
-                    logos_lidl_gen::parse(&std::fs::read_to_string(&dep).expect("read dep contract"))
-                        .expect("parse dep contract");
-
-                let version =
-                    std::env::var("LOGOS_PROTOCOL_VERSION").unwrap_or_else(|_| "0.1.0".to_string());
-                let mut code =
-                    logos_lidl_gen::rustgen_provider::generate_provider_with(&module, &version, false);
-                code.push('\n');
-                code.push_str(&logos_lidl_gen::generate_deps(&[(
-                    "counter".to_string(),
-                    counter,
-                )]));
-
-                let out = std::path::Path::new(&std::env::var("OUT_DIR").unwrap()).join("provider_gen.rs");
-                std::fs::write(&out, code).expect("write generated scaffold");
-            }
-      - title: "Cargo.toml"
+          The crate depends only on the SDK and `serde_json`. There is **no
+          `logos-lidl-gen` build-dependency and no `build.rs`** — the builder
+          runs the generator (`codegen.rust`, below):
         file:
           path: rust-orchestrator/rust-lib/Cargo.toml
           language: toml
@@ -341,10 +302,7 @@ sections:
 
             [dependencies]
             serde_json = "1"
-            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "7ce12b9a9586f307a375ef646fbc5c9d14a0968e" }
-
-            [build-dependencies]
-            logos-lidl-gen = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "7ce12b9a9586f307a375ef646fbc5c9d14a0968e" }
+            logos-rust-sdk = { git = "https://github.com/logos-co/logos-rust-sdk", rev = "340f42d41008488d912257e7836789795adbaeb7" }
       - title: "Derive the .lidl from the trait"
         text: |
           This is the Rust analog of the C++ generator's `--header-to-lidl`:
@@ -363,19 +321,15 @@ sections:
           Methods keep their Rust names; the defaulted `on_context_ready` hook
           is correctly excluded (default-bodied trait methods are framework
           plumbing, not contract).
-      - title: "Copy the dependency's contract"
-        text: |
-          The orchestrator consumes `cpp_counter_module` — its typed client is
-          generated from the counter's contract, so copy the `.lidl` in (in a
-          multi-repo setup this would come from the dep's published flake
-          output):
-        run: "mkdir -p rust-orchestrator/rust-lib/deps && cp cpp-counter/cpp_counter_module.lidl rust-orchestrator/rust-lib/deps/"
-        check_file: "rust-orchestrator/rust-lib/deps/cpp_counter_module.lidl"
       - title: "metadata.json + CMakeLists.txt + flake.nix"
         text: |
-          Standard cdylib-module wiring — the same shapes as logos-rust-sdk's
-          Rust provider tutorial, with the dependency declared in
-          `metadata.json` so the host auto-loads it:
+          `codegen.rust` marks this as a builder-built Rust module:
+          `author_trait: true` is the rust-first signal — the contract trait is
+          in the crate, so the builder runs the generator with `--no-trait` and
+          wraps it. The dependency (`cpp_counter_module`) is declared in
+          `dependencies`, so the host auto-loads it AND the builder generates its
+          typed `modules().cpp_counter_module` client from its published
+          contract — no manual copy. No `buildRustPackage`, no `preConfigure`:
         file:
           path: rust-orchestrator/metadata.json
           language: json
@@ -393,7 +347,8 @@ sections:
               "include": [],
               "capabilities": [],
               "codegen": {
-                "lidl": "rust-lib/rust_orchestrator_module.lidl"
+                "lidl": "rust-lib/rust_orchestrator_module.lidl",
+                "rust": { "crate": "rust-lib", "staticlib": "rust_orchestrator", "author_trait": true }
               },
               "nix": {
                 "external_libraries": [],
@@ -417,35 +372,7 @@ sections:
             configure_file(${CMAKE_CURRENT_SOURCE_DIR}/metadata.json
                            ${CMAKE_CURRENT_BINARY_DIR}/metadata.json COPYONLY)
 
-            logos_module(
-                NAME rust_orchestrator_module
-            )
-
-            find_library(LIBRUST_ORCHESTRATOR
-                NAMES librust_orchestrator.a rust_orchestrator
-                PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib
-                NO_DEFAULT_PATH
-            )
-
-            if(NOT LIBRUST_ORCHESTRATOR)
-                message(FATAL_ERROR "librust_orchestrator.a not found in lib/ — preConfigure must stage it.")
-            endif()
-
-            # One protocol stack shared by glue and Rust: re-mention the protocol target
-            # after the Rust archive so single-pass linkers resolve its lp_* references.
-            target_link_libraries(rust_orchestrator_module_module_plugin PRIVATE
-                ${LIBRUST_ORCHESTRATOR}
-                logos-protocol::logos_protocol
-            )
-
-            if(APPLE)
-                target_link_libraries(rust_orchestrator_module_module_plugin PRIVATE
-                    "-framework CoreFoundation"
-                    "-framework Security"
-                )
-            else()
-                target_link_libraries(rust_orchestrator_module_module_plugin PRIVATE pthread dl)
-            endif()
+            logos_module(NAME rust_orchestrator_module)
       - file:
           path: rust-orchestrator/flake.nix
           language: nix
@@ -455,47 +382,31 @@ sections:
 
               inputs = {
                 logos-module-builder.url = "github:logos-co/logos-module-builder{release}";
+                # Provides logos-lidl-gen (the generator the builder runs) and the SDK
+                # the crate links — one extra input vs a C++ module.
+                logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7";
                 # The dependency's flake. Placeholder — locked to the real checkout in
                 # the build step via --override-input (nix rejects relative paths here).
                 cpp_counter_module.url = "path:/path/to/cpp-counter";
               };
 
-              outputs = inputs@{ self, logos-module-builder, cpp_counter_module, ... }:
+              outputs = inputs@{ self, logos-module-builder, ... }:
                 let
                   nixpkgs = logos-module-builder.inputs.nixpkgs;
                   systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
                   forAllSystems = f: nixpkgs.lib.genAttrs systems f;
-
-                  rustLib = system:
-                    let pkgs = nixpkgs.legacyPackages.${system};
-                    in pkgs.rustPlatform.buildRustPackage {
-                      pname = "rust_orchestrator";
-                      version = "1.0.0";
-                      src = ./rust-lib;
-                      cargoLock = {
-                        lockFile = ./rust-lib/Cargo.lock;
-                        allowBuiltinFetchGit = true;
-                      };
-                      doCheck = false;
-                    };
-
-                  module = system:
-                    logos-module-builder.lib.mkLogosModule {
+                in
+                {
+                  packages = forAllSystems (system:
+                    (logos-module-builder.lib.mkLogosModule {
                       src = ./.;
                       configFile = ./metadata.json;
                       flakeInputs = inputs;
-                      preConfigure = ''
-                        mkdir -p lib
-                        cp ${rustLib system}/lib/librust_orchestrator.a lib/
-                      '';
-                    };
-                in
-                {
-                  packages = forAllSystems (system: (module system).packages.${system});
+                    }).packages.${system});
                 };
             }
       - title: "Build it"
-        run: "sh -c 'cd rust-orchestrator && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_counter_module path:$PWD/../cpp-counter && git add flake.lock && nix build .#lgx -o orch-lgx --override-input cpp_counter_module path:$PWD/../cpp-counter'"
+        run: "sh -c 'cd rust-orchestrator && printf \"result\\nresult-*\\nlib/\\nrust-lib/target/\\nrust-lib/generated/\\n\" > .gitignore && (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile) && git init -q && git add -A && nix flake update --override-input cpp_counter_module path:$PWD/../cpp-counter && git add flake.lock && nix build .#lgx -o orch-lgx --override-input cpp_counter_module path:$PWD/../cpp-counter'"
         code_block: |
           cd rust-orchestrator
           (cd rust-lib && nix run nixpkgs#cargo -- generate-lockfile)

--- a/flake.lock
+++ b/flake.lock
@@ -4313,6 +4313,41 @@
         "type": "github"
       }
     },
+    "logos-rust-sdk": {
+      "inputs": {
+        "logos-logoscore-cli": [
+          "logos-cpp-sdk"
+        ],
+        "logos-module-builder": [
+          "logos-cpp-sdk"
+        ],
+        "logos-module-client": [
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-rust-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781550278,
+        "narHash": "sha256-j3CZSeGvvw+X5qRLlaHh1UfUNFc2hNs756hSN04J/XQ=",
+        "owner": "logos-co",
+        "repo": "logos-rust-sdk",
+        "rev": "340f42d41008488d912257e7836789795adbaeb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-rust-sdk",
+        "rev": "340f42d41008488d912257e7836789795adbaeb7",
+        "type": "github"
+      }
+    },
     "logos-standalone-app": {
       "inputs": {
         "logos-capability-module": "logos-capability-module",
@@ -7732,6 +7767,7 @@
         "logos-plugin-qt": "logos-plugin-qt",
         "logos-protocol": "logos-protocol",
         "logos-qt-sdk": "logos-qt-sdk",
+        "logos-rust-sdk": "logos-rust-sdk",
         "logos-standalone-app": "logos-standalone-app",
         "logos-test-framework": "logos-test-framework_3",
         "nix-bundle-lgx": "nix-bundle-lgx_8",

--- a/flake.nix
+++ b/flake.nix
@@ -23,10 +23,21 @@
     # Test framework for module unit tests
     logos-test-framework.url = "github:logos-co/logos-test-framework";
     logos-test-framework.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
+    # The Rust SDK provides logos-lidl-gen (the generator the builder runs for
+    # codegen.rust modules) and the SDK source the crate links. logos-rust-sdk
+    # depends BACK on this builder for its own integration tests, so its
+    # logos-module-builder input is cut with `follows` to break the cycle — we
+    # only consume its lidl-gen package + source tree, never its tests. The other
+    # branch-pinned test-only inputs are cut too so they aren't fetched.
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/340f42d41008488d912257e7836789795adbaeb7";
+    logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
+    logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
+    logos-rust-sdk.inputs.logos-module-client.follows = "logos-cpp-sdk";
+    logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";
     nixpkgs.follows = "logos-nix/nixpkgs";
   };
 
-  outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, ... }:
+  outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, logos-rust-sdk, ... }:
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
 
@@ -39,7 +50,7 @@
       # Use rawLib from backends — we inject logos-cpp-sdk/logos-module ourselves
       lib = import ./lib {
         inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app;
-        inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework;
+        inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework logos-rust-sdk;
         inherit (nixpkgs) lib;
         uiBackend = logos-plugin-qt.rawLib or logos-plugin-qt.lib;
         coreBackend = logos-plugin-core.rawLib or logos-plugin-core.lib;
@@ -49,6 +60,14 @@
     {
       # Export the library functions for use by modules
       lib = lib;
+
+      # The logos-rust-sdk source tree at the rev this builder pins — exposed so a
+      # codegen.rust module can stage it as `../logos-rust-sdk-src` to generate its
+      # Cargo.lock against the SAME SDK the builder links, without needing a
+      # logos-rust-sdk input in the module's own flake.
+      packages = forAllSystems ({ pkgs, ... }: {
+        rust-sdk-src = pkgs.runCommand "logos-rust-sdk-src" {} "cp -r ${logos-rust-sdk} $out";
+      });
 
       # Also expose as an overlay for convenience
       overlays.default = final: prev: {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,7 @@
 #
 # logos-cpp-sdk and logos-module are owned by this builder and injected into
 # backends — backends never resolve these deps themselves.
-{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, builderRoot }:
+{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, builderRoot }:
 
 let
   # Import common utilities (backend-agnostic)
@@ -17,7 +17,7 @@ let
   mkLogosModule = import ./mkLogosModule.nix {
     inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app lib;
     inherit common parseMetadata builderRoot uiBackend coreBackend;
-    inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework;
+    inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework logos-rust-sdk;
   };
 
   # Import the shared C++ plugin build pipeline (used by mkLogosQmlModule for backend builds)

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -248,10 +248,18 @@ let
       # with `follows` in flake.nix to break the cycle (see there).
       isRustModule = (config.codegen or {}) ? rust;
       rustCfg = (config.codegen or {}).rust or {};
-      rustStaticName =
-        rustCfg.staticlib or (throw "codegen.rust must set 'staticlib' (e.g. \"rust_provider\" for librust_provider.a) in ${config.name}");
       rustCrateDir =
         "${src}/${rustCfg.crate or (throw "codegen.rust must set 'crate' (the crate directory, e.g. \"rust-lib\") in ${config.name}")}";
+      # The staticlib basename (produces lib<name>.a) — read from the crate's
+      # Cargo.toml ([lib].name, else [package].name with - -> _) so the author
+      # needn't repeat it. codegen.rust.staticlib still overrides if set.
+      rustCargoToml =
+        if !isRustModule then {}
+        else builtins.fromTOML (builtins.readFile "${rustCrateDir}/Cargo.toml");
+      rustStaticName =
+        rustCfg.staticlib
+          or (rustCargoToml.lib.name
+              or (lib.replaceStrings ["-"] ["_"] rustCargoToml.package.name));
       # Rust-FIRST authoring: when codegen.rust names the contract `trait`, that
       # trait is declared in the crate and the .lidl is DERIVED from it at build
       # time (logos-lidl-gen --from-rust over the crate source) — exactly as a
@@ -313,13 +321,13 @@ let
             -o "$out/provider_gen.rs"
         '';
 
-      # Rust-first only: stage the derived .lidl into the build tree at
-      # codegen.lidl's path BEFORE the Qt-glue codegen reads it (cdylibCodegen
-      # consumes the relative codegen.lidl). Empty for contract-first, where the
-      # .lidl is committed and already present in the source tree.
+      # Rust-first only: stage the derived .lidl into generated_code/ BEFORE the
+      # Qt-glue codegen runs — that's where cdylibCodegen reads it for a rust-first
+      # module (so no codegen.lidl is needed in metadata; the builder owns the
+      # path). Empty for contract-first, where the .lidl is committed.
       lidlStaging = lib.optionalString rustDeriveMode ''
-        mkdir -p "$(dirname "${config.codegen.lidl}")"
-        cp ${derivedLidl}/${config.name}.lidl "${config.codegen.lidl}"
+        mkdir -p generated_code
+        cp ${derivedLidl}/${config.name}.lidl generated_code/${config.name}.lidl
       '';
 
       # The crate source laid out for the build: the crate under rust-lib/ (with

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -251,12 +251,19 @@ let
         rustCfg.staticlib or (throw "codegen.rust must set 'staticlib' (e.g. \"rust_provider\" for librust_provider.a) in ${config.name}");
       rustCrateDir =
         "${src}/${rustCfg.crate or (throw "codegen.rust must set 'crate' (the crate directory, e.g. \"rust-lib\") in ${config.name}")}";
-      # Rust-FIRST authoring: the contract trait is declared in the crate (the
-      # .lidl was derived from it with `logos-lidl-gen --from-rust`), so the
-      # scaffold must wrap the author's trait rather than generate one — the
-      # generator runs with --no-trait. Default (false) is contract-first: the
-      # .lidl is the source of truth and the trait is generated.
-      rustAuthorTrait = rustCfg.author_trait or false;
+      # Rust-FIRST authoring: when codegen.rust names the contract `trait`, that
+      # trait is declared in the crate and the .lidl is DERIVED from it at build
+      # time (logos-lidl-gen --from-rust over the crate source) — exactly as a
+      # universal C++ module derives its .lidl from the impl header. The .rs file
+      # is the single source of truth: no committed .lidl, no manual derive step.
+      # The scaffold is then generated with --no-trait (the trait is the
+      # author's). Without `trait`, the module is contract-first: codegen.lidl is
+      # a committed file and the trait is generated.
+      rustTrait = rustCfg.trait or null;
+      rustDeriveMode = rustTrait != null;
+      # The .rs file holding the trait (+ optional <Trait>Events companion),
+      # relative to the crate dir.
+      rustSource = rustCfg.source or "src/lib.rs";
       rustGen =
         if !isRustModule then null
         else ((flakeInputs.logos-rust-sdk or (throw
@@ -273,16 +280,45 @@ let
         ++ (map (e: "--dep ${e.name}=${e.path}") resolvedInterfaceDeps)
       );
 
+      # The contract .lidl, derived from the crate's trait in rust-first mode.
+      # Reused by the scaffold gen, the Qt glue (staged into the build below), and
+      # the published `packages.<sys>.lidl`.
+      derivedLidl =
+        if !rustDeriveMode then null
+        else pkgs.runCommand "logos-${config.name}-derived-lidl" {
+          nativeBuildInputs = [ rustGen ];
+        } ''
+          mkdir -p $out
+          logos-lidl-gen --from-rust "${rustCrateDir}/${rustSource}" \
+            --trait ${rustTrait} --module-name ${config.name} --module-version ${config.version} \
+            -o "$out/${config.name}.lidl"
+        '';
+
+      # The .lidl the generators consume: the derived one (rust-first) or the
+      # committed codegen.lidl (contract-first).
+      rustLidlPath =
+        if rustDeriveMode then "${derivedLidl}/${config.name}.lidl"
+        else "${src}/${config.codegen.lidl}";
+
       rustScaffold =
         if !isRustModule then null
         else pkgs.runCommand "logos-${config.name}-rust-scaffold" {
           nativeBuildInputs = [ rustGen ];
         } ''
           mkdir -p $out
-          logos-lidl-gen "${src}/${config.codegen.lidl}" --provider ${lib.optionalString rustAuthorTrait "--no-trait"} ${rustDepFlags} \
+          logos-lidl-gen "${rustLidlPath}" --provider ${lib.optionalString rustDeriveMode "--no-trait"} ${rustDepFlags} \
             ${lib.optionalString (protocolVersion != null) "--protocol-version ${protocolVersion}"} \
             -o "$out/provider_gen.rs"
         '';
+
+      # Rust-first only: stage the derived .lidl into the build tree at
+      # codegen.lidl's path BEFORE the Qt-glue codegen reads it (cdylibCodegen
+      # consumes the relative codegen.lidl). Empty for contract-first, where the
+      # .lidl is committed and already present in the source tree.
+      lidlStaging = lib.optionalString rustDeriveMode ''
+        mkdir -p "$(dirname "${config.codegen.lidl}")"
+        cp ${derivedLidl}/${config.name}.lidl "${config.codegen.lidl}"
+      '';
 
       # The crate source with the generated scaffold injected at
       # generated/provider_gen.rs — the crate `include!`s it from there (no
@@ -343,6 +379,8 @@ let
           preConfigureStr = modulePreConfigure.compose {
             inherit config externalLibs protocolVersion;
             userPre = userPreConfigure;
+            # Stage the rust-first derived .lidl before the glue codegen reads it.
+            preCodegen = lidlStaging;
             fixDarwin = false;
             # logos-plugin-qt buildPlugin already stages external libs into lib/
             copyExternals = false;
@@ -465,10 +503,15 @@ let
                  --metadata "${configFile}" \
                  -o "$out/${config.name}.lidl"
              ''
-        # Cdylib modules are contract-first: the committed .lidl IS the
-        # interface (whether the impl is Rust or C++), so publishing it is a
-        # copy — consumers generate typed bindings from it like for any other
-        # dep, regardless of the module's implementation language.
+        # Cdylib modules publish their .lidl as the interface (whether the impl
+        # is Rust or C++), so consumers generate typed bindings from it like for
+        # any other dep. Contract-first modules copy the committed file; a
+        # rust-first module publishes the .lidl DERIVED from its trait.
+        else if rustDeriveMode
+        then pkgs.runCommand "logos-${config.name}-lidl" {} ''
+               mkdir -p $out
+               cp "${derivedLidl}/${config.name}.lidl" "$out/${config.name}.lidl"
+             ''
         else if config.interface == "cdylib" && config.codegen ? lidl
         then pkgs.runCommand "logos-${config.name}-lidl" {} ''
                mkdir -p $out

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -2,7 +2,7 @@
 # This is the main entry point for building Logos modules.
 # Plugin compilation and header generation are delegated to a backend selected
 # by metadata.json "type": core modules use coreBackend, UI modules use uiBackend.
-{ nixpkgs, lib, common, parseMetadata, builderRoot, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
+{ nixpkgs, lib, common, parseMetadata, builderRoot, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
 
 {
   # Required: Path to the module source
@@ -240,11 +240,12 @@ let
       # generator. The author writes no build.rs and the module's flake stays
       # trivial (no buildRustPackage / preConfigure staging).
       #
-      # logos-lidl-gen comes from the MODULE's flakeInputs (not a builder input):
-      # logos-rust-sdk already depends on this builder for its tests, so making
-      # it a builder input would be a cycle. The module needs logos-rust-sdk in
-      # its inputs anyway (the crate depends on the SDK), so reading it from
-      # flakeInputs adds no new dependency edge.
+      # logos-lidl-gen AND the SDK source the crate links both come from this
+      # builder's own logos-rust-sdk input — so a Rust module's flake.nix is
+      # identical to a C++ one (just logos-module-builder), and the generator and
+      # the runtime SDK are the SAME pinned rev (no skew). logos-rust-sdk depends
+      # back on this builder for its tests, so its module-builder input is cut
+      # with `follows` in flake.nix to break the cycle (see there).
       isRustModule = (config.codegen or {}) ? rust;
       rustCfg = (config.codegen or {}).rust or {};
       rustStaticName =
@@ -264,11 +265,12 @@ let
       # The .rs file holding the trait (+ optional <Trait>Events companion),
       # relative to the crate dir.
       rustSource = rustCfg.source or "src/lib.rs";
-      rustGen =
+      rustSdk =
         if !isRustModule then null
-        else ((flakeInputs.logos-rust-sdk or (throw
-                "codegen.rust module '${config.name}' needs 'logos-rust-sdk' in flakeInputs — add it to the module flake's inputs and pass `flakeInputs = inputs`."))
-              .packages.${system}.lidl-gen);
+        else if logos-rust-sdk == null
+        then throw "codegen.rust module '${config.name}' requires logos-module-builder to be built with a logos-rust-sdk input (it provides the lidl-gen generator + the SDK source). Update the builder."
+        else logos-rust-sdk;
+      rustGen = if !isRustModule then null else rustSdk.packages.${system}.lidl-gen;
 
       # The dep contracts that feed the Rust generator: the same resolved
       # concrete + interface deps the C++ generator gets. Concrete deps →
@@ -320,16 +322,21 @@ let
         cp ${derivedLidl}/${config.name}.lidl "${config.codegen.lidl}"
       '';
 
-      # The crate source with the generated scaffold injected at
-      # generated/provider_gen.rs — the crate `include!`s it from there (no
-      # build.rs, no OUT_DIR). Author crates carry only the trait impl + hook.
+      # The crate source laid out for the build: the crate under rust-lib/ (with
+      # the generated scaffold injected at generated/provider_gen.rs) and the
+      # builder's logos-rust-sdk source alongside it, so the crate's
+      # `logos-rust-sdk = { path = "../logos-rust-sdk-src" }` dep resolves against
+      # the SAME rev the generator came from. The author crate carries only the
+      # trait impl + hook — no build.rs, no OUT_DIR.
       rustCrateSrc =
         if !isRustModule then null
-        else pkgs.runCommand "logos-${config.name}-rust-crate" {} ''
-          cp -r ${rustCrateDir} $out
-          chmod -R u+w $out
-          mkdir -p $out/generated
-          cp ${rustScaffold}/provider_gen.rs $out/generated/provider_gen.rs
+        else pkgs.runCommand "logos-${config.name}-rust-src" {} ''
+          mkdir -p $out
+          cp -r ${rustCrateDir} $out/rust-lib
+          chmod -R u+w $out/rust-lib
+          mkdir -p $out/rust-lib/generated
+          cp ${rustScaffold}/provider_gen.rs $out/rust-lib/generated/provider_gen.rs
+          cp -r ${rustSdk} $out/logos-rust-sdk-src
         '';
 
       rustStaticLib =
@@ -338,6 +345,7 @@ let
           pname = rustStaticName;
           version = config.version;
           src = rustCrateSrc;
+          sourceRoot = "logos-${config.name}-rust-src/rust-lib";
           cargoLock = {
             lockFile = "${rustCrateDir}/Cargo.lock";
             allowBuiltinFetchGit = true;

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -251,6 +251,12 @@ let
         rustCfg.staticlib or (throw "codegen.rust must set 'staticlib' (e.g. \"rust_provider\" for librust_provider.a) in ${config.name}");
       rustCrateDir =
         "${src}/${rustCfg.crate or (throw "codegen.rust must set 'crate' (the crate directory, e.g. \"rust-lib\") in ${config.name}")}";
+      # Rust-FIRST authoring: the contract trait is declared in the crate (the
+      # .lidl was derived from it with `logos-lidl-gen --from-rust`), so the
+      # scaffold must wrap the author's trait rather than generate one — the
+      # generator runs with --no-trait. Default (false) is contract-first: the
+      # .lidl is the source of truth and the trait is generated.
+      rustAuthorTrait = rustCfg.author_trait or false;
       rustGen =
         if !isRustModule then null
         else ((flakeInputs.logos-rust-sdk or (throw
@@ -273,7 +279,7 @@ let
           nativeBuildInputs = [ rustGen ];
         } ''
           mkdir -p $out
-          logos-lidl-gen "${src}/${config.codegen.lidl}" --provider ${rustDepFlags} \
+          logos-lidl-gen "${src}/${config.codegen.lidl}" --provider ${lib.optionalString rustAuthorTrait "--no-trait"} ${rustDepFlags} \
             ${lib.optionalString (protocolVersion != null) "--protocol-version ${protocolVersion}"} \
             -o "$out/provider_gen.rs"
         '';

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -232,6 +232,84 @@ let
           in if builtins.length parts < 2 then null
              else builtins.head (builtins.elemAt parts 1);
 
+      # ── Rust cdylib authoring (codegen.rust) ───────────────────────────────
+      # A Rust module's module-impl C ABI scaffold (logos_module_* exports +
+      # typed trait + RustModuleContext + dep clients) is generated from the SAME
+      # .lidl contract that drives the Qt glue, and the crate is compiled to a
+      # staticlib — both done HERE by the builder, exactly as it runs the C++
+      # generator. The author writes no build.rs and the module's flake stays
+      # trivial (no buildRustPackage / preConfigure staging).
+      #
+      # logos-lidl-gen comes from the MODULE's flakeInputs (not a builder input):
+      # logos-rust-sdk already depends on this builder for its tests, so making
+      # it a builder input would be a cycle. The module needs logos-rust-sdk in
+      # its inputs anyway (the crate depends on the SDK), so reading it from
+      # flakeInputs adds no new dependency edge.
+      isRustModule = (config.codegen or {}) ? rust;
+      rustCfg = (config.codegen or {}).rust or {};
+      rustStaticName =
+        rustCfg.staticlib or (throw "codegen.rust must set 'staticlib' (e.g. \"rust_provider\" for librust_provider.a) in ${config.name}");
+      rustCrateDir =
+        "${src}/${rustCfg.crate or (throw "codegen.rust must set 'crate' (the crate directory, e.g. \"rust-lib\") in ${config.name}")}";
+      rustGen =
+        if !isRustModule then null
+        else ((flakeInputs.logos-rust-sdk or (throw
+                "codegen.rust module '${config.name}' needs 'logos-rust-sdk' in flakeInputs — add it to the module flake's inputs and pass `flakeInputs = inputs`."))
+              .packages.${system}.lidl-gen);
+
+      # The dep contracts that feed the Rust generator: the same resolved
+      # concrete + interface deps the C++ generator gets. Concrete deps →
+      # `modules().<dep>`; interface deps → a bound client (`<Iface>Client::bind`).
+      # Both arrive as `--dep name=<lidl>` (the Rust CLI has no separate
+      # interface flag — every generated client carries new() AND bind()).
+      rustDepFlags = lib.concatStringsSep " " (
+        (map (d: "--dep ${d.name}=${d.path}") staticDeps)
+        ++ (map (e: "--dep ${e.name}=${e.path}") resolvedInterfaceDeps)
+      );
+
+      rustScaffold =
+        if !isRustModule then null
+        else pkgs.runCommand "logos-${config.name}-rust-scaffold" {
+          nativeBuildInputs = [ rustGen ];
+        } ''
+          mkdir -p $out
+          logos-lidl-gen "${src}/${config.codegen.lidl}" --provider ${rustDepFlags} \
+            ${lib.optionalString (protocolVersion != null) "--protocol-version ${protocolVersion}"} \
+            -o "$out/provider_gen.rs"
+        '';
+
+      # The crate source with the generated scaffold injected at
+      # generated/provider_gen.rs — the crate `include!`s it from there (no
+      # build.rs, no OUT_DIR). Author crates carry only the trait impl + hook.
+      rustCrateSrc =
+        if !isRustModule then null
+        else pkgs.runCommand "logos-${config.name}-rust-crate" {} ''
+          cp -r ${rustCrateDir} $out
+          chmod -R u+w $out
+          mkdir -p $out/generated
+          cp ${rustScaffold}/provider_gen.rs $out/generated/provider_gen.rs
+        '';
+
+      rustStaticLib =
+        if !isRustModule then null
+        else pkgs.rustPlatform.buildRustPackage {
+          pname = rustStaticName;
+          version = config.version;
+          src = rustCrateSrc;
+          cargoLock = {
+            lockFile = "${rustCrateDir}/Cargo.lock";
+            allowBuiltinFetchGit = true;
+          };
+          doCheck = false;
+        };
+
+      # Stage the compiled staticlib where LogosModule.cmake's
+      # LOGOS_MODULE_RUST_STATIC_LIBS block finds it (the plugin build's lib/).
+      rustStaging = lib.optionalString isRustModule ''
+        mkdir -p lib
+        cp ${rustStaticLib}/lib/lib${rustStaticName}.a lib/
+      '';
+
 
       # Backend arguments for a given external-lib variant ("default" or
       # "portable"). Shared by buildVariant (compiles the plugin) and the
@@ -246,10 +324,15 @@ let
               externalInputs = lib.mapAttrs (resolveExtInput variant) externalLibInputs;
             };
 
+          # rustStaging (empty for non-Rust modules) drops the compiled Rust
+          # staticlib into lib/ before cmake, where the LOGOS_MODULE_RUST_STATIC_LIBS
+          # block links it — the builder-driven replacement for the per-flake
+          # buildRustPackage + cp the author used to write by hand.
           userPreConfigure =
-            if builtins.isFunction preConfigure
-            then preConfigure { inherit externalLibs; }
-            else preConfigure;
+            rustStaging + (
+              if builtins.isFunction preConfigure
+              then preConfigure { inherit externalLibs; }
+              else preConfigure);
 
           preConfigureStr = modulePreConfigure.compose {
             inherit config externalLibs protocolVersion;
@@ -291,7 +374,8 @@ let
             "-DLOGOS_CPP_SDK_ROOT=${logosSdk}"
             "-DLOGOS_QT_SDK_ROOT=${logosQtSdk}"
             "-DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg}"
-          ] ++ goCmakeFlags ++ apiStyleCmakeFlags;
+          ] ++ goCmakeFlags ++ apiStyleCmakeFlags
+            ++ lib.optionals isRustModule [ "-DLOGOS_MODULE_RUST_STATIC_LIBS=${rustStaticName}" ];
           extraEnv = {
             LOGOS_CPP_SDK_ROOT = "${logosSdk}";
             LOGOS_QT_SDK_ROOT = "${logosQtSdk}";
@@ -302,7 +386,11 @@ let
         }
         # Only pass interfaceDeps when the module declares any — keeps existing
         # dependency-only modules buildable against a backend that predates the
-        # interface-dependencies feature (graceful degradation).
+        # interface-dependencies feature (graceful degradation). A Rust module's
+        # deps ALSO feed the Rust generator (rustDepFlags) for the typed
+        # modules()/bind() it actually calls; they still go to the C++ backend
+        # too so the generated umbrella (logos_sdk.h, emitted from
+        # metadata.dependencies) finds each dep's api header and compiles.
         // lib.optionalAttrs (config.interface_dependencies != []) {
           interfaceDeps = resolvedInterfaceDeps;
         }

--- a/lib/modulePreConfigure.nix
+++ b/lib/modulePreConfigure.nix
@@ -190,14 +190,17 @@ let
       fi
     '';
 
-  compose = { config, externalLibs, userPre, fixDarwin ? false, copyExternals ? false, protocolVersion ? null }:
+  # preCodegen runs AFTER the protocol-version stamp / external copy / darwin fix
+  # but BEFORE codegen — used to stage a builder-derived .lidl (rust-first) into
+  # the tree where cdylibCodegen will read codegen.lidl.
+  compose = { config, externalLibs, userPre, fixDarwin ? false, copyExternals ? false, protocolVersion ? null, preCodegen ? "" }:
     let
       stamp = stampProtocolVersion protocolVersion;
       copy = if copyExternals then copyExternalLibsToLib externalLibs else "";
       codegen = autoCodegen config;
       fix = if fixDarwin then fixupDarwinDylibs else "";
     in
-      stamp + copy + fix + codegen + userPre;
+      stamp + copy + fix + preCodegen + codegen + userPre;
 
 in {
   inherit defaultImplClassFromName copyExternalLibsToLib fixupDarwinDylibs universalCodegen providerCodegen uiCodegen autoCodegen compose stampProtocolVersion;

--- a/lib/modulePreConfigure.nix
+++ b/lib/modulePreConfigure.nix
@@ -113,7 +113,14 @@ let
   cdylibCodegen = config:
     let
       cg = config.codegen or {};
-      lidlFile = cg.lidl or (throw "cdylib interface requires codegen.lidl in metadata.json");
+      # A rust-first module (codegen.rust.trait) derives its .lidl from the trait;
+      # the builder stages it at generated_code/<name>.lidl (mkLogosModule's
+      # lidlStaging), so no codegen.lidl is needed. Otherwise it's the committed
+      # contract named by codegen.lidl.
+      lidlFile =
+        if ((cg.rust or {}).trait or null) != null
+        then "generated_code/${config.name}.lidl"
+        else (cg.lidl or (throw "cdylib interface requires codegen.lidl in metadata.json"));
       # Contract-first C++ flavor: when codegen names an impl_class, the
       # generator ALSO emits the C-ABI export wrapper (+ typed events) around
       # that hand-written Qt-free class. Without it (e.g. Rust modules whose


### PR DESCRIPTION
## What

A Rust cdylib module's module-impl C ABI scaffold **and** its static archive are now produced by `mkLogosModule` itself, driven by `metadata.json`'s new `codegen.rust` block — exactly as the builder already runs the C++ generator. The author writes no `build.rs`, and the module's `flake.nix` / `CMakeLists.txt` shrink to the same shape a C++ module uses.

```json
"codegen": {
  "lidl": "rust-lib/<name>.lidl",
  "rust": { "crate": "rust-lib", "staticlib": "<libname>" }
}
```

## How

When `codegen.rust` is present, `mkLogosModule`:
- runs `logos-lidl-gen --provider <lidl> [--dep ...]`, feeding it the **same** resolved concrete + interface deps the C++ generator gets (concrete → `modules().<dep>`; interface → a `bind()`-able client);
- injects the scaffold at `generated/provider_gen.rs` and `buildRustPackage`s the crate to a staticlib;
- stages the archive into `lib/` and sets `-DLOGOS_MODULE_RUST_STATIC_LIBS` so a new `cmake/LogosModule.cmake` block links it (plain link + protocol re-mention + frameworks/pthread — mirrors the existing Go static-archive path).

`logos-lidl-gen` is read from the **module's** `flakeInputs.logos-rust-sdk`, **not** a builder input: `logos-rust-sdk` already depends on this builder (for its tests), so a `builder → rust-sdk` input edge would be a cycle. The module needs `logos-rust-sdk` in its inputs regardless (the crate links the SDK), so reading it from `flakeInputs` adds no new edge.

## Verified

A minimal `codegen.rust` module — and a full 3-module trio (Rust provider + event, C++ provider, Rust consumer with concrete + interface deps, sync/async typed calls, context, event subscription) — build with **no `build.rs`**, a trivial flake and trivial CMakeLists, load under `lm`, and return correct values over a `logoscore` daemon. The trio is the new `logos-rust-sdk` cross-language-composition doc-test (21/21 steps green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)