### PR TITLE
chore: bump logos-rust-sdk to the single-mode Send-lift master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4418,17 +4418,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1781897494,
-        "narHash": "sha256-4WsMEAD86C5cDMKC3jC8dA2AtMBgJxYdeep8z2swob4=",
+        "lastModified": 1782045655,
+        "narHash": "sha256-fprp1M+5opx3nfqAW+2HKcRUQyc+zqxsOxdNvpJFFv0=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "eff1ad5f039e37eaab88a845ac8d4529cb58c2ff",
+        "rev": "9957a9dd81c38c27e7021b623709129d3a4b7476",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "eff1ad5f039e37eaab88a845ac8d4529cb58c2ff",
+        "rev": "9957a9dd81c38c27e7021b623709129d3a4b7476",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/eff1ad5f039e37eaab88a845ac8d4529cb58c2ff";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/9957a9dd81c38c27e7021b623709129d3a4b7476";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-module-client.follows = "logos-cpp-sdk";


### PR DESCRIPTION
#137 added the `nix.rust.toolchain` rust-overlay but kept the old rust-sdk pin, so the single-mode `Send`-lift wasn't the default — a module needing it (the RAILGUN engine's non-`Send` signer) had to thread rust-sdk in itself. Pin rust-sdk to `9957a9d` so the lift ships by default. Backward-compatible (the single-mode codegen is a superset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)