### PR TITLE
chore: bump logos-protocol and logos-cpp-sdk

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784762341,
-        "narHash": "sha256-sFFXe4cprvrynEyfMi4TDLJPtDkd069YpwByhC3YbD8=",
+        "lastModified": 1785270289,
+        "narHash": "sha256-kig2GkKDY7S50tffIf/HhOAldvVGzXP0wheCVKPFeeM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "2e31eeb1ac2c55245fbaa3030ff0a164fb68dd06",
+        "rev": "3d322bd3159075443f4976ebb35040a70f7ff3df",
         "type": "github"
       },
       "original": {
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785065460,
-        "narHash": "sha256-cp5Un0NBXwNoK/+atBLMl4NwCfDXzy0KMpyUOtK6pcc=",
+        "lastModified": 1785261709,
+        "narHash": "sha256-dcI6zmGy5+99MB9TaN7KGJkbvDWV8WT+B/8b5UPLjkE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ae2f7e1b5842d62836091c6dc0c903508806456e",
+        "rev": "362b03fb1ec25b35ed5d630670f5fd2bd899b196",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Mechanical re-pin. No source changes.

| input | from | to |
|---|---|---|
| `logos-protocol` | pre-#29 | `362b03f` — one canonical LIDL ↔ JSON codec (#29) |
| `logos-cpp-sdk` | pre-#111 | `3d322bd` — 64-bit `int`/`uint`, records, cdylib composites (#111, #113) |

### Why it matters

The protocol bump folds the Qt and plain-wire conversion copies into the shared
codec. That fixes three defects that were pinned as known-broken cells in the
LIDL conformance matrix:

* a `bstr` nested in a container was UTF-8 mangled — every byte ≥ 0x80 became U+FFFD
* an **empty** nested `bstr` arrived as `null` and failed the call
* a `uint64` above `int64max` degraded to a double once nested

All three are measured fixed after this bump.

### One behavioural change to know about

The Rust provider becomes **strict**. Arguments the host used to coerce before
the module saw them are now rejected with `dispatch_failed`: `-1` for a `uint`,
`3.7` for an `int`, `1` for a `bool`, a mixed-element `[tstr]`, a scalar passed
for `[any]` or `{tstr:any}`. That is the more correct behaviour — a provider
enforcing the types its contract declares — but it *is* a semantic change for
any caller that was relying on the coercion.
