### PR TITLE
feat(builder): per-module rust toolchain via nix.rust.toolchain

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7859,7 +7859,28 @@
         "nixpkgs": [
           "logos-nix",
           "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
         ]
+      },
+      "locked": {
+        "lastModified": 1782012058,
+        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,10 @@
 
   inputs = {
     logos-nix.url = "github:logos-co/logos-nix";
+    # Optional newer rustc for crates whose deps out-pace the nixpkgs rustc
+    # (opt-in per module via metadata `nix.rust.toolchain`).
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     # SDK and module deps — owned by this builder, injected into backends
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-cpp-sdk.inputs.logos-protocol.follows = "logos-protocol";
@@ -37,7 +41,7 @@
     nixpkgs.follows = "logos-nix/nixpkgs";
   };
 
-  outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, logos-rust-sdk, ... }:
+  outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, logos-rust-sdk, rust-overlay ? null, ... }:
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
 
@@ -51,6 +55,7 @@
       lib = import ./lib {
         inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app;
         inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework logos-rust-sdk;
+        inherit rust-overlay;
         inherit (nixpkgs) lib;
         uiBackend = logos-plugin-qt.rawLib or logos-plugin-qt.lib;
         coreBackend = logos-plugin-core.rawLib or logos-plugin-core.lib;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,7 @@
 #
 # logos-cpp-sdk and logos-module are owned by this builder and injected into
 # backends — backends never resolve these deps themselves.
-{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, builderRoot }:
+{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, builderRoot, rust-overlay ? null }:
 
 let
   # Import common utilities (backend-agnostic)
@@ -18,6 +18,7 @@ let
     inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app lib;
     inherit common parseMetadata builderRoot uiBackend coreBackend;
     inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework logos-rust-sdk;
+    inherit rust-overlay;
   };
 
   # Import the shared C++ plugin build pipeline (used by mkLogosQmlModule for backend builds)

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -2,7 +2,7 @@
 # This is the main entry point for building Logos modules.
 # Plugin compilation and header generation are delegated to a backend selected
 # by metadata.json "type": core modules use coreBackend, UI modules use uiBackend.
-{ nixpkgs, lib, common, parseMetadata, builderRoot, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
+{ nixpkgs, lib, common, parseMetadata, builderRoot, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, rust-overlay ? null }:
 
 {
   # Required: Path to the module source
@@ -91,6 +91,21 @@ let
   packages = forAllSystems (system:
     let
       pkgs = import nixpkgs { inherit system; };
+
+      # Rust toolchain for the crate compile. Default = the pinned nixpkgs rustc,
+      # so non-Rust modules and Rust modules without a `nix.rust.toolchain` are
+      # unchanged. When a module sets `nix.rust.toolchain` (e.g. "1.96.0") and the
+      # builder has a rust-overlay input, use a rust-overlay stable toolchain at
+      # that version — for crates whose deps need a newer rustc than nixpkgs ships
+      # (the railgun engine's alloy 1.8 / ruint need >= 1.91).
+      rustPlatform =
+        if config.nix_rust.toolchain != null && rust-overlay != null
+        then
+          let
+            rpkgs = import nixpkgs { inherit system; overlays = [ (import rust-overlay) ]; };
+            toolchain = rpkgs.rust-bin.stable.${config.nix_rust.toolchain}.default;
+          in rpkgs.makeRustPlatform { cargo = toolchain; rustc = toolchain; }
+        else pkgs.rustPlatform;
 
       # ── Concrete dependency classification ─────────────────────────────────
       # A dependency's typed `modules().<dep>` wrapper is generated from its
@@ -365,7 +380,7 @@ let
 
       rustStaticLib =
         if !isRustModule then null
-        else pkgs.rustPlatform.buildRustPackage {
+        else rustPlatform.buildRustPackage {
           pname = rustStaticName;
           version = config.version;
           src = rustCrateSrc;

--- a/lib/parseMetadata.nix
+++ b/lib/parseMetadata.nix
@@ -112,6 +112,12 @@
           runtime = safeList (((nix.rust or {}).packages or {}).runtime or []);
         };
         env = let e = (nix.rust or {}).env or {}; in if builtins.isAttrs e then e else {};
+        # Optional stable rustc version (e.g. "1.96.0") for the crate compile.
+        # When set, the builder uses a rust-overlay toolchain at that version
+        # instead of the pinned nixpkgs rustc — for modules whose deps need a
+        # newer rustc than the workspace nixpkgs ships (e.g. the railgun engine's
+        # alloy 1.8 / ruint). null (default) = unchanged, uses nixpkgs rustc.
+        toolchain = let t = (nix.rust or {}).toolchain or null; in if builtins.isString t then t else null;
       };
 
       # Module API style: "legacy" (default), "universal" (pure C++ + generated Qt glue),


### PR DESCRIPTION
Adds a `rust-overlay` flake input + a `nix.rust.toolchain` metadata field. When set (e.g. `"1.96.0"`), `mkLogosModule` builds the crate with a rust-overlay `makeRustPlatform` at that version instead of `pkgs.rustPlatform`, so a Rust cdylib module whose deps need a newer rustc than nixpkgs ships (alloy 1.8 / ruint need ≥1.91) can pin its own toolchain. Default (`null`) is unchanged. **Prerequisite for the RAILGUN private-tx module.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)