### PR TITLE
chore: bump logos-protocol to the owner-thread destroy fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10911,11 +10911,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784686752,
-        "narHash": "sha256-YfIUX0xYtvp7FrvYJtBDDZNzQsCPihWEZ6GxvKwVifA=",
+        "lastModified": 1784753092,
+        "narHash": "sha256-cxl80GhIEd4U5R24ROJyDhj9zDpJ/oKCTd18oHWQREU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6401e30ae1cfabac77285ee8e7a82c2cef3858f1",
+        "rev": "8ede8ece0817265c93297393febe6d908f8eb179",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Re-pins `logos-protocol` to **8ede8ec** — logos-co/logos-protocol#27, *destroy clients on their owner thread*.

## What it fixes

`lp_client_destroy` did a bare `delete` on the `LogosAPIClient` from whatever thread released the last handle share. That is not always the owner: any binding that parks a client share in a worker (a rust-sdk `EventSubscription` moved into a bridge thread, for one) runs the destroy there. Over QtRO that tears the transport's `QLocalSocket` notifiers down cross-thread, the fd closes under the owner's event dispatcher, and the module process takes SIGSEGV:

```
QSocketNotifier: Socket notifiers cannot be enabled or disabled from another thread   x2
QSocketNotifier: Invalid socket 19 with type Read, disabling...
FATAL: module 'chat_module' crashed (signal 11)
```

Every call path already marshalled with `logos::runOnOwnerThread`; destruction was the one that did not. It now defers via `deleteLater()`.

## Evidence

Reproduced end-to-end under `logoscore` with a pre-fix `chat_module`, then fixed — 3/3 runs each way, deterministic. A control arm (protocol master **without** #27) still crashes 3/3, isolating that single commit as the cause.

## Why this is the one that matters for modules

`logos-cpp-sdk` and `logos-qt-sdk` are both declared here with `inputs.logos-protocol.follows = "logos-protocol"`, so **this** bump is what every module built through the builder actually links. Verified in the resulting lock — both nested nodes resolve to `8ede8ece`:

```
logos-cpp-sdk -> its protocol rev = 8ede8ece
logos-qt-sdk  -> its protocol rev = 8ede8ece
logos-protocol   rev = 8ede8ece
```

Because of that `follows` wiring this PR is **independent** of logos-cpp-sdk#109 and logos-qt-sdk#16 — all three can merge in any order.

`logos-rust-sdk` deliberately gets no bump: it carries no `logos-protocol` input (its flake comment notes the pin "is reached via `logos-module-builder.inputs.logos-protocol`"), and it only binds the `lp_*` ABI, which is unchanged by #27. It picks up the fixed library automatically through this input.

## Scope note

Crosses **only** #27 — this repo's pin was already at 6401e30.

Checks green: `default`, `rust-native-dep`, `qml-integration`, `static-extlib`, `test-framework-integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
