### PR TITLE
chore: bump protocol + cpp-sdk to the whole-valued-float fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785338010,
-        "narHash": "sha256-ngqxnFKiTaGEO9J5LeDeR79bFFMACUaHLD4IXv1/akA=",
+        "lastModified": 1785344749,
+        "narHash": "sha256-3LpY1xPeeKQ7NmcUwQUq/mEiYekxveS1CxGN8UqU+Vc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "ff8c3003a494cf01d93d28e030e041e78f3dbbda",
+        "rev": "c3641330662454c849103908180993981050a8c8",
         "type": "github"
       },
       "original": {
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785336618,
-        "narHash": "sha256-s+3ZB2cVUJe1+dEZzpQlD46w2xZWXu5L4K1v15HNhBk=",
+        "lastModified": 1785343924,
+        "narHash": "sha256-7hoe38lZ398SLj8uyGAl2OpqnrSAA4vb4xfhnY7Mt+U=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "c0df466172497741dfaa25d2e74a98947df60ada",
+        "rev": "3da8de93dfd1bc835c10ad48088d56bd6c607b97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow-up to #170.

| input | | |
|---|---|---|
| `logos-protocol` | 3da8de9 | logos-co/logos-protocol#32 |
| `logos-cpp-sdk` | c364133 | logos-co/logos-cpp-sdk#116 |

The signedness check that #170 carried went one step too far: it rejected `3.0` as well as `3.7`, which broke four `test_basic_module_cpp` cases (`addInts(3.0, 4.0)`, `echoInt(42.0)`, `isPositive(5.0)`, `twoArgs(hi, 3.0)`) that pass a whole-valued double where the contract declares an integer.

Those tests are right: JSON does not distinguish `3` from `3.0`, and the codec already accepts an integral number for `float64` on that same reasoning. A float now decodes as an integer when it has no fractional part and fits the range — `3.7` is still refused, which is what the original change was for.

Both repos, because the cdylib generator emits its own copy of the codec; a rule applied to one leaves the other disagreeing.

Lock-only. `checks.default` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)