### PR TITLE
chore: bump logos-protocol to master (qt_remote completion re-entrancy fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4218,11 +4218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781895282,
-        "narHash": "sha256-3tTpCVDKTXNoYWUTPr5WOdw5m/46SrlHMbXQaGMVEFA=",
+        "lastModified": 1782082589,
+        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "4ea32a314a38aeee4fbc390ba2cf852a2c7f92eb",
+        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-protocol` **4ea32a3 → 315a3a2** ([logos-protocol#7](https://github.com/logos-co/logos-protocol/pull/7)).

That PR defers the async `concurrency:"multi"` completion callback off QtRO's
`onClientRead` read stack, fixing the cross-process `SIGSEGV`
(`KERN_INVALID_ADDRESS` in `onClientRead`) that the EVM wallet backend hits on
`refresh_balances` (fans balance reads out to eth_rpc via `call_async`, then emits
`balances_updated` from the gather completion). A/B-proven against a local Anvil
chain: published backend crashes, patched backend returns balances cleanly.

Non-ABI change. `logos-cpp-sdk` and `logos-qt-sdk` follow this `logos-protocol`
input, so every module built via `mkLogosModule` picks up the fix on rebuild.
`flake.lock`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)