### PR TITLE
fix: Dev shell external lib paths

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -511,8 +511,9 @@ function(logos_module)
     # Handle external libraries
     foreach(ext_lib ${MODULE_EXTERNAL_LIBS})
         # Allow nix dev shell (or any caller) to point directly at a store path
-        # by exporting LOGOS_EXT_ROOT_<name>=/nix/store/…, skipping the ./lib/ staging copy.
-        set(_ext_root_var "LOGOS_EXT_ROOT_${ext_lib}")
+        # by exporting LOGOS_EXT_ROOT_<NAME>=/nix/store/…, skipping the ./lib/ staging copy.
+        string(TOUPPER "${ext_lib}" _ext_lib_upper)
+        set(_ext_root_var "LOGOS_EXT_ROOT_${_ext_lib_upper}")
         if(DEFINED ENV{${_ext_root_var}})
             set(EXT_LIB_DIR "$ENV{${_ext_root_var}}/lib")
             set(EXT_INCLUDE_DIR "$ENV{${_ext_root_var}}/include")

--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -510,21 +510,30 @@ function(logos_module)
 
     # Handle external libraries
     foreach(ext_lib ${MODULE_EXTERNAL_LIBS})
-        set(EXT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
-        
+        # Allow nix dev shell (or any caller) to point directly at a store path
+        # by exporting LOGOS_EXT_ROOT_<name>=/nix/store/…, skipping the ./lib/ staging copy.
+        set(_ext_root_var "LOGOS_EXT_ROOT_${ext_lib}")
+        if(DEFINED ENV{${_ext_root_var}})
+            set(EXT_LIB_DIR "$ENV{${_ext_root_var}}/lib")
+            set(EXT_INCLUDE_DIR "$ENV{${_ext_root_var}}/include")
+        else()
+            set(EXT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+            set(EXT_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+        endif()
+
         # Find the library (prefer shared, fall back to static)
         if(APPLE)
             set(EXT_LIB_NAMES lib${ext_lib}.dylib lib${ext_lib}.so ${ext_lib}.dylib ${ext_lib}.so lib${ext_lib}.a ${ext_lib}.a)
         else()
             set(EXT_LIB_NAMES lib${ext_lib}.so lib${ext_lib}.dylib ${ext_lib}.so ${ext_lib}.dylib lib${ext_lib}.a ${ext_lib}.a)
         endif()
-        
+
         find_library(${ext_lib}_PATH NAMES ${EXT_LIB_NAMES} PATHS ${EXT_LIB_DIR} NO_DEFAULT_PATH)
-        
+
         if(${ext_lib}_PATH)
             target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${${ext_lib}_PATH})
-            target_include_directories(${MODULE_NAME}_module_plugin PRIVATE ${EXT_LIB_DIR})
-            
+            target_include_directories(${MODULE_NAME}_module_plugin PRIVATE ${EXT_INCLUDE_DIR})
+
             # Copy shared libraries to output directory (static archives are linked in, no runtime copy needed)
             get_filename_component(EXT_LIB_FILENAME "${${ext_lib}_PATH}" NAME)
             if(NOT EXT_LIB_FILENAME MATCHES "\\.a$")

--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -512,6 +512,9 @@ function(logos_module)
     foreach(ext_lib ${MODULE_EXTERNAL_LIBS})
         # Allow nix dev shell (or any caller) to point directly at a store path
         # by exporting LOGOS_EXT_ROOT_<NAME>=/nix/store/…, skipping the ./lib/ staging copy.
+        # The expected format is a package root laid out as lib/+include/ (a Nix
+        # derivation), unlike the ./lib/ fallback, which is one flat directory
+        # holding both the library and its headers.
         string(TOUPPER "${ext_lib}" _ext_lib_upper)
         set(_ext_root_var "LOGOS_EXT_ROOT_${_ext_lib_upper}")
         if(DEFINED ENV{${_ext_root_var}})

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -638,7 +638,7 @@ let
       runtimePkgs = map (getPkg pkgs) config.nix_packages.runtime;
 
       # Resolve external lib inputs for this system so we can point cmake directly
-      # at their Nix store paths via LOGOS_EXT_ROOT_<name>, skipping the ./lib/ staging copy.
+      # at their Nix store paths via LOGOS_EXT_ROOT_<NAME>, skipping the ./lib/ staging copy.
       resolveExtInputDev = name: value:
         if builtins.isAttrs value && value ? input then
           let pkgName = (value.packages or {}).default or "default";
@@ -658,7 +658,7 @@ let
           export LOGOS_PROTOCOL_ROOT="${logos-protocol.packages.${system}.default}"
           ${lib.optionalString hasBuilderCmake ''export LOGOS_MODULE_BUILDER_ROOT="${builderRoot}"''}
           ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: drv: ''
-            export LOGOS_EXT_ROOT_${name}="${drv}"
+            export LOGOS_EXT_ROOT_${lib.toUpper name}="${drv}"
           '') devExternalLibs)}
           echo "Logos ${config.name} module development environment"
           echo "LOGOS_CPP_SDK_ROOT: $LOGOS_CPP_SDK_ROOT"

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -636,16 +636,30 @@ let
       backendShell = selectedBackend.devShellInputs pkgs { inherit logosModule; };
       buildPkgs = map (getPkg pkgs) config.nix_packages.build;
       runtimePkgs = map (getPkg pkgs) config.nix_packages.runtime;
+
+      # Resolve external lib inputs for this system so we can point cmake directly
+      # at their Nix store paths via LOGOS_EXT_ROOT_<name>, skipping the ./lib/ staging copy.
+      resolveExtInputDev = name: value:
+        if builtins.isAttrs value && value ? input then
+          let pkgName = (value.packages or {}).default or "default";
+          in value.input.packages.${system}.${pkgName} or null
+        else
+          value.packages.${system}.default or value;
+      devExternalLibs = lib.filterAttrs (_: v: v != null && lib.isDerivation v)
+        (lib.mapAttrs resolveExtInputDev externalLibInputs);
     in {
       default = pkgs.mkShell {
         nativeBuildInputs = backendShell.nativeBuildInputs ++ buildPkgs ++ [ logosSdk ];
-        buildInputs = backendShell.buildInputs ++ runtimePkgs;
+        buildInputs = backendShell.buildInputs ++ runtimePkgs ++ lib.attrValues devExternalLibs;
         shellHook = ''
           ${backendShell.shellHook}
           export LOGOS_CPP_SDK_ROOT="${logosSdk}"
           export LOGOS_QT_SDK_ROOT="${logos-qt-sdk.packages.${system}.default}"
           export LOGOS_PROTOCOL_ROOT="${logos-protocol.packages.${system}.default}"
           ${lib.optionalString hasBuilderCmake ''export LOGOS_MODULE_BUILDER_ROOT="${builderRoot}"''}
+          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: drv: ''
+            export LOGOS_EXT_ROOT_${name}="${drv}"
+          '') devExternalLibs)}
           echo "Logos ${config.name} module development environment"
           echo "LOGOS_CPP_SDK_ROOT: $LOGOS_CPP_SDK_ROOT"
           echo "LOGOS_MODULE_ROOT: $LOGOS_MODULE_ROOT"


### PR DESCRIPTION
## Summary

`nix develop` shells fail to configure modules that declare external libraries (e.g. logos_blockchain), because CMake only looks for them in `./lib/`, and that directory is only populated by the staging copy that nix build performs, a step the dev shell never runs. 

Since Nix already has the library built and available as a flake input, copying it into `./lib/` for the shell case is unnecessary; we can just point CMake at the existing store path directly.

## Fix

- `cmake/LogosModule.cmake`: each external lib now checks for `LOGOS_EXT_ROOT_<NAME>` and uses it as the `lib`/`include` dir, falling back to `./lib/` if unset. Note that the env var path needs separate `lib`/`include` dirs, since a Nix package layout splits `lib/` and `include/` into different subdirectories. The `./lib/` fallback is untouched: both vars still resolve to the same directory there, so existing (non-Nix-shell) behavior is unchanged.

- `lib/mkLogosModule.nix`: resolves each `externalLibInputs` entry to its derivation, adds it to `buildInputs`, and exports `LOGOS_EXT_ROOT_<NAME>` in the shellHook, reusing the already-built input instead of staging a copy.

## Testing

Verified against `logos-blockchain-module`: `nix develop` exports `LOGOS_EXT_ROOT_LOGOS_BLOCKCHAIN`, and `just configure`/`just build` both succeed with a properly linked plugin .so.