### PR TITLE
chore: re-pin logos-cpp-sdk to master (Qt client codegen fixes)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -625,11 +625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784316449,
-        "narHash": "sha256-/u5ulpkwj5VDT0PuODc6COCDwbaJK5AxGtglK4Qnqqc=",
+        "lastModified": 1784433810,
+        "narHash": "sha256-jMzxHylUgFE5im6wpYavkEnUhQhnBLDqs9vExfgy2BU=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "2f348049487ad3fcd15507e408b8384d2bdb45bd",
+        "rev": "e8966bf7a9162f0af0768e56ace60a94ae1602df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `logos-cpp-sdk` `2f34804 -> e8966bf` to pick up the codegen fixes in
logos-co/logos-cpp-sdk#105:

- Qt client packs a `QVariantList`-typed argument (every `[T]` list) as **one**
  element instead of concatenating its elements into the args list.
- The lp wrapper passes an `any` (QVariant) return through raw instead of forcing
  it to an object (which collapsed non-object values to `{}`).

`logos-qt-sdk` and `logos-test-framework` follow `logos-cpp-sdk`, so this single
input update threads both fixes through every module the builder generates.

Verified end-to-end: a universal proxy generated with this builder round-trips
`echoAny` (`"x" -> "x"`, was `{}`) and every typed array over the full surface.

Needed to green logos-co/logos-test-modules#25 and logos-co/logos-logoscore-cli#69
(full-surface sync+async coverage), and to cut a module-builder release for the
cross-version doctest cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)