### PR TITLE
doctest(cdylib-qt-free-outbound): stop the daemon so it can't poison the next spec

### DIFF
--- a/doctests/cdylib-qt-free-outbound.test.yaml
+++ b/doctests/cdylib-qt-free-outbound.test.yaml
@@ -382,6 +382,12 @@ sections:
           `peek()` is `modules().cpp_counter_module.current()` — the counter
           holds 8, reached entirely through the relay's Qt-free typed surface.
 
+      - title: "Stop the daemon"
+        run: "./logos/bin/logoscore stop"
+        code_block: "logoscore stop"
+      - run: "sleep 2"
+      - run: "./logos/bin/logoscore status || true"
+
   - title: "What just happened"
     text: |
       The relay's `modules().cpp_counter_module` wrapper, generated from the


### PR DESCRIPTION
## What

Add the standard `Stop the daemon` / `sleep` / `status` teardown to the
`cdylib-qt-free-outbound.test.yaml` doctest, matching the sibling
`cross-language-composition*` specs.

## Why

The "Qt-Free Outbound" spec started a logoscore daemon (`logoscore -D -m ./modules ... &`) but never stopped it, leaking the daemon past the end of the spec.

This was harmless until `logos-logoscore-cli` [#46](https://github.com/logos-co/logos-logoscore-cli/pull/46) added a guard that refuses to start a second daemon sharing a config dir. After that bump landed in the [nightly](https://github.com/logos-co/logos-workspace/actions/runs/27556359710), the next spec's `logoscore -D` exited non-zero — silently, because it's backgrounded with `&` — and that spec's commands hit the **leaked** daemon instead, which only knows this spec's modules.

Symptom in the nightly: `wrap-external-lib-1-source`'s `load-module greet_module` / `call greet_module hello` failed with

```json
{"code":"MODULE_LOAD_FAILED","known_modules":["cpp_relay_module","cpp_counter_module","capability_module"],...}
```

— `known_modules` is exactly *this* spec's module set.

## Notes

- A companion harness fix in `logos-doctest` isolates `LOGOSCORE_CONFIG_DIR` per spec so leaked daemons can never poison the next spec again; this spec fix is the focused correctness change.
- All module-builder daemon specs are now balanced (start ↔ stop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)