### PR TITLE
chore(nix): dedupe logos-nix with follows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,7 @@
     "default-container": {
       "inputs": {
         "logos-container": "logos-container",
-        "logos-nix": "logos-nix_13",
+        "logos-nix": "logos-nix_6",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -29,7 +29,7 @@
     "default-container_2": {
       "inputs": {
         "logos-container": "logos-container_6",
-        "logos-nix": "logos-nix_65",
+        "logos-nix": "logos-nix_58",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -62,7 +62,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_3",
         "logos-module": "logos-module_5",
         "logos-module-loader": "logos-module-loader",
-        "logos-nix": "logos-nix_18",
+        "logos-nix": "logos-nix_11",
         "logos-protocol": "logos-protocol_4",
         "logos-qt-sdk": "logos-qt-sdk_2",
         "nixpkgs": [
@@ -101,7 +101,7 @@
         ],
         "logos-module": "logos-module_18",
         "logos-module-loader": "logos-module-loader_3",
-        "logos-nix": "logos-nix_69",
+        "logos-nix": "logos-nix_62",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -254,7 +254,7 @@
     },
     "logos-container_2": {
       "inputs": {
-        "logos-nix": "logos-nix_14",
+        "logos-nix": "logos-nix_7",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -313,7 +313,7 @@
     },
     "logos-container_4": {
       "inputs": {
-        "logos-nix": "logos-nix_49",
+        "logos-nix": "logos-nix_42",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -408,7 +408,7 @@
     },
     "logos-container_7": {
       "inputs": {
-        "logos-nix": "logos-nix_66",
+        "logos-nix": "logos-nix_59",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -479,7 +479,7 @@
     },
     "logos-container_9": {
       "inputs": {
-        "logos-nix": "logos-nix_97",
+        "logos-nix": "logos-nix_90",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -509,7 +509,9 @@
     "logos-cpp-sdk": {
       "inputs": {
         "logos-lidl": "logos-lidl",
-        "logos-nix": "logos-nix",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-protocol"
         ],
@@ -581,7 +583,7 @@
     "logos-cpp-sdk_11": {
       "inputs": {
         "logos-lidl": "logos-lidl_34",
-        "logos-nix": "logos-nix_98",
+        "logos-nix": "logos-nix_91",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -729,7 +731,7 @@
     "logos-cpp-sdk_2": {
       "inputs": {
         "logos-lidl": "logos-lidl_6",
-        "logos-nix": "logos-nix_12",
+        "logos-nix": "logos-nix_5",
         "logos-protocol": "logos-protocol_3",
         "nixpkgs": [
           "logos-standalone-app",
@@ -755,7 +757,7 @@
     "logos-cpp-sdk_3": {
       "inputs": {
         "logos-lidl": "logos-lidl_7",
-        "logos-nix": "logos-nix_15",
+        "logos-nix": "logos-nix_8",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -788,7 +790,7 @@
     "logos-cpp-sdk_4": {
       "inputs": {
         "logos-lidl": "logos-lidl_9",
-        "logos-nix": "logos-nix_22",
+        "logos-nix": "logos-nix_15",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -860,7 +862,7 @@
     "logos-cpp-sdk_6": {
       "inputs": {
         "logos-lidl": "logos-lidl_18",
-        "logos-nix": "logos-nix_50",
+        "logos-nix": "logos-nix_43",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -891,7 +893,7 @@
     "logos-cpp-sdk_7": {
       "inputs": {
         "logos-lidl": "logos-lidl_19",
-        "logos-nix": "logos-nix_53",
+        "logos-nix": "logos-nix_46",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -926,7 +928,7 @@
     "logos-cpp-sdk_8": {
       "inputs": {
         "logos-lidl": "logos-lidl_24",
-        "logos-nix": "logos-nix_64",
+        "logos-nix": "logos-nix_57",
         "logos-protocol": "logos-protocol_12",
         "nixpkgs": [
           "logos-standalone-app",
@@ -956,7 +958,7 @@
     "logos-cpp-sdk_9": {
       "inputs": {
         "logos-lidl": "logos-lidl_25",
-        "logos-nix": "logos-nix_70",
+        "logos-nix": "logos-nix_63",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -998,7 +1000,9 @@
     },
     "logos-design-system": {
       "inputs": {
-        "logos-nix": "logos-nix_2",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "nix-bundle-appimage": "nix-bundle-appimage",
         "nix-bundle-dir": "nix-bundle-dir",
         "nix-bundle-macos-app": "nix-bundle-macos-app",
@@ -1024,7 +1028,7 @@
     },
     "logos-design-system_2": {
       "inputs": {
-        "logos-nix": "logos-nix_23",
+        "logos-nix": "logos-nix_16",
         "nix-bundle-appimage": "nix-bundle-appimage_2",
         "nix-bundle-dir": "nix-bundle-dir_2",
         "nix-bundle-macos-app": "nix-bundle-macos-app_2",
@@ -1054,7 +1058,7 @@
     },
     "logos-design-system_3": {
       "inputs": {
-        "logos-nix": "logos-nix_54",
+        "logos-nix": "logos-nix_47",
         "nix-bundle-appimage": "nix-bundle-appimage_4",
         "nix-bundle-dir": "nix-bundle-dir_7",
         "nix-bundle-macos-app": "nix-bundle-macos-app_3",
@@ -1084,7 +1088,7 @@
     },
     "logos-design-system_4": {
       "inputs": {
-        "logos-nix": "logos-nix_71",
+        "logos-nix": "logos-nix_64",
         "nix-bundle-appimage": "nix-bundle-appimage_5",
         "nix-bundle-dir": "nix-bundle-dir_8",
         "nix-bundle-macos-app": "nix-bundle-macos-app_4",
@@ -1126,7 +1130,7 @@
         "logos-module": "logos-module_13",
         "logos-module-loader": "logos-module-loader_2",
         "logos-modules-state-module": "logos-modules-state-module",
-        "logos-nix": "logos-nix_130",
+        "logos-nix": "logos-nix_123",
         "logos-package-manager": "logos-package-manager_5",
         "logos-plugin-qt": "logos-plugin-qt_18",
         "logos-protocol": "logos-protocol_23",
@@ -1162,7 +1166,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_11",
         "logos-module": "logos-module_25",
         "logos-module-loader": "logos-module-loader_4",
-        "logos-nix": "logos-nix_101",
+        "logos-nix": "logos-nix_94",
         "logos-package-manager": "logos-package-manager_3",
         "logos-plugin-qt": "logos-plugin-qt_14",
         "logos-protocol": "logos-protocol_17",
@@ -2895,7 +2899,9 @@
     },
     "logos-module": {
       "inputs": {
-        "logos-nix": "logos-nix_3",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-module",
           "logos-nix",
@@ -2921,7 +2927,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_4",
         "logos-design-system": "logos-design-system_2",
         "logos-module": "logos-module_7",
-        "logos-nix": "logos-nix_25",
+        "logos-nix": "logos-nix_18",
         "logos-plugin-core": "logos-plugin-core_2",
         "logos-plugin-qt": "logos-plugin-qt_4",
         "logos-protocol": "logos-protocol_5",
@@ -2966,7 +2972,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_7",
         "logos-design-system": "logos-design-system_3",
         "logos-module": "logos-module_14",
-        "logos-nix": "logos-nix_56",
+        "logos-nix": "logos-nix_49",
         "logos-plugin-core": "logos-plugin-core_3",
         "logos-plugin-qt": "logos-plugin-qt_8",
         "logos-protocol": "logos-protocol_10",
@@ -3007,7 +3013,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_9",
         "logos-design-system": "logos-design-system_4",
         "logos-module": "logos-module_19",
-        "logos-nix": "logos-nix_73",
+        "logos-nix": "logos-nix_66",
         "logos-plugin-core": "logos-plugin-core_4",
         "logos-plugin-qt": "logos-plugin-qt_10",
         "logos-protocol": "logos-protocol_13",
@@ -3058,7 +3064,7 @@
     "logos-module-loader": {
       "inputs": {
         "logos-container": "logos-container_3",
-        "logos-nix": "logos-nix_17",
+        "logos-nix": "logos-nix_10",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3085,7 +3091,7 @@
     "logos-module-loader_2": {
       "inputs": {
         "logos-container": "logos-container_5",
-        "logos-nix": "logos-nix_52",
+        "logos-nix": "logos-nix_45",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3111,7 +3117,7 @@
     "logos-module-loader_3": {
       "inputs": {
         "logos-container": "logos-container_8",
-        "logos-nix": "logos-nix_68",
+        "logos-nix": "logos-nix_61",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3142,7 +3148,7 @@
     "logos-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_10",
-        "logos-nix": "logos-nix_100",
+        "logos-nix": "logos-nix_93",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3171,7 +3177,7 @@
     },
     "logos-module_10": {
       "inputs": {
-        "logos-nix": "logos-nix_32",
+        "logos-nix": "logos-nix_25",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3200,7 +3206,7 @@
     },
     "logos-module_11": {
       "inputs": {
-        "logos-nix": "logos-nix_34",
+        "logos-nix": "logos-nix_27",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3229,7 +3235,7 @@
     },
     "logos-module_12": {
       "inputs": {
-        "logos-nix": "logos-nix_36",
+        "logos-nix": "logos-nix_29",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3258,7 +3264,7 @@
     },
     "logos-module_13": {
       "inputs": {
-        "logos-nix": "logos-nix_51",
+        "logos-nix": "logos-nix_44",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3283,7 +3289,7 @@
     },
     "logos-module_14": {
       "inputs": {
-        "logos-nix": "logos-nix_55",
+        "logos-nix": "logos-nix_48",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3310,7 +3316,7 @@
     },
     "logos-module_15": {
       "inputs": {
-        "logos-nix": "logos-nix_57",
+        "logos-nix": "logos-nix_50",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3338,7 +3344,7 @@
     },
     "logos-module_16": {
       "inputs": {
-        "logos-nix": "logos-nix_59",
+        "logos-nix": "logos-nix_52",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3366,7 +3372,7 @@
     },
     "logos-module_17": {
       "inputs": {
-        "logos-nix": "logos-nix_63",
+        "logos-nix": "logos-nix_56",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3395,7 +3401,7 @@
     },
     "logos-module_18": {
       "inputs": {
-        "logos-nix": "logos-nix_67",
+        "logos-nix": "logos-nix_60",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3425,7 +3431,7 @@
     },
     "logos-module_19": {
       "inputs": {
-        "logos-nix": "logos-nix_72",
+        "logos-nix": "logos-nix_65",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3456,7 +3462,7 @@
     },
     "logos-module_2": {
       "inputs": {
-        "logos-nix": "logos-nix_5",
+        "logos-nix": "logos-nix_2",
         "nixpkgs": [
           "logos-plugin-core",
           "logos-module",
@@ -3480,7 +3486,7 @@
     },
     "logos-module_20": {
       "inputs": {
-        "logos-nix": "logos-nix_74",
+        "logos-nix": "logos-nix_67",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3512,7 +3518,7 @@
     },
     "logos-module_21": {
       "inputs": {
-        "logos-nix": "logos-nix_76",
+        "logos-nix": "logos-nix_69",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3544,7 +3550,7 @@
     },
     "logos-module_22": {
       "inputs": {
-        "logos-nix": "logos-nix_80",
+        "logos-nix": "logos-nix_73",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3577,7 +3583,7 @@
     },
     "logos-module_23": {
       "inputs": {
-        "logos-nix": "logos-nix_82",
+        "logos-nix": "logos-nix_75",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3610,7 +3616,7 @@
     },
     "logos-module_24": {
       "inputs": {
-        "logos-nix": "logos-nix_84",
+        "logos-nix": "logos-nix_77",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3643,7 +3649,7 @@
     },
     "logos-module_25": {
       "inputs": {
-        "logos-nix": "logos-nix_99",
+        "logos-nix": "logos-nix_92",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3672,7 +3678,7 @@
     },
     "logos-module_26": {
       "inputs": {
-        "logos-nix": "logos-nix_107",
+        "logos-nix": "logos-nix_100",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3702,7 +3708,7 @@
     },
     "logos-module_27": {
       "inputs": {
-        "logos-nix": "logos-nix_112",
+        "logos-nix": "logos-nix_105",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3731,7 +3737,7 @@
     },
     "logos-module_28": {
       "inputs": {
-        "logos-nix": "logos-nix_115",
+        "logos-nix": "logos-nix_108",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3760,7 +3766,7 @@
     },
     "logos-module_29": {
       "inputs": {
-        "logos-nix": "logos-nix_117",
+        "logos-nix": "logos-nix_110",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3789,7 +3795,7 @@
     },
     "logos-module_3": {
       "inputs": {
-        "logos-nix": "logos-nix_7",
+        "logos-nix": "logos-nix_3",
         "nixpkgs": [
           "logos-plugin-qt",
           "logos-module",
@@ -3813,7 +3819,7 @@
     },
     "logos-module_30": {
       "inputs": {
-        "logos-nix": "logos-nix_136",
+        "logos-nix": "logos-nix_129",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3839,7 +3845,7 @@
     },
     "logos-module_31": {
       "inputs": {
-        "logos-nix": "logos-nix_140",
+        "logos-nix": "logos-nix_133",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3866,7 +3872,7 @@
     },
     "logos-module_32": {
       "inputs": {
-        "logos-nix": "logos-nix_143",
+        "logos-nix": "logos-nix_135",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -3891,7 +3897,7 @@
     },
     "logos-module_33": {
       "inputs": {
-        "logos-nix": "logos-nix_148",
+        "logos-nix": "logos-nix_139",
         "nixpkgs": [
           "logos-test-framework",
           "logos-plugin-qt",
@@ -3916,7 +3922,7 @@
     },
     "logos-module_34": {
       "inputs": {
-        "logos-nix": "logos-nix_150",
+        "logos-nix": "logos-nix_140",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -3941,7 +3947,7 @@
     },
     "logos-module_4": {
       "inputs": {
-        "logos-nix": "logos-nix_11",
+        "logos-nix": "logos-nix_4",
         "nixpkgs": [
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -3966,7 +3972,7 @@
     },
     "logos-module_5": {
       "inputs": {
-        "logos-nix": "logos-nix_16",
+        "logos-nix": "logos-nix_9",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -3992,7 +3998,7 @@
     },
     "logos-module_6": {
       "inputs": {
-        "logos-nix": "logos-nix_21",
+        "logos-nix": "logos-nix_14",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4020,7 +4026,7 @@
     },
     "logos-module_7": {
       "inputs": {
-        "logos-nix": "logos-nix_24",
+        "logos-nix": "logos-nix_17",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4047,7 +4053,7 @@
     },
     "logos-module_8": {
       "inputs": {
-        "logos-nix": "logos-nix_26",
+        "logos-nix": "logos-nix_19",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4075,7 +4081,7 @@
     },
     "logos-module_9": {
       "inputs": {
-        "logos-nix": "logos-nix_28",
+        "logos-nix": "logos-nix_21",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4125,11 +4131,11 @@
         "nixpkgs-windows": "nixpkgs-windows"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -4160,7 +4166,7 @@
     "logos-nix_100": {
       "inputs": {
         "nixpkgs": "nixpkgs_100",
-        "nixpkgs-windows": "nixpkgs-windows_96"
+        "nixpkgs-windows": "nixpkgs-windows_94"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4179,7 +4185,7 @@
     "logos-nix_101": {
       "inputs": {
         "nixpkgs": "nixpkgs_101",
-        "nixpkgs-windows": "nixpkgs-windows_97"
+        "nixpkgs-windows": "nixpkgs-windows_95"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4198,7 +4204,7 @@
     "logos-nix_102": {
       "inputs": {
         "nixpkgs": "nixpkgs_102",
-        "nixpkgs-windows": "nixpkgs-windows_98"
+        "nixpkgs-windows": "nixpkgs-windows_96"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4217,7 +4223,7 @@
     "logos-nix_103": {
       "inputs": {
         "nixpkgs": "nixpkgs_103",
-        "nixpkgs-windows": "nixpkgs-windows_99"
+        "nixpkgs-windows": "nixpkgs-windows_97"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4235,14 +4241,15 @@
     },
     "logos-nix_104": {
       "inputs": {
-        "nixpkgs": "nixpkgs_104"
+        "nixpkgs": "nixpkgs_104",
+        "nixpkgs-windows": "nixpkgs-windows_98"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -4253,26 +4260,8 @@
     },
     "logos-nix_105": {
       "inputs": {
-        "nixpkgs": "nixpkgs_105"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_106": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_106",
-        "nixpkgs-windows": "nixpkgs-windows_100"
+        "nixpkgs": "nixpkgs_105",
+        "nixpkgs-windows": "nixpkgs-windows_99"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4288,10 +4277,28 @@
         "type": "github"
       }
     },
+    "logos-nix_106": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_106"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_107": {
       "inputs": {
         "nixpkgs": "nixpkgs_107",
-        "nixpkgs-windows": "nixpkgs-windows_101"
+        "nixpkgs-windows": "nixpkgs-windows_100"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4310,7 +4317,7 @@
     "logos-nix_108": {
       "inputs": {
         "nixpkgs": "nixpkgs_108",
-        "nixpkgs-windows": "nixpkgs-windows_102"
+        "nixpkgs-windows": "nixpkgs-windows_101"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4329,7 +4336,7 @@
     "logos-nix_109": {
       "inputs": {
         "nixpkgs": "nixpkgs_109",
-        "nixpkgs-windows": "nixpkgs-windows_103"
+        "nixpkgs-windows": "nixpkgs-windows_102"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4351,11 +4358,11 @@
         "nixpkgs-windows": "nixpkgs-windows_11"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -4367,7 +4374,7 @@
     "logos-nix_110": {
       "inputs": {
         "nixpkgs": "nixpkgs_110",
-        "nixpkgs-windows": "nixpkgs-windows_104"
+        "nixpkgs-windows": "nixpkgs-windows_103"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4386,14 +4393,14 @@
     "logos-nix_111": {
       "inputs": {
         "nixpkgs": "nixpkgs_111",
-        "nixpkgs-windows": "nixpkgs-windows_105"
+        "nixpkgs-windows": "nixpkgs-windows_104"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -4405,7 +4412,7 @@
     "logos-nix_112": {
       "inputs": {
         "nixpkgs": "nixpkgs_112",
-        "nixpkgs-windows": "nixpkgs-windows_106"
+        "nixpkgs-windows": "nixpkgs-windows_105"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4423,14 +4430,15 @@
     },
     "logos-nix_113": {
       "inputs": {
-        "nixpkgs": "nixpkgs_113"
+        "nixpkgs": "nixpkgs_113",
+        "nixpkgs-windows": "nixpkgs-windows_106"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -4498,15 +4506,14 @@
     },
     "logos-nix_117": {
       "inputs": {
-        "nixpkgs": "nixpkgs_117",
-        "nixpkgs-windows": "nixpkgs-windows_110"
+        "nixpkgs": "nixpkgs_117"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -4517,15 +4524,14 @@
     },
     "logos-nix_118": {
       "inputs": {
-        "nixpkgs": "nixpkgs_118",
-        "nixpkgs-windows": "nixpkgs-windows_111"
+        "nixpkgs": "nixpkgs_118"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -4537,7 +4543,7 @@
     "logos-nix_119": {
       "inputs": {
         "nixpkgs": "nixpkgs_119",
-        "nixpkgs-windows": "nixpkgs-windows_112"
+        "nixpkgs-windows": "nixpkgs-windows_110"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4575,7 +4581,7 @@
     "logos-nix_120": {
       "inputs": {
         "nixpkgs": "nixpkgs_120",
-        "nixpkgs-windows": "nixpkgs-windows_113"
+        "nixpkgs-windows": "nixpkgs-windows_111"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4594,7 +4600,7 @@
     "logos-nix_121": {
       "inputs": {
         "nixpkgs": "nixpkgs_121",
-        "nixpkgs-windows": "nixpkgs-windows_114"
+        "nixpkgs-windows": "nixpkgs-windows_112"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4613,7 +4619,7 @@
     "logos-nix_122": {
       "inputs": {
         "nixpkgs": "nixpkgs_122",
-        "nixpkgs-windows": "nixpkgs-windows_115"
+        "nixpkgs-windows": "nixpkgs-windows_113"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4632,6 +4638,44 @@
     "logos-nix_123": {
       "inputs": {
         "nixpkgs": "nixpkgs_123",
+        "nixpkgs-windows": "nixpkgs-windows_114"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_124": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_124",
+        "nixpkgs-windows": "nixpkgs-windows_115"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_125": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_125",
         "nixpkgs-windows": "nixpkgs-windows_116"
       },
       "locked": {
@@ -4648,53 +4692,16 @@
         "type": "github"
       }
     },
-    "logos-nix_124": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_124"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_125": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_125"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_126": {
       "inputs": {
-        "nixpkgs": "nixpkgs_126",
-        "nixpkgs-windows": "nixpkgs-windows_117"
+        "nixpkgs": "nixpkgs_126"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -4705,15 +4712,14 @@
     },
     "logos-nix_127": {
       "inputs": {
-        "nixpkgs": "nixpkgs_127",
-        "nixpkgs-windows": "nixpkgs-windows_118"
+        "nixpkgs": "nixpkgs_127"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -4725,7 +4731,7 @@
     "logos-nix_128": {
       "inputs": {
         "nixpkgs": "nixpkgs_128",
-        "nixpkgs-windows": "nixpkgs-windows_119"
+        "nixpkgs-windows": "nixpkgs-windows_117"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4744,7 +4750,7 @@
     "logos-nix_129": {
       "inputs": {
         "nixpkgs": "nixpkgs_129",
-        "nixpkgs-windows": "nixpkgs-windows_120"
+        "nixpkgs-windows": "nixpkgs-windows_118"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4782,14 +4788,14 @@
     "logos-nix_130": {
       "inputs": {
         "nixpkgs": "nixpkgs_130",
-        "nixpkgs-windows": "nixpkgs-windows_121"
+        "nixpkgs-windows": "nixpkgs-windows_119"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -4801,14 +4807,14 @@
     "logos-nix_131": {
       "inputs": {
         "nixpkgs": "nixpkgs_131",
-        "nixpkgs-windows": "nixpkgs-windows_122"
+        "nixpkgs-windows": "nixpkgs-windows_120"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -4820,7 +4826,7 @@
     "logos-nix_132": {
       "inputs": {
         "nixpkgs": "nixpkgs_132",
-        "nixpkgs-windows": "nixpkgs-windows_123"
+        "nixpkgs-windows": "nixpkgs-windows_121"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4838,14 +4844,15 @@
     },
     "logos-nix_133": {
       "inputs": {
-        "nixpkgs": "nixpkgs_133"
+        "nixpkgs": "nixpkgs_133",
+        "nixpkgs-windows": "nixpkgs-windows_122"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -4856,14 +4863,15 @@
     },
     "logos-nix_134": {
       "inputs": {
-        "nixpkgs": "nixpkgs_134"
+        "nixpkgs": "nixpkgs_134",
+        "nixpkgs-windows": "nixpkgs-windows_123"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -4931,15 +4939,14 @@
     },
     "logos-nix_138": {
       "inputs": {
-        "nixpkgs": "nixpkgs_138",
-        "nixpkgs-windows": "nixpkgs-windows_127"
+        "nixpkgs": "nixpkgs_138"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -4951,7 +4958,7 @@
     "logos-nix_139": {
       "inputs": {
         "nixpkgs": "nixpkgs_139",
-        "nixpkgs-windows": "nixpkgs-windows_128"
+        "nixpkgs-windows": "nixpkgs-windows_127"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -4989,7 +4996,7 @@
     "logos-nix_140": {
       "inputs": {
         "nixpkgs": "nixpkgs_140",
-        "nixpkgs-windows": "nixpkgs-windows_129"
+        "nixpkgs-windows": "nixpkgs-windows_128"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5008,7 +5015,7 @@
     "logos-nix_141": {
       "inputs": {
         "nixpkgs": "nixpkgs_141",
-        "nixpkgs-windows": "nixpkgs-windows_130"
+        "nixpkgs-windows": "nixpkgs-windows_129"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5027,6 +5034,25 @@
     "logos-nix_142": {
       "inputs": {
         "nixpkgs": "nixpkgs_142",
+        "nixpkgs-windows": "nixpkgs-windows_130"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_143": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_143",
         "nixpkgs-windows": "nixpkgs-windows_131"
       },
       "locked": {
@@ -5043,29 +5069,10 @@
         "type": "github"
       }
     },
-    "logos-nix_143": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_143",
-        "nixpkgs-windows": "nixpkgs-windows_132"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_144": {
       "inputs": {
         "nixpkgs": "nixpkgs_144",
-        "nixpkgs-windows": "nixpkgs-windows_133"
+        "nixpkgs-windows": "nixpkgs-windows_132"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5083,15 +5090,14 @@
     },
     "logos-nix_145": {
       "inputs": {
-        "nixpkgs": "nixpkgs_145",
-        "nixpkgs-windows": "nixpkgs-windows_134"
+        "nixpkgs": "nixpkgs_145"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -5121,7 +5127,7 @@
     "logos-nix_147": {
       "inputs": {
         "nixpkgs": "nixpkgs_147",
-        "nixpkgs-windows": "nixpkgs-windows_135"
+        "nixpkgs-windows": "nixpkgs-windows_133"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5140,7 +5146,7 @@
     "logos-nix_148": {
       "inputs": {
         "nixpkgs": "nixpkgs_148",
-        "nixpkgs-windows": "nixpkgs-windows_136"
+        "nixpkgs-windows": "nixpkgs-windows_134"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5159,7 +5165,7 @@
     "logos-nix_149": {
       "inputs": {
         "nixpkgs": "nixpkgs_149",
-        "nixpkgs-windows": "nixpkgs-windows_137"
+        "nixpkgs-windows": "nixpkgs-windows_135"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5197,176 +5203,7 @@
     "logos-nix_150": {
       "inputs": {
         "nixpkgs": "nixpkgs_150",
-        "nixpkgs-windows": "nixpkgs-windows_138"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_151": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_151",
-        "nixpkgs-windows": "nixpkgs-windows_139"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_152": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_152",
-        "nixpkgs-windows": "nixpkgs-windows_140"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_153": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_153",
-        "nixpkgs-windows": "nixpkgs-windows_141"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_154": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_154",
-        "nixpkgs-windows": "nixpkgs-windows_142"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_155": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_155",
-        "nixpkgs-windows": "nixpkgs-windows_143"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_156": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_156",
-        "nixpkgs-windows": "nixpkgs-windows_144"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_157": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_157"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_158": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_158"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_159": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_159",
-        "nixpkgs-windows": "nixpkgs-windows_145"
+        "nixpkgs-windows": "nixpkgs-windows_136"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5386,63 +5223,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs_16",
         "nixpkgs-windows": "nixpkgs-windows_16"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_160": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_160",
-        "nixpkgs-windows": "nixpkgs-windows_146"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_161": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_161",
-        "nixpkgs-windows": "nixpkgs-windows_147"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_162": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_162",
-        "nixpkgs-windows": "nixpkgs-windows_148"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5635,11 +5415,11 @@
         "nixpkgs-windows": "nixpkgs-windows_25"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -5806,11 +5586,11 @@
         "nixpkgs-windows": "nixpkgs-windows_33"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -5825,11 +5605,11 @@
         "nixpkgs-windows": "nixpkgs-windows_34"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -5859,15 +5639,14 @@
     },
     "logos-nix_36": {
       "inputs": {
-        "nixpkgs": "nixpkgs_36",
-        "nixpkgs-windows": "nixpkgs-windows_36"
+        "nixpkgs": "nixpkgs_36"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -5878,15 +5657,14 @@
     },
     "logos-nix_37": {
       "inputs": {
-        "nixpkgs": "nixpkgs_37",
-        "nixpkgs-windows": "nixpkgs-windows_37"
+        "nixpkgs": "nixpkgs_37"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -5898,7 +5676,7 @@
     "logos-nix_38": {
       "inputs": {
         "nixpkgs": "nixpkgs_38",
-        "nixpkgs-windows": "nixpkgs-windows_38"
+        "nixpkgs-windows": "nixpkgs-windows_36"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5917,7 +5695,7 @@
     "logos-nix_39": {
       "inputs": {
         "nixpkgs": "nixpkgs_39",
-        "nixpkgs-windows": "nixpkgs-windows_39"
+        "nixpkgs-windows": "nixpkgs-windows_37"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -5939,11 +5717,11 @@
         "nixpkgs-windows": "nixpkgs-windows_4"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -5955,14 +5733,14 @@
     "logos-nix_40": {
       "inputs": {
         "nixpkgs": "nixpkgs_40",
-        "nixpkgs-windows": "nixpkgs-windows_40"
+        "nixpkgs-windows": "nixpkgs-windows_38"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -5974,14 +5752,14 @@
     "logos-nix_41": {
       "inputs": {
         "nixpkgs": "nixpkgs_41",
-        "nixpkgs-windows": "nixpkgs-windows_41"
+        "nixpkgs-windows": "nixpkgs-windows_39"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -5993,7 +5771,7 @@
     "logos-nix_42": {
       "inputs": {
         "nixpkgs": "nixpkgs_42",
-        "nixpkgs-windows": "nixpkgs-windows_42"
+        "nixpkgs-windows": "nixpkgs-windows_40"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -6011,14 +5789,15 @@
     },
     "logos-nix_43": {
       "inputs": {
-        "nixpkgs": "nixpkgs_43"
+        "nixpkgs": "nixpkgs_43",
+        "nixpkgs-windows": "nixpkgs-windows_41"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -6029,14 +5808,15 @@
     },
     "logos-nix_44": {
       "inputs": {
-        "nixpkgs": "nixpkgs_44"
+        "nixpkgs": "nixpkgs_44",
+        "nixpkgs-windows": "nixpkgs-windows_42"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -6412,11 +6192,11 @@
         "nixpkgs-windows": "nixpkgs-windows_60"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -6545,11 +6325,11 @@
         "nixpkgs-windows": "nixpkgs-windows_67"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -6864,15 +6644,14 @@
     },
     "logos-nix_84": {
       "inputs": {
-        "nixpkgs": "nixpkgs_84",
-        "nixpkgs-windows": "nixpkgs-windows_82"
+        "nixpkgs": "nixpkgs_84"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -6883,15 +6662,14 @@
     },
     "logos-nix_85": {
       "inputs": {
-        "nixpkgs": "nixpkgs_85",
-        "nixpkgs-windows": "nixpkgs-windows_83"
+        "nixpkgs": "nixpkgs_85"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -6903,7 +6681,7 @@
     "logos-nix_86": {
       "inputs": {
         "nixpkgs": "nixpkgs_86",
-        "nixpkgs-windows": "nixpkgs-windows_84"
+        "nixpkgs-windows": "nixpkgs-windows_82"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -6922,7 +6700,7 @@
     "logos-nix_87": {
       "inputs": {
         "nixpkgs": "nixpkgs_87",
-        "nixpkgs-windows": "nixpkgs-windows_85"
+        "nixpkgs-windows": "nixpkgs-windows_83"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -6941,7 +6719,7 @@
     "logos-nix_88": {
       "inputs": {
         "nixpkgs": "nixpkgs_88",
-        "nixpkgs-windows": "nixpkgs-windows_86"
+        "nixpkgs-windows": "nixpkgs-windows_84"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -6960,7 +6738,7 @@
     "logos-nix_89": {
       "inputs": {
         "nixpkgs": "nixpkgs_89",
-        "nixpkgs-windows": "nixpkgs-windows_87"
+        "nixpkgs-windows": "nixpkgs-windows_85"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -6998,7 +6776,7 @@
     "logos-nix_90": {
       "inputs": {
         "nixpkgs": "nixpkgs_90",
-        "nixpkgs-windows": "nixpkgs-windows_88"
+        "nixpkgs-windows": "nixpkgs-windows_86"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -7016,14 +6794,15 @@
     },
     "logos-nix_91": {
       "inputs": {
-        "nixpkgs": "nixpkgs_91"
+        "nixpkgs": "nixpkgs_91",
+        "nixpkgs-windows": "nixpkgs-windows_87"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -7034,14 +6813,15 @@
     },
     "logos-nix_92": {
       "inputs": {
-        "nixpkgs": "nixpkgs_92"
+        "nixpkgs": "nixpkgs_92",
+        "nixpkgs-windows": "nixpkgs-windows_88"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -7128,15 +6908,14 @@
     },
     "logos-nix_97": {
       "inputs": {
-        "nixpkgs": "nixpkgs_97",
-        "nixpkgs-windows": "nixpkgs-windows_93"
+        "nixpkgs": "nixpkgs_97"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -7147,15 +6926,14 @@
     },
     "logos-nix_98": {
       "inputs": {
-        "nixpkgs": "nixpkgs_98",
-        "nixpkgs-windows": "nixpkgs-windows_94"
+        "nixpkgs": "nixpkgs_98"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -7167,7 +6945,7 @@
     "logos-nix_99": {
       "inputs": {
         "nixpkgs": "nixpkgs_99",
-        "nixpkgs-windows": "nixpkgs-windows_95"
+        "nixpkgs-windows": "nixpkgs-windows_93"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -7185,7 +6963,7 @@
     },
     "logos-package": {
       "inputs": {
-        "logos-nix": "logos-nix_38",
+        "logos-nix": "logos-nix_31",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7213,7 +6991,7 @@
     },
     "logos-package-manager": {
       "inputs": {
-        "logos-nix": "logos-nix_41",
+        "logos-nix": "logos-nix_34",
         "logos-package": "logos-package_2",
         "nix-bundle-appimage": "nix-bundle-appimage_3",
         "nix-bundle-dir": "nix-bundle-dir_5",
@@ -7244,7 +7022,7 @@
     },
     "logos-package-manager_2": {
       "inputs": {
-        "logos-nix": "logos-nix_89",
+        "logos-nix": "logos-nix_82",
         "logos-package": "logos-package_5",
         "nix-bundle-appimage": "nix-bundle-appimage_6",
         "nix-bundle-dir": "nix-bundle-dir_11",
@@ -7279,7 +7057,7 @@
     },
     "logos-package-manager_3": {
       "inputs": {
-        "logos-nix": "logos-nix_102",
+        "logos-nix": "logos-nix_95",
         "logos-package": "logos-package_7",
         "nix-bundle-appimage": "nix-bundle-appimage_7",
         "nix-bundle-dir": "nix-bundle-dir_14",
@@ -7311,7 +7089,7 @@
     },
     "logos-package-manager_4": {
       "inputs": {
-        "logos-nix": "logos-nix_122",
+        "logos-nix": "logos-nix_115",
         "logos-package": "logos-package_9",
         "nix-bundle-appimage": "nix-bundle-appimage_8",
         "nix-bundle-dir": "nix-bundle-dir_17",
@@ -7342,7 +7120,7 @@
     },
     "logos-package-manager_5": {
       "inputs": {
-        "logos-nix": "logos-nix_131",
+        "logos-nix": "logos-nix_124",
         "logos-package": "logos-package_11",
         "nix-bundle-appimage": "nix-bundle-appimage_9",
         "nix-bundle-dir": "nix-bundle-dir_20",
@@ -7370,7 +7148,7 @@
     },
     "logos-package-manager_6": {
       "inputs": {
-        "logos-nix": "logos-nix_155",
+        "logos-nix": "logos-nix_143",
         "logos-package": "logos-package_13",
         "nix-bundle-appimage": "nix-bundle-appimage_10",
         "nix-bundle-dir": "nix-bundle-dir_23",
@@ -7397,7 +7175,7 @@
     },
     "logos-package_10": {
       "inputs": {
-        "logos-nix": "logos-nix_128",
+        "logos-nix": "logos-nix_121",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7426,7 +7204,7 @@
     },
     "logos-package_11": {
       "inputs": {
-        "logos-nix": "logos-nix_132",
+        "logos-nix": "logos-nix_125",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7452,7 +7230,7 @@
     },
     "logos-package_12": {
       "inputs": {
-        "logos-nix": "logos-nix_152",
+        "logos-nix": "logos-nix_141",
         "nixpkgs": [
           "nix-bundle-lgx",
           "logos-package",
@@ -7476,7 +7254,7 @@
     },
     "logos-package_13": {
       "inputs": {
-        "logos-nix": "logos-nix_156",
+        "logos-nix": "logos-nix_144",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -7501,7 +7279,7 @@
     },
     "logos-package_14": {
       "inputs": {
-        "logos-nix": "logos-nix_161",
+        "logos-nix": "logos-nix_149",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -7526,7 +7304,7 @@
     },
     "logos-package_2": {
       "inputs": {
-        "logos-nix": "logos-nix_42",
+        "logos-nix": "logos-nix_35",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7555,7 +7333,7 @@
     },
     "logos-package_3": {
       "inputs": {
-        "logos-nix": "logos-nix_47",
+        "logos-nix": "logos-nix_40",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7584,7 +7362,7 @@
     },
     "logos-package_4": {
       "inputs": {
-        "logos-nix": "logos-nix_86",
+        "logos-nix": "logos-nix_79",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7616,7 +7394,7 @@
     },
     "logos-package_5": {
       "inputs": {
-        "logos-nix": "logos-nix_90",
+        "logos-nix": "logos-nix_83",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7649,7 +7427,7 @@
     },
     "logos-package_6": {
       "inputs": {
-        "logos-nix": "logos-nix_95",
+        "logos-nix": "logos-nix_88",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7682,7 +7460,7 @@
     },
     "logos-package_7": {
       "inputs": {
-        "logos-nix": "logos-nix_103",
+        "logos-nix": "logos-nix_96",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7712,7 +7490,7 @@
     },
     "logos-package_8": {
       "inputs": {
-        "logos-nix": "logos-nix_119",
+        "logos-nix": "logos-nix_112",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7740,7 +7518,7 @@
     },
     "logos-package_9": {
       "inputs": {
-        "logos-nix": "logos-nix_123",
+        "logos-nix": "logos-nix_116",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7771,7 +7549,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_2",
         "logos-module": "logos-module_2",
-        "logos-nix": "logos-nix_6",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-protocol"
         ],
@@ -7799,7 +7579,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_10",
         "logos-module": "logos-module_8",
-        "logos-nix": "logos-nix_27",
+        "logos-nix": "logos-nix_20",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7835,7 +7615,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_20",
         "logos-module": "logos-module_15",
-        "logos-nix": "logos-nix_58",
+        "logos-nix": "logos-nix_51",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7871,7 +7651,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_26",
         "logos-module": "logos-module_20",
-        "logos-nix": "logos-nix_75",
+        "logos-nix": "logos-nix_68",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -7915,7 +7695,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_3",
         "logos-module": "logos-module_3",
-        "logos-nix": "logos-nix_8",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-protocol"
         ],
@@ -7943,7 +7725,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_27",
         "logos-module": "logos-module_21",
-        "logos-nix": "logos-nix_77",
+        "logos-nix": "logos-nix_70",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -8340,7 +8122,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_42",
         "logos-module": "logos-module_30",
-        "logos-nix": "logos-nix_137",
+        "logos-nix": "logos-nix_130",
         "logos-protocol": "logos-protocol_22",
         "nixpkgs": [
           "logos-standalone-app",
@@ -8448,7 +8230,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_44",
         "logos-module": "logos-module_32",
-        "logos-nix": "logos-nix_144",
+        "logos-nix": "logos-nix_136",
         "logos-protocol": "logos-protocol_25",
         "nixpkgs": [
           "logos-standalone-app",
@@ -8585,7 +8367,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_11",
         "logos-module": "logos-module_9",
-        "logos-nix": "logos-nix_29",
+        "logos-nix": "logos-nix_22",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -8759,7 +8541,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_21",
         "logos-module": "logos-module_16",
-        "logos-nix": "logos-nix_60",
+        "logos-nix": "logos-nix_53",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -8845,7 +8627,9 @@
     },
     "logos-protocol": {
       "inputs": {
-        "logos-nix": "logos-nix_9",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-protocol",
           "logos-nix",
@@ -8868,7 +8652,7 @@
     },
     "logos-protocol_10": {
       "inputs": {
-        "logos-nix": "logos-nix_61",
+        "logos-nix": "logos-nix_54",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -8967,7 +8751,7 @@
     },
     "logos-protocol_13": {
       "inputs": {
-        "logos-nix": "logos-nix_78",
+        "logos-nix": "logos-nix_71",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -9125,7 +8909,7 @@
     },
     "logos-protocol_17": {
       "inputs": {
-        "logos-nix": "logos-nix_108",
+        "logos-nix": "logos-nix_101",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -9348,7 +9132,7 @@
     },
     "logos-protocol_23": {
       "inputs": {
-        "logos-nix": "logos-nix_138",
+        "logos-nix": "logos-nix_131",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -9433,7 +9217,7 @@
     },
     "logos-protocol_26": {
       "inputs": {
-        "logos-nix": "logos-nix_145",
+        "logos-nix": "logos-nix_137",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-protocol",
@@ -9565,7 +9349,7 @@
     },
     "logos-protocol_4": {
       "inputs": {
-        "logos-nix": "logos-nix_19",
+        "logos-nix": "logos-nix_12",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -9591,7 +9375,7 @@
     },
     "logos-protocol_5": {
       "inputs": {
-        "logos-nix": "logos-nix_30",
+        "logos-nix": "logos-nix_23",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -9756,7 +9540,7 @@
     },
     "logos-qt-mcp": {
       "inputs": {
-        "logos-nix": "logos-nix_113",
+        "logos-nix": "logos-nix_106",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -9784,7 +9568,7 @@
     },
     "logos-qt-mcp_2": {
       "inputs": {
-        "logos-nix": "logos-nix_146",
+        "logos-nix": "logos-nix_138",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -9812,7 +9596,9 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_4",
-        "logos-nix": "logos-nix_10",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-plugin-qt": "logos-plugin-qt_2",
         "logos-protocol": [
           "logos-protocol"
@@ -9841,7 +9627,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_13",
         "logos-lidl": "logos-lidl_43",
-        "logos-nix": "logos-nix_139",
+        "logos-nix": "logos-nix_132",
         "logos-plugin-qt": "logos-plugin-qt_19",
         "logos-protocol": "logos-protocol_24",
         "nixpkgs": [
@@ -9913,7 +9699,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_8",
-        "logos-nix": "logos-nix_20",
+        "logos-nix": "logos-nix_13",
         "logos-plugin-qt": "logos-plugin-qt_3",
         "logos-protocol": [
           "logos-standalone-app",
@@ -9954,7 +9740,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_12",
-        "logos-nix": "logos-nix_31",
+        "logos-nix": "logos-nix_24",
         "logos-plugin-qt": "logos-plugin-qt_5",
         "logos-protocol": [
           "logos-standalone-app",
@@ -10055,7 +9841,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_22",
-        "logos-nix": "logos-nix_62",
+        "logos-nix": "logos-nix_55",
         "logos-plugin-qt": "logos-plugin-qt_9",
         "logos-protocol": [
           "logos-standalone-app",
@@ -10102,7 +9888,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_28",
-        "logos-nix": "logos-nix_79",
+        "logos-nix": "logos-nix_72",
         "logos-plugin-qt": "logos-plugin-qt_11",
         "logos-protocol": [
           "logos-standalone-app",
@@ -10233,7 +10019,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_36",
-        "logos-nix": "logos-nix_109",
+        "logos-nix": "logos-nix_102",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -10529,7 +10315,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos",
-        "logos-nix": "logos-nix_142",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-plugin-qt": "logos-plugin-qt_20",
         "logos-protocol": "logos-protocol_26",
         "logos-qt-mcp": "logos-qt-mcp_2",
@@ -10567,7 +10355,7 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_2",
-        "logos-nix": "logos-nix_111",
+        "logos-nix": "logos-nix_104",
         "logos-plugin-qt": "logos-plugin-qt_15",
         "logos-protocol": "logos-protocol_18",
         "logos-qt-mcp": "logos-qt-mcp",
@@ -10611,7 +10399,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_33",
+        "logos-nix": "logos-nix_26",
         "logos-plugin-qt": "logos-plugin-qt_6",
         "logos-protocol": "logos-protocol_7",
         "logos-qt-sdk": "logos-qt-sdk_4",
@@ -10652,7 +10440,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_81",
+        "logos-nix": "logos-nix_74",
         "logos-plugin-qt": "logos-plugin-qt_12",
         "logos-protocol": "logos-protocol_14",
         "logos-qt-sdk": "logos-qt-sdk_7",
@@ -10693,7 +10481,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_114",
+        "logos-nix": "logos-nix_107",
         "logos-plugin-qt": "logos-plugin-qt_16",
         "logos-protocol": "logos-protocol_19",
         "logos-qt-sdk": "logos-qt-sdk_9",
@@ -10726,7 +10514,9 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_147",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-plugin-qt": "logos-plugin-qt_21",
         "logos-protocol": "logos-protocol_27",
         "logos-qt-sdk": "logos-qt-sdk_11",
@@ -10786,7 +10576,7 @@
     "logos-view-module-runtime": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_5",
-        "logos-nix": "logos-nix_35",
+        "logos-nix": "logos-nix_28",
         "logos-plugin-qt": "logos-plugin-qt_7",
         "logos-protocol": "logos-protocol_9",
         "nixpkgs": [
@@ -10816,7 +10606,7 @@
     "logos-view-module-runtime_2": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_10",
-        "logos-nix": "logos-nix_83",
+        "logos-nix": "logos-nix_76",
         "logos-plugin-qt": "logos-plugin-qt_13",
         "logos-protocol": "logos-protocol_16",
         "nixpkgs": [
@@ -10850,7 +10640,7 @@
     "logos-view-module-runtime_3": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_12",
-        "logos-nix": "logos-nix_116",
+        "logos-nix": "logos-nix_109",
         "logos-plugin-qt": "logos-plugin-qt_17",
         "logos-protocol": "logos-protocol_21",
         "nixpkgs": [
@@ -10880,7 +10670,9 @@
     "logos-view-module-runtime_4": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_14",
-        "logos-nix": "logos-nix_149",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-plugin-qt": "logos-plugin-qt_22",
         "logos-protocol": "logos-protocol_29",
         "nixpkgs": [
@@ -11033,7 +10825,7 @@
     },
     "nix-bundle-appimage_10": {
       "inputs": {
-        "logos-nix": "logos-nix_157",
+        "logos-nix": "logos-nix_145",
         "nix-bundle-dir": "nix-bundle-dir_22",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -11100,7 +10892,7 @@
     },
     "nix-bundle-appimage_3": {
       "inputs": {
-        "logos-nix": "logos-nix_43",
+        "logos-nix": "logos-nix_36",
         "nix-bundle-dir": "nix-bundle-dir_4",
         "nixpkgs": [
           "logos-standalone-app",
@@ -11224,7 +11016,7 @@
     },
     "nix-bundle-appimage_6": {
       "inputs": {
-        "logos-nix": "logos-nix_91",
+        "logos-nix": "logos-nix_84",
         "nix-bundle-dir": "nix-bundle-dir_10",
         "nixpkgs": [
           "logos-standalone-app",
@@ -11258,7 +11050,7 @@
     },
     "nix-bundle-appimage_7": {
       "inputs": {
-        "logos-nix": "logos-nix_104",
+        "logos-nix": "logos-nix_97",
         "nix-bundle-dir": "nix-bundle-dir_13",
         "nixpkgs": [
           "logos-standalone-app",
@@ -11289,7 +11081,7 @@
     },
     "nix-bundle-appimage_8": {
       "inputs": {
-        "logos-nix": "logos-nix_124",
+        "logos-nix": "logos-nix_117",
         "nix-bundle-dir": "nix-bundle-dir_16",
         "nixpkgs": [
           "logos-standalone-app",
@@ -11319,7 +11111,7 @@
     },
     "nix-bundle-appimage_9": {
       "inputs": {
-        "logos-nix": "logos-nix_133",
+        "logos-nix": "logos-nix_126",
         "nix-bundle-dir": "nix-bundle-dir_19",
         "nixpkgs": [
           "logos-standalone-app",
@@ -11371,7 +11163,7 @@
     },
     "nix-bundle-dir_10": {
       "inputs": {
-        "logos-nix": "logos-nix_92",
+        "logos-nix": "logos-nix_85",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11403,7 +11195,7 @@
     },
     "nix-bundle-dir_11": {
       "inputs": {
-        "logos-nix": "logos-nix_93",
+        "logos-nix": "logos-nix_86",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11436,7 +11228,7 @@
     },
     "nix-bundle-dir_12": {
       "inputs": {
-        "logos-nix": "logos-nix_96",
+        "logos-nix": "logos-nix_89",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11469,7 +11261,7 @@
     },
     "nix-bundle-dir_13": {
       "inputs": {
-        "logos-nix": "logos-nix_105",
+        "logos-nix": "logos-nix_98",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11498,7 +11290,7 @@
     },
     "nix-bundle-dir_14": {
       "inputs": {
-        "logos-nix": "logos-nix_106",
+        "logos-nix": "logos-nix_99",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11528,7 +11320,7 @@
     },
     "nix-bundle-dir_15": {
       "inputs": {
-        "logos-nix": "logos-nix_120",
+        "logos-nix": "logos-nix_113",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11556,7 +11348,7 @@
     },
     "nix-bundle-dir_16": {
       "inputs": {
-        "logos-nix": "logos-nix_125",
+        "logos-nix": "logos-nix_118",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11584,7 +11376,7 @@
     },
     "nix-bundle-dir_17": {
       "inputs": {
-        "logos-nix": "logos-nix_126",
+        "logos-nix": "logos-nix_119",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11613,7 +11405,7 @@
     },
     "nix-bundle-dir_18": {
       "inputs": {
-        "logos-nix": "logos-nix_129",
+        "logos-nix": "logos-nix_122",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11642,7 +11434,7 @@
     },
     "nix-bundle-dir_19": {
       "inputs": {
-        "logos-nix": "logos-nix_134",
+        "logos-nix": "logos-nix_127",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11700,7 +11492,7 @@
     },
     "nix-bundle-dir_20": {
       "inputs": {
-        "logos-nix": "logos-nix_135",
+        "logos-nix": "logos-nix_128",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11726,7 +11518,7 @@
     },
     "nix-bundle-dir_21": {
       "inputs": {
-        "logos-nix": "logos-nix_153",
+        "logos-nix": "logos-nix_142",
         "nixpkgs": [
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -11750,7 +11542,7 @@
     },
     "nix-bundle-dir_22": {
       "inputs": {
-        "logos-nix": "logos-nix_158",
+        "logos-nix": "logos-nix_146",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -11774,7 +11566,7 @@
     },
     "nix-bundle-dir_23": {
       "inputs": {
-        "logos-nix": "logos-nix_159",
+        "logos-nix": "logos-nix_147",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -11799,7 +11591,7 @@
     },
     "nix-bundle-dir_24": {
       "inputs": {
-        "logos-nix": "logos-nix_162",
+        "logos-nix": "logos-nix_150",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -11824,7 +11616,7 @@
     },
     "nix-bundle-dir_3": {
       "inputs": {
-        "logos-nix": "logos-nix_39",
+        "logos-nix": "logos-nix_32",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11852,7 +11644,7 @@
     },
     "nix-bundle-dir_4": {
       "inputs": {
-        "logos-nix": "logos-nix_44",
+        "logos-nix": "logos-nix_37",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11880,7 +11672,7 @@
     },
     "nix-bundle-dir_5": {
       "inputs": {
-        "logos-nix": "logos-nix_45",
+        "logos-nix": "logos-nix_38",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -11909,7 +11701,7 @@
     },
     "nix-bundle-dir_6": {
       "inputs": {
-        "logos-nix": "logos-nix_48",
+        "logos-nix": "logos-nix_41",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -12012,7 +11804,7 @@
     },
     "nix-bundle-dir_9": {
       "inputs": {
-        "logos-nix": "logos-nix_87",
+        "logos-nix": "logos-nix_80",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -12044,7 +11836,7 @@
     },
     "nix-bundle-lgx": {
       "inputs": {
-        "logos-nix": "logos-nix_37",
+        "logos-nix": "logos-nix_30",
         "logos-package": "logos-package",
         "nix-bundle-dir": "nix-bundle-dir_3",
         "nixpkgs": [
@@ -12073,7 +11865,7 @@
     },
     "nix-bundle-lgx_2": {
       "inputs": {
-        "logos-nix": "logos-nix_46",
+        "logos-nix": "logos-nix_39",
         "logos-package": "logos-package_3",
         "nix-bundle-dir": "nix-bundle-dir_6",
         "nixpkgs": [
@@ -12103,7 +11895,7 @@
     },
     "nix-bundle-lgx_3": {
       "inputs": {
-        "logos-nix": "logos-nix_85",
+        "logos-nix": "logos-nix_78",
         "logos-package": "logos-package_4",
         "nix-bundle-dir": "nix-bundle-dir_9",
         "nixpkgs": [
@@ -12136,7 +11928,7 @@
     },
     "nix-bundle-lgx_4": {
       "inputs": {
-        "logos-nix": "logos-nix_94",
+        "logos-nix": "logos-nix_87",
         "logos-package": "logos-package_6",
         "nix-bundle-dir": "nix-bundle-dir_12",
         "nixpkgs": [
@@ -12170,7 +11962,7 @@
     },
     "nix-bundle-lgx_5": {
       "inputs": {
-        "logos-nix": "logos-nix_118",
+        "logos-nix": "logos-nix_111",
         "logos-package": "logos-package_8",
         "nix-bundle-dir": "nix-bundle-dir_15",
         "nixpkgs": [
@@ -12199,7 +11991,7 @@
     },
     "nix-bundle-lgx_6": {
       "inputs": {
-        "logos-nix": "logos-nix_127",
+        "logos-nix": "logos-nix_120",
         "logos-package": "logos-package_10",
         "nix-bundle-dir": "nix-bundle-dir_18",
         "nixpkgs": [
@@ -12229,7 +12021,9 @@
     },
     "nix-bundle-lgx_7": {
       "inputs": {
-        "logos-nix": "logos-nix_151",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-package": "logos-package_12",
         "nix-bundle-dir": "nix-bundle-dir_21",
         "nixpkgs": [
@@ -12254,7 +12048,7 @@
     },
     "nix-bundle-lgx_8": {
       "inputs": {
-        "logos-nix": "logos-nix_160",
+        "logos-nix": "logos-nix_148",
         "logos-package": "logos-package_14",
         "nix-bundle-dir": "nix-bundle-dir_24",
         "nixpkgs": [
@@ -12280,7 +12074,7 @@
     },
     "nix-bundle-logos-module-install": {
       "inputs": {
-        "logos-nix": "logos-nix_40",
+        "logos-nix": "logos-nix_33",
         "logos-package-manager": "logos-package-manager",
         "nix-bundle-lgx": "nix-bundle-lgx_2",
         "nixpkgs": [
@@ -12309,7 +12103,7 @@
     },
     "nix-bundle-logos-module-install_2": {
       "inputs": {
-        "logos-nix": "logos-nix_88",
+        "logos-nix": "logos-nix_81",
         "logos-package-manager": "logos-package-manager_2",
         "nix-bundle-lgx": "nix-bundle-lgx_4",
         "nixpkgs": [
@@ -12342,7 +12136,7 @@
     },
     "nix-bundle-logos-module-install_3": {
       "inputs": {
-        "logos-nix": "logos-nix_121",
+        "logos-nix": "logos-nix_114",
         "logos-package-manager": "logos-package-manager_4",
         "nix-bundle-lgx": "nix-bundle-lgx_6",
         "nixpkgs": [
@@ -12371,7 +12165,9 @@
     },
     "nix-bundle-logos-module-install_4": {
       "inputs": {
-        "logos-nix": "logos-nix_154",
+        "logos-nix": [
+          "logos-nix"
+        ],
         "logos-package-manager": "logos-package-manager_6",
         "nix-bundle-lgx": "nix-bundle-lgx_8",
         "nixpkgs": [
@@ -13246,199 +13042,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-windows_137": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_138": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_139": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
     "nixpkgs-windows_14": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_140": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_141": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_142": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_143": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_144": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_145": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_146": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_147": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_148": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -15854,199 +15458,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_151": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_152": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_153": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_154": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_155": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_156": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_157": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_158": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_159": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_16": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_160": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_161": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_162": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -17520,7 +16932,7 @@
     },
     "process-stats": {
       "inputs": {
-        "logos-nix": "logos-nix_110",
+        "logos-nix": "logos-nix_103",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -17549,7 +16961,7 @@
     },
     "process-stats_2": {
       "inputs": {
-        "logos-nix": "logos-nix_141",
+        "logos-nix": "logos-nix_134",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -17577,7 +16989,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk",
         "logos-design-system": "logos-design-system",
         "logos-module": "logos-module",
-        "logos-nix": "logos-nix_4",
+        "logos-nix": "logos-nix",
         "logos-plugin-core": "logos-plugin-core",
         "logos-plugin-qt": "logos-plugin-qt",
         "logos-protocol": "logos-protocol",

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
     # correctly false — ancestry is the wrong test, the files are the test.
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-cpp-sdk.inputs.logos-protocol.follows = "logos-protocol";
+    logos-cpp-sdk.inputs.logos-nix.follows = "logos-nix";
     # Protocol layer (transports + lp_* C ABI + the protocol semver every
     # module gets stamped with) and the Qt developer layer modules link.
     #
@@ -35,6 +36,7 @@
     # now the right thing for the whole closure to land on. NOTE: SQUASH-merged,
     # so ancestry of c8bab12 in master is correctly false — check the files.
     logos-protocol.url = "github:logos-co/logos-protocol";
+    logos-protocol.inputs.logos-nix.follows = "logos-nix";
     # Unpinned: feat/sdk-codegen-b3-d11 merged (logos-qt-sdk#33), so the header
     # this builder probes and the logos-qt-generator it takes are both on master
     # in their B3 shape. Also SQUASH-merged — ancestry of aca2951 in master is
@@ -48,7 +50,9 @@
     logos-qt-sdk.url = "github:logos-co/logos-qt-sdk";
     logos-qt-sdk.inputs.logos-protocol.follows = "logos-protocol";
     logos-qt-sdk.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
+    logos-qt-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-module.url = "github:logos-co/logos-module";
+    logos-module.inputs.logos-nix.follows = "logos-nix";
     # UI modules (type: ui, ui_qml) always use Qt.
     #
     # This backend also owns the Qt HOST RUNTIME every plugin links
@@ -79,6 +83,7 @@
     # lives in THIS repo, so the builder never reads cmake/ from this backend.
     logos-plugin-qt.url = "github:logos-co/logos-plugin-qt";
     logos-plugin-qt.inputs.logos-protocol.follows = "logos-protocol";
+    logos-plugin-qt.inputs.logos-nix.follows = "logos-nix";
     # Core modules (type: core) use this backend — defaults to Qt, swappable
     # later. It MUST stay on the same rev as logos-plugin-qt above: the two
     # inputs are selected per module TYPE, they both carry the Qt host runtime,
@@ -87,13 +92,17 @@
     # logos-plugin-qt above now that logos-plugin-qt#19 has merged.
     logos-plugin-core.url = "github:logos-co/logos-plugin-qt";
     logos-plugin-core.inputs.logos-protocol.follows = "logos-protocol";
+    logos-plugin-core.inputs.logos-nix.follows = "logos-nix";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
+    nix-bundle-lgx.inputs.logos-nix.follows = "logos-nix";
     nix-bundle-logos-module-install.url = "github:logos-co/nix-bundle-logos-module-install";
+    nix-bundle-logos-module-install.inputs.logos-nix.follows = "logos-nix";
     # Host shell used by `nix run` / integration tests for ui_qml modules.
     # Design system + view-module-runtime are pinned HERE (not only inside
     # standalone's lock) so a bump for module testing is one lock update on
     # this flake — no standalone release required.
     logos-design-system.url = "github:logos-co/logos-design-system";
+    logos-design-system.inputs.logos-nix.follows = "logos-nix";
     # Rev-pinned: `view-interface-abi` below reads this runtime's HOST-side
     # declaration of the view plugin interfaces and diffs it against the
     # module-side templates from logos-view-module. Both sides moved to the
@@ -103,6 +112,7 @@
     # the qt-host repoint and no longer rev-pins logos-plugin-qt itself — the two
     # sides of the ABI check are back in step on master.
     logos-view-module-runtime.url = "github:logos-co/logos-view-module-runtime";
+    logos-view-module-runtime.inputs.logos-nix.follows = "logos-nix";
     # The MODULE side of that same pair, and the ui_qml authoring flavour as a
     # whole: LogosViewModule.cmake, the four LogosView*.in templates
     # logos_module(REP_FILE ...) instantiates, and the view glue generator.
@@ -136,6 +146,7 @@
     logos-standalone-app.url = "github:logos-co/logos-standalone-app";
     logos-standalone-app.inputs.logos-design-system.follows = "logos-design-system";
     logos-standalone-app.inputs.logos-view-module-runtime.follows = "logos-view-module-runtime";
+    logos-standalone-app.inputs.logos-nix.follows = "logos-nix";
     # Test framework for module unit tests.
     #
     # Rev-pinned, unlike before: mkLogosModuleTests now passes
@@ -148,6 +159,7 @@
     # waiting on.
     logos-test-framework.url = "github:logos-co/logos-test-framework";
     logos-test-framework.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
+    logos-test-framework.inputs.logos-nix.follows = "logos-nix";
     # The Rust SDK provides logos-lidl-gen (the generator the builder runs for
     # codegen.rust modules) and the SDK source the crate links. logos-rust-sdk
     # depends BACK on this builder for its own integration tests, so its


### PR DESCRIPTION
## Summary

`logos-module-builder` is the aggregator every module depends on. It pulls a stack of `logos-*` inputs directly, and each one vendored its own copy of `logos-nix`. This PR pins them all to the root `logos-nix` with `follows`, so the builder and every downstream module lock share one copy instead of N.

Before this PR, only `logos-test-framework.inputs.logos-cpp-sdk` was deduped. This adds `inputs.logos-nix.follows = "logos-nix"` to every top-level input that carried a private `logos-nix`:

- `logos-cpp-sdk`
- `logos-protocol`
- `logos-qt-sdk`
- `logos-module`
- `logos-plugin-qt`
- `logos-plugin-core`
- `logos-design-system`
- `logos-view-module-runtime`
- `logos-standalone-app`
- `logos-test-framework`
- `nix-bundle-lgx`
- `nix-bundle-logos-module-install`

`logos-view-module` and `logos-rust-sdk` already carried the `follows` on master, so the whole top-level set is now covered.

## Result

Measured on the rebased branch against master `3711449`. A `logos-nix` copy is a lock node whose locked repo is `logos-nix`.

| metric | master | this PR |
|---|---|---|
| nodes | 360 | 324 |
| `logos-nix` node copies | 77 | 65 |

No input revision moves. Every input resolves to the same `logos-nix` rev as before, shared instead of duplicated. `nix flake metadata` evaluates.

## Scope

Top-level input edges only. The 65 `logos-nix` copies that remain are transitive: `logos-module` pulls 15, `nix-bundle-dir` 10, `logos-package` 7, and the rest are spread over `logos-package-manager`, `nix-bundle-appimage`, `logos-container`, `logos-module-loader` and the SDK repos. Each of those must add the `follows` in its own flake, so they are out of scope here.
