### PR TITLE
chore: bump logos-protocol to master (rejection re-exchange #26)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10911,11 +10911,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784512868,
-        "narHash": "sha256-URbriX1AnFRgP7ZmgINPkTPnvCNNilzLxnIhGa2Ot6M=",
+        "lastModified": 1784668723,
+        "narHash": "sha256-bN4KcHm1wzWIvg0W/abV5SEruqdD75wOLjGkJTLjl5I=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "664b43f18a9e752c0a80a422e5edfd99d76ffef6",
+        "rev": "ef24bd70d930de8c54d98efd0ce21de939a616f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `logos-protocol` pin to master (ef24bd7 — logos-protocol#26, rejection-driven token re-exchange + `unauthorized` sentinel); cpp-sdk/qt-sdk follow this pin. No source changes. Standalone `nix flake check` passes; also validated by the workspace `ws test --all` run against #26.

Part of the #26 propagation chain: logos-protocol#26 → logos-cpp-sdk#108 (merged) → this → logos-rust-sdk (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)