### PR TITLE
chore: bump the SDKs to the scalar + void fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785270289,
-        "narHash": "sha256-kig2GkKDY7S50tffIf/HhOAldvVGzXP0wheCVKPFeeM=",
+        "lastModified": 1785338010,
+        "narHash": "sha256-ngqxnFKiTaGEO9J5LeDeR79bFFMACUaHLD4IXv1/akA=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "3d322bd3159075443f4976ebb35040a70f7ff3df",
+        "rev": "ff8c3003a494cf01d93d28e030e041e78f3dbbda",
         "type": "github"
       },
       "original": {
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785295592,
-        "narHash": "sha256-CQ7QNiBaEf/s+om7pK9NtmYnZ4oDWHgPwX3muZ5uYdE=",
+        "lastModified": 1785336618,
+        "narHash": "sha256-s+3ZB2cVUJe1+dEZzpQlD46w2xZWXu5L4K1v15HNhBk=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "8b8a358c8bfdf92e54c5164fd460c4ab31e2f400",
+        "rev": "c0df466172497741dfaa25d2e74a98947df60ada",
         "type": "github"
       },
       "original": {
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784762357,
-        "narHash": "sha256-SozQr27TzKAk0WxNiXHC/CvXkuB2ovu81/VLsiDhvUg=",
+        "lastModified": 1785338013,
+        "narHash": "sha256-HxUSlvzwnuvQTqb7h6ROTuQxQBqsU1M68ePXQcbEcJA=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "92bd4491041485efda6e1a2061629ea438af07ab",
+        "rev": "a5874feb1a5f0dd7d04c3281ea2892381c939c1d",
         "type": "github"
       },
       "original": {
@@ -27440,17 +27440,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1785281653,
-        "narHash": "sha256-WKvrGwRdH9r3qbyBuuGkn/Di/QtwIRC9gzYqlOe1OC8=",
+        "lastModified": 1785339813,
+        "narHash": "sha256-yAxm6rX5FrryazA1GalZIR6Ki8wZyT4Gw8BdcSK8Rl8=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "2eabc95c602424c4df8df868757900738dcd2aea",
+        "rev": "e43eb3d7520cd175ba9386475022a3dcd909925b",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "2eabc95c602424c4df8df868757900738dcd2aea",
+        "rev": "e43eb3d7520cd175ba9386475022a3dcd909925b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/2eabc95c602424c4df8df868757900738dcd2aea";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/e43eb3d7520cd175ba9386475022a3dcd909925b";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";


### PR DESCRIPTION
Carries four merged fixes to every module built through this builder.

| input | | |
|---|---|---|
| `logos-protocol` | c0df466 | logos-co/logos-protocol#31 — signedness and range in `Codec<T>`; pending-call sentinel matched by shape rather than key presence |
| `logos-cpp-sdk` | ff8c300 | logos-co/logos-cpp-sdk#115 — cdylib typed scalars go through the codec, and the *emitted* codec checks signedness |
| `logos-qt-sdk` | a5874fe | logos-co/logos-qt-sdk#20 — `void` converged in the shared cdylib glue |
| `logos-rust-sdk` | e43eb3d | logos-co/logos-rust-sdk#30 — `void` arms on both sides, plus the interface metadata |

Together they close two divergences where the same contract answered differently depending on which provider a consumer resolved to:

```
echoUint(-1)  ->  18446744073709551615 (C++)  vs  dispatch_failed (Rust)
doVoid()      ->  true (C++)                  vs  METHOD_FAILED (Rust)
```

Both are now the same on both sides, and the conformance registry drops from three xfails to one (logos-co/logos-test-modules#30).

## One thing worth knowing about this repo

`logos-rust-sdk` is pinned **by rev in `flake.nix`** (line 44), to break the cycle where rust-sdk depends back on this builder. So `nix flake update logos-rust-sdk` is a silent no-op — it reports success and changes nothing — and the URL has to be edited by hand. That has already cost this chain one round trip, when a bump looked applied and wasn't.

Lock + one URL line. `nix build .#checks.<sys>.default` green; all four root inputs verified at the revs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)