### PR TITLE
feat: build redistributable binaries for ui_qml modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ logos-module-builder/
 │   ├── mkLogosQmlModule.nix # Builder for ui_qml modules (QML view + optional C++ backend)
 │   ├── buildCppPlugin.nix  # Shared C++ plugin build pipeline
 │   ├── mkStandaloneApp.nix # apps.default for logos-standalone-app
+│   ├── appRuntimeLayout.nix # Plugin + modules directories the host loads
+│   ├── mkAppBundle.nix     # Redistributable binaries (AppImage, macOS .app)
 │   ├── mkModuleLib.nix     # Library builder
 │   ├── mkModuleInclude.nix # Header generator
 │   ├── mkExternalLib.nix   # External library handler

--- a/docs/nix-api.md
+++ b/docs/nix-api.md
@@ -272,8 +272,11 @@ mkLogosQmlModule {
   preConfigure = "";
   postInstall = "";
   logosStandalone = null;
+  appIcons = { };
 }
 ```
+
+`appIcons` supplies the artwork for the redistributable binaries: `png` (256x256) is the desktop and AppImage icon, `icns` the macOS bundle icon. Both are paths in the module repo.
 
 ### Return Value
 
@@ -288,6 +291,9 @@ mkLogosQmlModule {
       lgx-portable = <portable lgx>;
       install = <dev install package>;
       install-portable = <portable install package>;
+      bin-bundle-dir = <self-contained directory>;
+      bin-appimage = <AppImage>;            # Linux, when appIcons.png is set
+      bin-macos-app = <.app bundle>;        # macOS, when appIcons.icns is set
     };
   };
 
@@ -340,6 +346,21 @@ mkLogosQmlModule {
       configFile = ./metadata.json;  # type: ui_qml, view: "Main.qml" (no "main")
       flakeInputs = inputs;
     };
+}
+```
+
+### Redistributable binaries
+
+`bin-bundle-dir` is the module running under the portable standalone host, relocated by [nix-bundle-dir](https://github.com/logos-co/nix-bundle-dir) into a directory that needs neither Nix nor Qt on the target machine. `bin-appimage` and `bin-macos-app` wrap that directory for distribution. The shipped host has the QML inspector compiled out.
+
+The desktop entry, `Info.plist` and entitlements are generated from `metadata.json` (`name`, `display_name`, `description`, `version`), so a module supplies only `appIcons`. The executable name is `name` with underscores turned into hyphens, and the same name identifies the AppImage and the `.app`.
+
+```nix
+logos-module-builder.lib.mkLogosQmlModule {
+  src = ./.;
+  configFile = ./metadata.json;
+  flakeInputs = inputs;
+  appIcons = { png = ./assets/chat-ui.png; icns = ./assets/chat-ui.icns; };
 }
 ```
 

--- a/docs/specs/project.md
+++ b/docs/specs/project.md
@@ -12,6 +12,8 @@ logos-module-builder/
 │   ├── buildCppPlugin.nix          # Shared C++ plugin build pipeline
 │   ├── mkExternalLib.nix           # Builds external C/C++ libraries from flake inputs or vendor paths
 │   ├── mkStandaloneApp.nix         # Creates `nix run` app wrapper for UI modules
+│   ├── appRuntimeLayout.nix        # Plugin + modules directories the standalone host loads
+│   ├── mkAppBundle.nix             # Redistributable binaries (AppImage, macOS .app)
 │   ├── parseMetadata.nix           # Parses metadata.json and applies defaults
 │   └── common.nix                  # Shared utilities (systems list, name helpers, transitive dep collection)
 ├── cmake/                          # (empty — LogosModule.cmake lives in logos-plugin-qt)
@@ -111,7 +113,7 @@ The builder itself contains no C++ code or compilation logic — it is pure Nix.
 
 **Purpose**: Builder for `ui_qml` modules — QML view with an optional C++ backend. When `main` is declared in metadata.json, uses `buildCppPlugin` to compile the backend and bundles it alongside the QML view. When `main` is absent, produces a QML-only output (no compilation). Validates `type == "ui_qml"` and `view != null`.
 
-**Parameters**: Same as mkLogosModule.
+**Parameters**: Same as mkLogosModule, plus `appIcons` (`{ png, icns }`, artwork for the redistributable binaries).
 
 **Outputs** (per system):
 
@@ -123,6 +125,9 @@ The builder itself contains no C++ code or compilation logic — it is pure Nix.
 | `lgx-portable` | LGX portable package |
 | `install` | Installed plugin directory (dev variant) |
 | `install-portable` | Installed plugin directory (portable variant) |
+| `bin-bundle-dir` | Self-contained directory: the module under the portable standalone host |
+| `bin-appimage` | AppImage (Linux, when `appIcons.png` is set) |
+| `bin-macos-app` | `.app` bundle (macOS, when `appIcons.icns` is set) |
 | `apps.default` | Standalone runner (always present) |
 | `devShells.default` | Development shell |
 

--- a/flake.lock
+++ b/flake.lock
@@ -9180,8 +9180,8 @@
       "inputs": {
         "logos-nix": "logos-nix_288",
         "logos-package": "logos-package_34",
-        "nix-bundle-appimage": "nix-bundle-appimage_15",
-        "nix-bundle-dir": "nix-bundle-dir_49",
+        "nix-bundle-appimage": "nix-bundle-appimage_16",
+        "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -12610,8 +12610,36 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
+        "logos-nix": [
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_16": {
+      "inputs": {
         "logos-nix": "logos-nix_290",
-        "nix-bundle-dir": "nix-bundle-dir_48",
+        "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -14130,6 +14158,31 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
+        "logos-nix": [
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782913618,
+        "narHash": "sha256-WzkZzJ3VSotFMOjbEDfjHZP0KoBW6GVi1Xc9i1E6mMY=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "4f72d7a64dd83979d771c17161f23ebc9dbedb40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_48": {
+      "inputs": {
         "logos-nix": "logos-nix_286",
         "nixpkgs": [
           "nix-bundle-lgx",
@@ -14152,7 +14205,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_48": {
+    "nix-bundle-dir_49": {
       "inputs": {
         "logos-nix": "logos-nix_291",
         "nixpkgs": [
@@ -14168,31 +14221,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_49": {
-      "inputs": {
-        "logos-nix": "logos-nix_292",
-        "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -14232,6 +14260,31 @@
       }
     },
     "nix-bundle-dir_50": {
+      "inputs": {
+        "logos-nix": "logos-nix_292",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_51": {
       "inputs": {
         "logos-nix": "logos-nix_295",
         "nixpkgs": [
@@ -14758,7 +14811,7 @@
       "inputs": {
         "logos-nix": "logos-nix_284",
         "logos-package": "logos-package_33",
-        "nix-bundle-dir": "nix-bundle-dir_47",
+        "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
           "nix-bundle-lgx",
           "logos-nix",
@@ -14783,7 +14836,7 @@
       "inputs": {
         "logos-nix": "logos-nix_293",
         "logos-package": "logos-package_35",
-        "nix-bundle-dir": "nix-bundle-dir_50",
+        "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -15242,6 +15295,34 @@
         ],
         "nixpkgs": [
           "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781728271,
+        "narHash": "sha256-LHdzXrQPJCEVLC9cntURu8O9qSPPrePoVBzZd0UFGN0=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "rev": "d6b0cc518e599ab7a52258bf3e1f8123c8a01d31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "type": "github"
+      }
+    },
+    "nix-bundle-macos-app_2": {
+      "inputs": {
+        "logos-nix": [
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "nix-bundle-macos-app",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -20203,8 +20284,11 @@
         "logos-standalone-app": "logos-standalone-app",
         "logos-test-framework": "logos-test-framework_7",
         "logos-view-module-runtime": "logos-view-module-runtime_7",
+        "nix-bundle-appimage": "nix-bundle-appimage_15",
+        "nix-bundle-dir": "nix-bundle-dir_47",
         "nix-bundle-lgx": "nix-bundle-lgx_20",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_7",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_2",
         "nixpkgs": [
           "logos-nix",
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,15 @@
     logos-plugin-core.url = "github:logos-co/logos-plugin-qt";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
     nix-bundle-logos-module-install.url = "github:logos-co/nix-bundle-logos-module-install";
+    # Redistributable app binaries for ui_qml modules (AppImage, macOS .app).
+    nix-bundle-dir.url = "github:logos-co/nix-bundle-dir";
+    nix-bundle-dir.inputs.logos-nix.follows = "logos-nix";
+    nix-bundle-appimage.url = "github:logos-co/nix-bundle-appimage";
+    nix-bundle-appimage.inputs.logos-nix.follows = "logos-nix";
+    nix-bundle-appimage.inputs.nix-bundle-dir.follows = "nix-bundle-dir";
+    nix-bundle-macos-app.url = "github:logos-co/nix-bundle-macos-app";
+    nix-bundle-macos-app.inputs.logos-nix.follows = "logos-nix";
+    nix-bundle-macos-app.inputs.nix-bundle-dir.follows = "nix-bundle-dir";
     # Host shell used by `nix run` / integration tests for ui_qml modules.
     # Design system + view-module-runtime are pinned HERE (not only inside
     # standalone's lock) so a bump for module testing is one lock update on
@@ -48,7 +57,7 @@
     nixpkgs.follows = "logos-nix/nixpkgs";
   };
 
-  outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, logos-rust-sdk, rust-overlay ? null, ... }:
+  outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, nix-bundle-dir, nix-bundle-appimage, nix-bundle-macos-app, logos-standalone-app, logos-test-framework, logos-rust-sdk, rust-overlay ? null, ... }:
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
 
@@ -61,6 +70,7 @@
       # Use rawLib from backends — we inject logos-cpp-sdk/logos-module ourselves
       lib = import ./lib {
         inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app;
+        inherit nix-bundle-dir nix-bundle-appimage nix-bundle-macos-app;
         inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-module logos-test-framework logos-rust-sdk;
         inherit rust-overlay;
         inherit (nixpkgs) lib;

--- a/lib/appRuntimeLayout.nix
+++ b/lib/appRuntimeLayout.nix
@@ -1,0 +1,134 @@
+# The runtime layout logos-standalone-app loads for a ui_qml module: the plugin
+# directory holding the module itself, and the modules directory its dependencies
+# are unpacked into. Shared by `nix run` (store paths) and the redistributable
+# app bundles (paths relative to the executable).
+{ pkgs
+, standalone
+, plugin ? null
+, qmlSrc ? null
+, metadataFile
+, dirName ? "logos-ui-plugin-dir"
+, format ? "qt-plugin"
+, moduleDeps ? {}
+}:
+
+let
+  parsedMetadata = builtins.fromJSON (builtins.readFile metadataFile);
+  iconFiles = pkgs.lib.optional
+    (parsedMetadata ? icon && parsedMetadata.icon != null && (qmlSrc != null || plugin != null))
+    ((dirOf metadataFile) + "/${parsedMetadata.icon}");
+
+  iconInstall = pkgs.lib.concatStringsSep "\n" (map (icon: ''
+    mkdir -p $out/icons
+    cp ${icon} $out/icons/${builtins.baseNameOf (toString icon)}
+  '') iconFiles);
+
+  pluginDir =
+    if format == "qml" && qmlSrc != null then
+      pkgs.runCommand dirName {} ''
+        set -euo pipefail
+        cp -r ${qmlSrc}/. $out
+        chmod -R u+w $out
+        cp ${metadataFile} $out/metadata.json
+        ${iconInstall}
+      ''
+    else if format == "qml" then
+      # plugin may be a lib/-layout directory (from mkLogosQmlModule combined)
+      # or a flat directory; handle both cases.
+      pkgs.runCommand dirName {} ''
+        set -euo pipefail
+        mkdir -p $out
+        if [ -d "${plugin}/lib" ]; then
+          cp -r ${plugin}/lib/. $out/
+        else
+          cp -r ${plugin}/. $out/
+        fi
+        chmod -R u+w $out
+        cp ${metadataFile} $out/metadata.json
+        ${iconInstall}
+      ''
+    else
+      pkgs.runCommand dirName {} ''
+        set -euo pipefail
+        mkdir -p $out
+        # Copy backend plugin (if present)
+        for f in ${plugin}/lib/*_plugin.*; do
+          [ -e "$f" ] && cp "$f" $out/
+        done
+        # Copy typed replica factory plugin (if present)
+        for f in ${plugin}/lib/*_replica_factory.*; do
+          [ -e "$f" ] && cp "$f" $out/
+        done
+        cp ${metadataFile} $out/metadata.json
+        ${iconInstall}
+        # Copy QML view directories and root-level QML files (if present)
+        for d in ${plugin}/lib/*/; do
+          [ -e "$d" ] || continue
+          dirname=$(basename "$d")
+          [ "$dirname" != "." ] && cp -r "$d" "$out/$dirname"
+        done
+        for f in ${plugin}/lib/*.qml; do
+          [ -e "$f" ] && cp "$f" $out/
+        done
+      '';
+
+  hasModuleDeps = moduleDeps != {};
+
+  # Create a merged modules directory containing the standalone app's built-in
+  # modules (e.g. capability_module) plus all resolved dependency modules.
+  # Each dependency is extracted from its LGX package — the same format used by
+  # lgpm and the standalone app's own capability_module bundling — ensuring all
+  # files (plugin binary + external libraries) are included.
+  modulesDir = pkgs.runCommand "${dirName}-modules" {
+    nativeBuildInputs = [ pkgs.python3 ];
+  } ''
+    mkdir -p $out
+
+    # Copy built-in modules from the standalone app (capability_module, etc.)
+    if [ -d "${standalone}/modules" ]; then
+      cp -r ${standalone}/modules/* $out/
+    fi
+
+    ${pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (name: lgxPkg: ''
+      # --- Install ${name} from LGX package ---
+      lgx_file=$(find ${lgxPkg} -name '*.lgx' | head -1)
+      if [ -n "$lgx_file" ]; then
+        extract_dir=$(mktemp -d)
+        tar -xzf "$lgx_file" -C "$extract_dir"
+
+        # Find the platform variant directory
+        variant_dir=""
+        for v in darwin-arm64-dev darwin-amd64-dev darwin-x86_64-dev \
+                 linux-x86_64-dev linux-amd64-dev linux-arm64-dev \
+                 darwin-arm64 darwin-amd64 darwin-x86_64 \
+                 linux-x86_64 linux-amd64 linux-arm64; do
+          if [ -d "$extract_dir/variants/$v" ]; then
+            variant_dir="$extract_dir/variants/$v"
+            break
+          fi
+        done
+
+        if [ -n "$variant_dir" ]; then
+          module_name=$(python3 -c "
+import json; f=open('$extract_dir/manifest.json'); print(json.load(f).get('name',str())); f.close()
+")
+          if [ -n "$module_name" ]; then
+            mkdir -p "$out/$module_name"
+            cp "$extract_dir/manifest.json" "$out/$module_name/"
+            cp -r "$variant_dir"/* "$out/$module_name/"
+            echo "Bundled $module_name from LGX into $out/$module_name/"
+          else
+            echo "Warning: could not read module name from LGX manifest for ${name}" >&2
+          fi
+        else
+          echo "Warning: no matching platform variant in LGX package for ${name}" >&2
+        fi
+        rm -rf "$extract_dir"
+      else
+        echo "Warning: no .lgx file found for ${name}" >&2
+      fi
+    '') moduleDeps)}
+  '';
+in {
+  inherit pluginDir modulesDir hasModuleDeps;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,7 +4,7 @@
 #
 # logos-cpp-sdk and logos-module are owned by this builder and injected into
 # backends — backends never resolve these deps themselves.
-{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, builderRoot, rust-overlay ? null }:
+{ nixpkgs, lib, uiBackend, coreBackend, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, logos-test-framework, logos-rust-sdk ? null, nix-bundle-lgx, nix-bundle-logos-module-install, nix-bundle-dir, nix-bundle-appimage, nix-bundle-macos-app, logos-standalone-app, builderRoot, rust-overlay ? null }:
 
 let
   # Import common utilities (backend-agnostic)
@@ -30,6 +30,7 @@ let
   # Import the ui_qml module builder (QML view + optional C++ backend)
   mkLogosQmlModule = import ./mkLogosQmlModule.nix {
     inherit nixpkgs nix-bundle-lgx nix-bundle-logos-module-install logos-standalone-app lib;
+    inherit nix-bundle-dir nix-bundle-appimage nix-bundle-macos-app;
     inherit common parseMetadata logos-cpp-sdk logos-protocol logos-qt-sdk logos-module uiBackend coreBackend;
   };
 

--- a/lib/mkAppBundle.nix
+++ b/lib/mkAppBundle.nix
@@ -1,0 +1,136 @@
+# Redistributable binaries for a ui_qml module: the standalone host, the module's
+# plugin directory and its dependency modules, laid out so every path resolves
+# relative to the executable. nix-bundle-dir turns that tree into a directory that
+# runs without Nix; the AppImage and .app wrappers are built from it.
+#
+# The desktop entry, Info.plist and entitlements are derived from metadata.json,
+# so a module only has to supply artwork.
+{ pkgs
+, lib
+, system
+, config
+, standalone
+, layout
+, icons
+, nix-bundle-dir
+, nix-bundle-appimage
+, nix-bundle-macos-app
+}:
+
+let
+  binName = builtins.replaceStrings [ "_" ] [ "-" ] config.name;
+  bundleId = "co.logos.${binName}";
+
+  app = pkgs.runCommand "logos-${config.name}-app" {
+    version = config.version;
+    passthru = {
+      extraDirs = [ "modules" "plugin" ];
+      # The host declares the Qt modules it only reaches by dlopen; staging its
+      # files here would otherwise drop them from the closure a bundler traces.
+      extraClosurePaths = standalone.extraClosurePaths or [];
+    };
+    meta.mainProgram = binName;
+  } ''
+    mkdir -p $out/bin $out/lib
+    cp -aL ${standalone}/bin/. $out/bin/
+    cp -aL ${standalone}/lib/. $out/lib/
+    cp -aL ${layout.modulesDir} $out/modules
+    cp -aL ${layout.pluginDir} $out/plugin
+    chmod -R u+w $out
+
+    # Both paths are resolved from the launcher's own location, so the tree
+    # keeps working wherever the bundle is unpacked.
+    cat > $out/bin/${binName} <<'LAUNCHER'
+#!/bin/sh
+DIR=$(cd "$(dirname "$0")" && pwd)
+exec "$DIR/logos-standalone-app" --modules-dir "$DIR/../modules" "$DIR/../plugin" "$@"
+LAUNCHER
+    chmod +x $out/bin/${binName}
+  '';
+
+  bundle = nix-bundle-dir.bundlers.${system}.qtApp app;
+
+  # builtins.toFile rather than writeText: mkAppImage reads the desktop entry at
+  # evaluation time, which would otherwise need import-from-derivation.
+  desktopFile = builtins.toFile "${binName}.desktop" ''
+    [Desktop Entry]
+    Type=Application
+    Name=${config.display_name}
+    Comment=${config.description}
+    Exec=${binName}
+    Icon=${binName}
+    Categories=Utility;
+  '';
+
+  # @VERSION@ and @BUILD_NUMBER@ are substituted by mkMacOSApp.
+  infoPlist = builtins.toFile "Info.plist.in" ''
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleDisplayName</key>
+        <string>${config.display_name}</string>
+        <key>CFBundleExecutable</key>
+        <string>${binName}</string>
+        <key>CFBundleIconFile</key>
+        <string>${builtins.baseNameOf (toString (icons.icns or ""))}</string>
+        <key>CFBundleIdentifier</key>
+        <string>${bundleId}</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>${config.display_name}</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>@VERSION@</string>
+        <key>CFBundleVersion</key>
+        <string>@BUILD_NUMBER@</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>12.0</string>
+        <key>NSHighResolutionCapable</key>
+        <true/>
+        <key>NSPrincipalClass</key>
+        <string>NSApplication</string>
+        <key>NSSupportsAutomaticGraphicsSwitching</key>
+        <true/>
+        <key>LSApplicationCategoryType</key>
+        <string>public.app-category.utilities</string>
+    </dict>
+    </plist>
+  '';
+
+  # The host dlopens bundled Qt plugins and module libraries that the ad-hoc
+  # signature does not cover.
+  entitlements = builtins.toFile "${binName}.entitlements" ''
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+    </dict>
+    </plist>
+  '';
+in
+{
+  bin-bundle-dir = bundle;
+}
+// lib.optionalAttrs (pkgs.stdenv.isLinux && icons ? png) {
+  bin-appimage = nix-bundle-appimage.lib.${system}.mkAppImage {
+    drv = app;
+    name = binName;
+    inherit bundle desktopFile;
+    icon = icons.png;
+  };
+}
+// lib.optionalAttrs (pkgs.stdenv.isDarwin && icons ? icns) {
+  bin-macos-app = nix-bundle-macos-app.lib.${system}.mkMacOSApp {
+    drv = app;
+    name = binName;
+    inherit bundle infoPlist entitlements;
+    icon = icons.icns;
+  };
+}

--- a/lib/mkLogosQmlModule.nix
+++ b/lib/mkLogosQmlModule.nix
@@ -1,7 +1,7 @@
 # ui_qml module builder — QML view + optional C++ backend (process-isolated).
 # Calls buildCppPlugin only when config.main is set; the resulting `combined`
 # output bundles the plugin .so (when present) with the QML view directory.
-{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, uiBackend, coreBackend, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app }:
+{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-protocol ? null, logos-qt-sdk ? null, logos-module, uiBackend, coreBackend, nix-bundle-lgx, nix-bundle-logos-module-install, logos-standalone-app, nix-bundle-dir, nix-bundle-appimage, nix-bundle-macos-app }:
 
 {
   # Required: Path to the module source
@@ -33,6 +33,11 @@
 
   # Optional: override the logos-standalone-app used for `nix run`.
   logosStandalone ? null,
+
+  # Optional: artwork for the redistributable app binaries. `png` (256x256) is
+  # the desktop/AppImage icon, `icns` the macOS bundle icon. bin-appimage and
+  # bin-macos-app are exposed only when the matching file is given.
+  appIcons ? {},
 }:
 
 let
@@ -69,6 +74,8 @@ let
   viewDir = builtins.dirOf config.view;
 
   mkStandaloneApp = import ./mkStandaloneApp.nix;
+  appRuntimeLayout = import ./appRuntimeLayout.nix;
+  mkAppBundle = import ./mkAppBundle.nix;
 
   forAllSystems = f: lib.genAttrs common.systems (system: f system);
 
@@ -228,6 +235,27 @@ let
     }
   );
 
+  # Redistributable binaries. The host is the portable standalone build — an
+  # unwrapped binary nix-bundle-dir can relocate, with the inspector compiled out.
+  appBundlePackages = forAllSystems (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+      standalone = resolvedStandalone.packages.${system}.portable;
+    in mkAppBundle {
+      inherit pkgs lib system config standalone;
+      inherit nix-bundle-dir nix-bundle-appimage nix-bundle-macos-app;
+      icons = appIcons;
+      layout = appRuntimeLayout {
+        inherit pkgs standalone;
+        plugin       = packages.${system}.default;
+        metadataFile = configFile;
+        dirName      = "logos-${config.name}-plugin-dir";
+        format       = if hasBackend then "qt-plugin" else "qml";
+        moduleDeps   = common.collectAllModuleDeps system flakeInputs config.dependencies;
+      };
+    }
+  );
+
   # Auto-detect UI integration tests: scan tests/ for .mjs files and produce
   # an integration-test package using logos-standalone-app's mkPluginTest.
   testsDir = src + "/tests";
@@ -260,9 +288,11 @@ let
     }
   ));
 
-  # Merge view-module-specific LGX outputs and integration tests into packages
+  # Merge view-module-specific LGX outputs, app bundles and integration tests
+  # into packages
   mergedPackages = lib.mapAttrs (system: sysPkgs:
-    sysPkgs // (lgxPackages.${system} or {}) // (integrationTestPackages.${system} or {})
+    sysPkgs // (lgxPackages.${system} or {}) // (appBundlePackages.${system} or {})
+      // (integrationTestPackages.${system} or {})
   ) packages;
 
 in {

--- a/lib/mkStandaloneApp.nix
+++ b/lib/mkStandaloneApp.nix
@@ -9,130 +9,17 @@
 }:
 
 let
-  parsedMetadata = builtins.fromJSON (builtins.readFile metadataFile);
-  iconFiles = pkgs.lib.optional
-    (parsedMetadata ? icon && parsedMetadata.icon != null && (qmlSrc != null || plugin != null))
-    ((dirOf metadataFile) + "/${parsedMetadata.icon}");
-
-  iconInstall = pkgs.lib.concatStringsSep "\n" (map (icon: ''
-    mkdir -p $out/icons
-    cp ${icon} $out/icons/${builtins.baseNameOf (toString icon)}
-  '') iconFiles);
-
-  pluginDir =
-    if format == "qml" && qmlSrc != null then
-      pkgs.runCommand dirName {} ''
-        set -euo pipefail
-        cp -r ${qmlSrc}/. $out
-        chmod -R u+w $out
-        cp ${metadataFile} $out/metadata.json
-        ${iconInstall}
-      ''
-    else if format == "qml" then
-      # plugin may be a lib/-layout directory (from mkLogosQmlModule combined)
-      # or a flat directory; handle both cases.
-      pkgs.runCommand dirName {} ''
-        set -euo pipefail
-        mkdir -p $out
-        if [ -d "${plugin}/lib" ]; then
-          cp -r ${plugin}/lib/. $out/
-        else
-          cp -r ${plugin}/. $out/
-        fi
-        chmod -R u+w $out
-        cp ${metadataFile} $out/metadata.json
-        ${iconInstall}
-      ''
-    else
-      pkgs.runCommand dirName {} ''
-        set -euo pipefail
-        mkdir -p $out
-        # Copy backend plugin (if present)
-        for f in ${plugin}/lib/*_plugin.*; do
-          [ -e "$f" ] && cp "$f" $out/
-        done
-        # Copy typed replica factory plugin (if present)
-        for f in ${plugin}/lib/*_replica_factory.*; do
-          [ -e "$f" ] && cp "$f" $out/
-        done
-        cp ${metadataFile} $out/metadata.json
-        ${iconInstall}
-        # Copy QML view directories and root-level QML files (if present)
-        for d in ${plugin}/lib/*/; do
-          [ -e "$d" ] || continue
-          dirname=$(basename "$d")
-          [ "$dirname" != "." ] && cp -r "$d" "$out/$dirname"
-        done
-        for f in ${plugin}/lib/*.qml; do
-          [ -e "$f" ] && cp "$f" $out/
-        done
-      '';
-
-  hasModuleDeps = moduleDeps != {};
-
-  # Create a merged modules directory containing the standalone app's built-in
-  # modules (e.g. capability_module) plus all resolved dependency modules.
-  # Each dependency is extracted from its LGX package — the same format used by
-  # lgpm and the standalone app's own capability_module bundling — ensuring all
-  # files (plugin binary + external libraries) are included.
-  modulesDir = pkgs.runCommand "${dirName}-modules" {
-    nativeBuildInputs = [ pkgs.python3 ];
-  } ''
-    mkdir -p $out
-
-    # Copy built-in modules from the standalone app (capability_module, etc.)
-    if [ -d "${standalone}/modules" ]; then
-      cp -r ${standalone}/modules/* $out/
-    fi
-
-    ${pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (name: lgxPkg: ''
-      # --- Install ${name} from LGX package ---
-      lgx_file=$(find ${lgxPkg} -name '*.lgx' | head -1)
-      if [ -n "$lgx_file" ]; then
-        extract_dir=$(mktemp -d)
-        tar -xzf "$lgx_file" -C "$extract_dir"
-
-        # Find the platform variant directory
-        variant_dir=""
-        for v in darwin-arm64-dev darwin-amd64-dev darwin-x86_64-dev \
-                 linux-x86_64-dev linux-amd64-dev linux-arm64-dev \
-                 darwin-arm64 darwin-amd64 darwin-x86_64 \
-                 linux-x86_64 linux-amd64 linux-arm64; do
-          if [ -d "$extract_dir/variants/$v" ]; then
-            variant_dir="$extract_dir/variants/$v"
-            break
-          fi
-        done
-
-        if [ -n "$variant_dir" ]; then
-          module_name=$(python3 -c "
-import json; f=open('$extract_dir/manifest.json'); print(json.load(f).get('name',str())); f.close()
-")
-          if [ -n "$module_name" ]; then
-            mkdir -p "$out/$module_name"
-            cp "$extract_dir/manifest.json" "$out/$module_name/"
-            cp -r "$variant_dir"/* "$out/$module_name/"
-            echo "Bundled $module_name from LGX into $out/$module_name/"
-          else
-            echo "Warning: could not read module name from LGX manifest for ${name}" >&2
-          fi
-        else
-          echo "Warning: no matching platform variant in LGX package for ${name}" >&2
-        fi
-        rm -rf "$extract_dir"
-      else
-        echo "Warning: no .lgx file found for ${name}" >&2
-      fi
-    '') moduleDeps)}
-  '';
+  layout = import ./appRuntimeLayout.nix {
+    inherit pkgs standalone plugin qmlSrc metadataFile dirName format moduleDeps;
+  };
 
   run = pkgs.writeShellApplication {
     name = "run-logos-standalone-ui";
     runtimeInputs = [ standalone ];
-    text = if hasModuleDeps then ''
-      exec ${standalone}/bin/logos-standalone-app --modules-dir "${modulesDir}" "${pluginDir}" "$@"
+    text = if layout.hasModuleDeps then ''
+      exec ${standalone}/bin/logos-standalone-app --modules-dir "${layout.modulesDir}" "${layout.pluginDir}" "$@"
     '' else ''
-      exec ${standalone}/bin/logos-standalone-app "${pluginDir}" "$@"
+      exec ${standalone}/bin/logos-standalone-app "${layout.pluginDir}" "$@"
     '';
   };
 in {

--- a/lib/parseMetadata.nix
+++ b/lib/parseMetadata.nix
@@ -13,6 +13,7 @@
     in {
       # Runtime fields
       name        = raw.name        or (throw "metadata.json must specify 'name'");
+      display_name = raw.display_name or raw.name or "";
       version     = raw.version     or "1.0.0";
       type        = raw.type        or "core";
       category    = raw.category    or "general";


### PR DESCRIPTION
A ui_qml module could only be run through nix, so anyone wanting to try one had to
install nix and build the whole closure first. The builder already holds everything
a package needs: the host, the plugin directory, the dependency modules and the
metadata. It can stage that tree with every path resolved relative to the
executable and hand it to the bundlers the ecosystem already uses, giving each
module an AppImage on Linux and an .app bundle on macOS.

A module supplies artwork and nothing else; the desktop entry, Info.plist and
entitlements are derived from metadata.json. The plugin and modules directories
move into their own file so the runnable app and the shipped bundle are built from
a single description of the layout.

---

Draft: depends on logos-co/logos-standalone-app#29, which is green on both architectures. The `logos-standalone-app` pin still has to move to the rev carrying `packages.<sys>.portable` before `nix build .#bin-*` resolves on a consuming module; the rest of the builder is unaffected, since the new outputs are lazy.