### PR TITLE
chore: bump logos-rust-sdk to the records support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27440,17 +27440,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1784316501,
-        "narHash": "sha256-hCrpy8F13nJuARMNP2ydqgJ0/GpGEc/A8oJYykcC3ek=",
+        "lastModified": 1785281653,
+        "narHash": "sha256-WKvrGwRdH9r3qbyBuuGkn/Di/QtwIRC9gzYqlOe1OC8=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "a55fdac1a202ff2a4cf9d562a263ab41db17d99f",
+        "rev": "2eabc95c602424c4df8df868757900738dcd2aea",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "a55fdac1a202ff2a4cf9d562a263ab41db17d99f",
+        "rev": "2eabc95c602424c4df8df868757900738dcd2aea",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/a55fdac1a202ff2a4cf9d562a263ab41db17d99f";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/2eabc95c602424c4df8df868757900738dcd2aea";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";


### PR DESCRIPTION
Bumps `logos-rust-sdk` `a55fdac` → `2eabc95` (#29), bringing the Rust record codegen.

The input is pinned by **rev in flake.nix**, not by branch — that pin exists to break the cycle where rust-sdk depends back on this builder — so `nix flake update logos-rust-sdk` is a no-op and the URL itself has to be edited. Worth knowing for the next bump.

### Why now

`logos-test-modules`' `test_fullapi_ext_rust` declares records (`Blob`, `Wrapper`) and cannot build without this: its structs come from the Rust provider codegen. That module is part of the conformance matrix PR (logos-test-modules#28), which is blocked on this.

Verified both `test_fullapi_ext_rust` and `test_fullapi_rust` build through this builder.