### PR TITLE
chore: re-pin cpp-sdk/qt-sdk/rust-sdk/protocol (full_api fixes)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784238640,
-        "narHash": "sha256-HVHw4VDO21r6zYKPotJRM2/IimkneYSV784koLkLDkM=",
+        "lastModified": 1784316449,
+        "narHash": "sha256-/u5ulpkwj5VDT0PuODc6COCDwbaJK5AxGtglK4Qnqqc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "c7444bc29a1b480505025d0ed1679bedb71bfa29",
+        "rev": "2f348049487ad3fcd15507e408b8384d2bdb45bd",
         "type": "github"
       },
       "original": {
@@ -10909,11 +10909,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782842011,
-        "narHash": "sha256-2PZuDfaLe/CAs3W1vD0XVeR6gu18qG64jHimleelZns=",
+        "lastModified": 1784316126,
+        "narHash": "sha256-3IS9qZTJM7NLctjsqmG5oQE7h/DDGODY8A01iI35iYI=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "976bc7a9a0563e5513617f04a47e7f87f40faeaa",
+        "rev": "4775e635ff5fd7b1a43f4e3f49d3d7460857574a",
         "type": "github"
       },
       "original": {
@@ -11357,11 +11357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782493580,
-        "narHash": "sha256-n0WnqIAejwE/GVb3qSFTiVVwOp/dyjSgfhPGg15YgOA=",
+        "lastModified": 1784316397,
+        "narHash": "sha256-sG349nSb1WPeNfSVnfpgN6KV3u2oP4A+KsLGX7raouI=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "6c9a0de131fee6a0fa2edff924913bb76caf0316",
+        "rev": "089142da855d488daa3547d1bde0ed870d22de96",
         "type": "github"
       },
       "original": {
@@ -11615,17 +11615,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1784238786,
-        "narHash": "sha256-5zyEEEoRss78z7Z2C/whib/gHToemcDseW7wXU4aGHs=",
+        "lastModified": 1784316501,
+        "narHash": "sha256-hCrpy8F13nJuARMNP2ydqgJ0/GpGEc/A8oJYykcC3ek=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "92a5c720c58f784cd944c940756f7b69a264dc07",
+        "rev": "a55fdac1a202ff2a4cf9d562a263ab41db17d99f",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "92a5c720c58f784cd944c940756f7b69a264dc07",
+        "rev": "a55fdac1a202ff2a4cf9d562a263ab41db17d99f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/92a5c720c58f784cd944c940756f7b69a264dc07";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/a55fdac1a202ff2a4cf9d562a263ab41db17d99f";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";


### PR DESCRIPTION
## What
Re-pins module-builder's SDK inputs to the merged full_api fixes:
| input | → | fix |
|---|---|---|
| logos-protocol | `4775e63` | #21 — qvariantToNlohmann container int-preservation |
| logos-cpp-sdk | `2f34804` | #103 — bstr + composite-`any` codegen |
| logos-qt-sdk | `089142d` | #10 — QtProviderObject QVariantList/Map args |
| logos-rust-sdk | `a55fdac` | #26 — clone `any` event params |

## Validation
All five `logos-test-modules` full_api modules (C++/Rust providers, C++/Rust proxies, ui_qml plugin) build through this module-builder with **no SDK overrides**.

## Chain
Unblocks logos-test-modules#24 (re-lock to this) → logos-logoscore-cli#65 + logos-basecamp#264 doctests.

Note: this bumps only the four fixes above. Your socket-stack SDK work (protocol#22, qt-sdk#11) is still open — when it lands, another module-builder bump rebases on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
