### PR TITLE
chore: re-pin logos-standalone-app to the ui-host token fix (#28)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11703,11 +11703,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784635008,
-        "narHash": "sha256-fp8lF4N69pVrhj4JzvqYA4rLXsmHtjROvs3Bo7o1YpA=",
+        "lastModified": 1784722921,
+        "narHash": "sha256-RyJoZ1BSXMyk7Bk0o/H5OutknJ+FMrWHPZThA5p/Y4U=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "c25aa61e3ad69358bbd9c8192c319ffcbf774189",
+        "rev": "155f21b95b499a1e2d011dc7094480504a49fe6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up [logos-standalone-app#28](https://github.com/logos-co/logos-standalone-app/pull/28) (`155f21b`): the standalone ui-host runner now registers a spawned UI module's auth token with `capability_module` **before** `ViewModuleHost::spawn`, instead of after `ready()`.

ui-host runs the loaded plugin's `initLogos()` synchronously, so a backend constructor can fire its first token-gated `capability_module.requestModule` before `ViewModuleHost` emits `ready()`. Registering the token only after waiting for ready races those first calls: they hit capability_module's fail-closed auth gate before the token is known and are rejected as "auth token not recognized", so the UI never becomes Ready. This matches what `logos-basecamp`'s `PluginLoader` already does.

Since module-builder is what hands the standalone runner to every UI module, this re-pin is how the fix reaches them.

## Diff

```
logos-standalone-app: c25aa61 -> 155f21b
```

Lock-only, one node, 3 lines. No transitive input drift — `155f21b` touches `app/mainwindow.cpp` only, so logos-standalone-app's own `flake.lock` is unchanged between the two revs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)