### PR TITLE
chore: re-pin logos-protocol to the lp owner-thread fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784753092,
-        "narHash": "sha256-cxl80GhIEd4U5R24ROJyDhj9zDpJ/oKCTd18oHWQREU=",
+        "lastModified": 1785065460,
+        "narHash": "sha256-cp5Un0NBXwNoK/+atBLMl4NwCfDXzy0KMpyUOtK6pcc=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "8ede8ece0817265c93297393febe6d908f8eb179",
+        "rev": "ae2f7e1b5842d62836091c6dc0c903508806456e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up **logos-protocol [#28](https://github.com/logos-co/logos-protocol/pull/28)** (`cacb177`): lp clients on a Qt-affine transport are constructed on the Qt main thread instead of on whichever thread happens to make the module's first outbound call.

## Why this repo cares

Every `interface: universal` (non-`ui_qml`) module is built with `-DLOGOS_API_STYLE=lp` by [`mkLogosModule.nix`](https://github.com/logos-co/logos-module-builder/blob/master/lib/mkLogosModule.nix), and the generated `bind_<iface>()` creates its client lazily on first use. So the first thread to make an inter-module call captured the module's whole transport — and if that was a worker thread (an HTTP handler, a timer thread), the QtRO node and its socket ended up on a thread with no event loop. Replica acquisition then never completed: each call burned its full 20 s timeout and returned an empty result, with no error reaching the module author.

This shipped to every universal module built by this repo, not just the one that surfaced it.

## Evidence

[openmetrics-module#6](https://github.com/logos-co/openmetrics-module/pull/6) went red on both platforms after its module-builder bump moved it onto the lp path. With the module rebuilt against this pin, and `/metrics` as the process's first IPC:

| doc-test step | before | after |
|---|---|---|
| Scrape `/metrics` | 40.5 s, one module silently missing | **8.2 ms, all modules** |
| Check `/health` | timeout (curl 28) | **0.46 ms, `ok`** |
| Stop the server | `RPC_FAILED` | **`{"result":1,"status":"ok"}`** |

Protocol side: 183/183 tests pass; the new regression tests fail after 24.8 s / 49.9 s with the fix reverted (the acquire timeouts themselves).

## Chain

1. logos-protocol#28 ← must merge first
2. **this PR** — re-pin `flake.lock` to master's SHA once #28 lands (it currently points at the PR branch commit `cacb177`)
3. downstream module bumps (openmetrics-module#6 and any other universal module) pick it up via this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)