### PR TITLE
chore: bump protocol/cpp-sdk/rust-sdk (plaintext-args log fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782492700,
-        "narHash": "sha256-Cfu9C6wMubyWTDLEh738rfCt3CuI91BZNWLj2GfTXAY=",
+        "lastModified": 1782844386,
+        "narHash": "sha256-8WWaS5BakBGLcsLlZPs9QWG5URwmRMV/Wj/Zny7vLLQ=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "350a2891e60a40aba93f273d85e8accb4803ac29",
+        "rev": "d12a7bbb45d7d05f003b5d746a6c4dbc9df28315",
         "type": "github"
       },
       "original": {
@@ -10909,11 +10909,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782490644,
-        "narHash": "sha256-IRHFIBa/+a10tVNEexm6DDZ0JPF8YQgUbxWoNwIytt4=",
+        "lastModified": 1782842011,
+        "narHash": "sha256-2PZuDfaLe/CAs3W1vD0XVeR6gu18qG64jHimleelZns=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "d5d58e7e230768505c683150f651358612abd442",
+        "rev": "976bc7a9a0563e5513617f04a47e7f87f40faeaa",
         "type": "github"
       },
       "original": {
@@ -11618,17 +11618,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1782045655,
-        "narHash": "sha256-fprp1M+5opx3nfqAW+2HKcRUQyc+zqxsOxdNvpJFFv0=",
+        "lastModified": 1782844668,
+        "narHash": "sha256-Ri1H6TuhSKgiW9wVRhBCjXtEwrvH1j8QZU1ciS2JI0c=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "9957a9dd81c38c27e7021b623709129d3a4b7476",
+        "rev": "270e4cf687896d501ed73c1409ea4157cc8a5b54",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "9957a9dd81c38c27e7021b623709129d3a4b7476",
+        "rev": "270e4cf687896d501ed73c1409ea4157cc8a5b54",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/9957a9dd81c38c27e7021b623709129d3a4b7476";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/270e4cf687896d501ed73c1409ea4157cc8a5b54";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-module-client.follows = "logos-cpp-sdk";


### PR DESCRIPTION
## What

Lands the [logos-protocol#10](https://github.com/logos-co/logos-protocol/pull/10) plaintext-args logging fix into the module build pipeline:

- `logos-protocol` `d5d58e7` → `976bc7a` (direct input) — `ModuleProxy::callRemoteMethod` now logs `args.size()`, not the argument values
- `logos-cpp-sdk` → `d12a7bb` (re-locked onto the new protocol)
- `logos-rust-sdk` → `270e4cf` (re-locked onto the new `logos-module-client`)

`logos-qt-sdk` and `logos-cpp-sdk` `follows logos-protocol`, so every module built through the builder now links protocol `976bc7a`. Verified: the qt-sdk and cpp-sdk protocol subtrees both resolve to `976bc7a`, and the `qml-integration` check (compiles a real module against the full stack) builds clean.

This is the tail of the chain: protocol → {cpp-sdk, module-client} → rust-sdk → **module-builder**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)