### PR TITLE
chore: bump logos-design-system to the merged controls polish

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3701,11 +3701,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784900108,
-        "narHash": "sha256-/zH0QJZWFP/w5qrSiMuIo7oWrUisDv7r4ZskQp9faFc=",
+        "lastModified": 1785226136,
+        "narHash": "sha256-jU7on18BFpAr9NrEDmjO1bD4kuoXQ8wZa21UHpTz+Yk=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "32cc9b40195b1f42b8a8c1affb56ebd3dcfef7f4",
+        "rev": "8e67643446dbadfa2fd20c77d454e2ced83ccdc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up the overlay scroll bar that reveals itself only while in use, LogosButton sizing from its own label with an icon slot on each side, the scrim behind a modal dialog, focus reaching LogosTextField's editor, and a monospace family token (logos-co/logos-design-system#39). QML and theme only, so the static targets an importer links are unchanged.

