### PR TITLE
chore: bump to the single-source LIDL codec

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785344749,
-        "narHash": "sha256-3LpY1xPeeKQ7NmcUwQUq/mEiYekxveS1CxGN8UqU+Vc=",
+        "lastModified": 1785353260,
+        "narHash": "sha256-z8NPSvBNM7AxcNTqTc/DdvFAXLeHiZ12enSgjh3qU40=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "c3641330662454c849103908180993981050a8c8",
+        "rev": "5f63af681ac4805d059332b63e6191c4a8e2820d",
         "type": "github"
       },
       "original": {
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785343924,
-        "narHash": "sha256-7hoe38lZ398SLj8uyGAl2OpqnrSAA4vb4xfhnY7Mt+U=",
+        "lastModified": 1785352565,
+        "narHash": "sha256-i5ynBtNk6Qe+YSHsa+O8DjnLpHXDVqyLGPxBAImipD8=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "3da8de93dfd1bc835c10ad48088d56bd6c607b97",
+        "rev": "4ee85b26a65e331821823f6435135c088a1bf447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| input | | |
|---|---|---|
| `logos-protocol` | 4ee85b2 | logos-co/logos-protocol#33 (path threading) + #34 (adopted byte coverage) |
| `logos-cpp-sdk` | 5f63af6 | logos-co/logos-cpp-sdk#117 (the codec exists once) + #118 (test decoupling) |

Modules built through this builder no longer carry a generated copy of the codec. The generic half — scalars, bstr, vector/map composition, error paths — now comes from `logos_codec.h`; what the generator still emits is one `Codec` specialization per record the module declares, which is irreducible without field reflection.

Two defects die with the duplication: padded base64 silently decoding to an empty vector, and a module contradicting itself where `echoBytes("hi")` succeeded while `echoBytesList(["hi"])` threw.

Lock-only. `checks.default` green.

Expected downstream: exactly one conformance cell moves — C++ `[bstr]` goes from rejecting `["hi"]` to accepting it as `[{"_bytes":"aGk"}]`, converging with Rust. Baselined ahead of time in logos-co/logos-test-modules#31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)