### PR TITLE
chore: bump cpp-sdk (#102) and rust-sdk (#25) for bstr event fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782844386,
-        "narHash": "sha256-8WWaS5BakBGLcsLlZPs9QWG5URwmRMV/Wj/Zny7vLLQ=",
+        "lastModified": 1784238640,
+        "narHash": "sha256-HVHw4VDO21r6zYKPotJRM2/IimkneYSV784koLkLDkM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d12a7bbb45d7d05f003b5d746a6c4dbc9df28315",
+        "rev": "c7444bc29a1b480505025d0ed1679bedb71bfa29",
         "type": "github"
       },
       "original": {
@@ -11605,9 +11605,6 @@
         "logos-module-builder": [
           "logos-cpp-sdk"
         ],
-        "logos-module-client": [
-          "logos-cpp-sdk"
-        ],
         "logos-nix": [
           "logos-nix"
         ],
@@ -11618,17 +11615,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1782844668,
-        "narHash": "sha256-Ri1H6TuhSKgiW9wVRhBCjXtEwrvH1j8QZU1ciS2JI0c=",
+        "lastModified": 1784238786,
+        "narHash": "sha256-5zyEEEoRss78z7Z2C/whib/gHToemcDseW7wXU4aGHs=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "270e4cf687896d501ed73c1409ea4157cc8a5b54",
+        "rev": "92a5c720c58f784cd944c940756f7b69a264dc07",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "270e4cf687896d501ed73c1409ea4157cc8a5b54",
+        "rev": "92a5c720c58f784cd944c940756f7b69a264dc07",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -33,10 +33,9 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/270e4cf687896d501ed73c1409ea4157cc8a5b54";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/92a5c720c58f784cd944c940756f7b69a264dc07";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
-    logos-rust-sdk.inputs.logos-module-client.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";
     nixpkgs.follows = "logos-nix/nixpkgs";
   };


### PR DESCRIPTION
Re-pin the two SDKs to their merged masters carrying the binary (`bstr`) event ser/deser fixes, so modules built through this builder get correct binary event payloads on both the C++ and Rust paths.

## Bumps

- **logos-cpp-sdk** `d12a7bb` → `c7444bc` (#100 + #102): cdylib event sidecar encodes `bstr` args canonically (`{"_bytes":"<base64url>"}`), `lp` consumer wrappers now decode tagged bytes into `std::vector<uint8_t>` (previously the natural subscriber compiled then threw at runtime), Qt-free event types in the sidecar, plus value-level + composition-doctest coverage.
- **logos-rust-sdk** `270e4cf` → `92a5c72` (#25): the generated provider event emitter no longer drops an event argument named `payload` (it shadowed the JSON accumulator); `bstr` emit + subscribe are now covered by lidl-gen unit tests and an ipc round-trip test.

Also drops the now-dangling `logos-rust-sdk.inputs.logos-module-client` follows override — rust-sdk `92a5c72` no longer declares that input (it reaches the `lp_*` C ABI via logos-protocol through the builder), which otherwise produces a `nix flake lock` warning.

## Validation

Rebuilt a C++ universal binary-event module end-to-end **through this branch** (module-builder overridden to this checkout; cpp-sdk pulled from its bumped `flake.lock`, not an override): a greeter emits a 109,447-byte payload on a `bstr` event, an orchestrator subscribes across the process boundary under a live `logoscore` daemon and reports what it received.

```
size:     109447
checksum: 223235117   (exact match — content intact, not just length)
```

`nix flake metadata` evaluates cleanly; the lock diff is limited to the two SDK revs and the removed override (no transitive churn — protocol/qt-sdk/lidl/nixpkgs are unchanged via the builder's `follows` unification).

The Rust `bstr` emit+subscribe path is covered by rust-sdk #25's own unit + ipc tests (green in that PR's CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
