### PR TITLE
fix: repin nixpkgs with fetchCargoVendor User-Agent hotfix (crates.io 403 breaking all module releases)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45939,6 +45939,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_642": {
+      "locked": {
+        "lastModified": 1785366257,
+        "narHash": "sha256-pv+s8QHZNIncHBQ833zt9QZ+DeCb3mHk/1aDuX+xLNY=",
+        "owner": "danisharora099",
+        "repo": "nixpkgs",
+        "rev": "eaec81d3b8a8d2339e25c718a1650b2c45adf726",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danisharora099",
+        "repo": "nixpkgs",
+        "rev": "eaec81d3b8a8d2339e25c718a1650b2c45adf726",
+        "type": "github"
+      }
+    },
     "nixpkgs_65": {
       "locked": {
         "lastModified": 1759036355,
@@ -47057,10 +47073,7 @@
         "logos-view-module-runtime": "logos-view-module-runtime_15",
         "nix-bundle-lgx": "nix-bundle-lgx_44",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_15",
-        "nixpkgs": [
-          "logos-nix",
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_642",
         "rust-overlay": "rust-overlay_5"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,15 @@
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";
-    nixpkgs.follows = "logos-nix/nixpkgs";
+    # HOTFIX (#159): crates.io now rejects the UA-less python fetch in this
+    # pin's fetchCargoVendor with HTTP 403, which breaks cargo vendoring in
+    # every module release that follows this flake's nixpkgs. This pin is the
+    # exact rev logos-nix locks (e9f00bd8) plus ONE commit: the upstream
+    # User-Agent fix (adapted from NixOS/nixpkgs@8209ba2b, NixOS/nixpkgs#512735),
+    # so the package set is byte-identical and all fixed-output hashes stay
+    # valid. Revert to `nixpkgs.follows = "logos-nix/nixpkgs"` once logos-nix
+    # advances past 2026-04-26 (first nixos-unstable containing the fix).
+    nixpkgs.url = "github:danisharora099/nixpkgs/eaec81d3b8a8d2339e25c718a1650b2c45adf726";
   };
 
   outputs = { self, nixpkgs, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-plugin-qt, logos-plugin-core, nix-bundle-logos-module-install, nix-bundle-lgx, logos-standalone-app, logos-test-framework, logos-rust-sdk, rust-overlay ? null, ... }:


### PR DESCRIPTION
Fixes #159 — every module release's cargo vendoring currently dies with `crates.io … Status code: 403`.

## Problem

crates.io now rejects requests carrying python-requests' default `User-Agent`. The nixpkgs rev this flake follows (`e9f00bd8`, via `logos-nix/nixpkgs`, 2025-09-28) predates the upstream fix, so its `fetchCargoVendor` helper (`pkgs/build-support/rust/fetch-cargo-vendor-util.py`) creates a `requests.Session()` with **no** `User-Agent` — every `*-vendor-staging` fixed-output derivation gets a 403. Because module flakes do `nixpkgs.follows = "logos-module-builder/nixpkgs"`, this breaks the whole ecosystem's release CI (evidence in #159).

Upstream fixed it in [NixOS/nixpkgs@`8209ba2b`](https://github.com/NixOS/nixpkgs/commit/8209ba2bc62783d05f197e66958853fd9ecab027) (merged 2026-04-26 in NixOS/nixpkgs#512735). It was **never backported** to release-25.05 or release-25.11 — only nixos-unstable ≥ 2026-04-26 has it.

## Fix: patched pin, scoped to the fixed-output fetch (zero rebuild fallout)

Options assessed:

- **(a) advance the pin to current nixos-unstable** — ~10 months of Qt/compiler/toolchain churn into every module build. Too risky for a hotfix; that jump should happen deliberately via logos-nix later.
- **(a') naive cherry-pick of the upstream commit onto `e9f00bd8`** — tried first, rejected: the patched util script is also referenced by the input-addressed `*-vendor` step, so the change cascades through `python3Packages.cryptography` into **Qt rebuilds** (empirically observed: qtdeclarative 6.9.2 compiling from source). On ephemeral CI runners that means hours per release.
- **(b) this PR: `e9f00bd8` + one commit that applies the UA only to the fixed-output `vendorStaging` derivation** (the only network-facing step). Fixed-output derivations are absorbed by `hashDerivationModulo`, so **no input-addressed derivation changes at all**.

Store-path invariance, verified by evaluation at both refs (unpatched `e9f00bd8` vs patched `eaec81d3`):

| attr | unpatched | patched |
|---|---|---|
| `cargo-auditable` | `68xislcb…` | `68xislcb…` (identical) |
| `python3Packages.cryptography` | `qlpkk5k0…` | `qlpkk5k0…` (identical) |
| `qt6.qtdeclarative` | `fn7iqpps…` | `fn7iqpps…` (identical) |
| `fetchCargoVendor` `-vendor` output | `h41y5c2x…` | `h41y5c2x…` (identical) |
| `-vendor-staging` **.drv** | `sbp0k9gd…` | `hknibz45…` (**only this changes**) |

So: binary-cache substitution from cache.nixos.org is completely unaffected, existing `cargoHash` values stay valid, and the only thing that changes is that the staging fetch now sends `User-Agent: nixpkgs-fetchCargoVendor/1 (https://github.com/NixOS/nixpkgs)`.

A plain overlay was ruled out: `fetchCargoVendorUtil` is a `let`-binding inside nixpkgs' `fetch-cargo-vendor.nix`, `makeRustPlatform` wires the fetcher via a nixpkgs-relative `callPackage` path, and module flakes import the followed nixpkgs themselves — nothing short of changing the nixpkgs *source* reaches their `rustPlatform.buildRustPackage { cargoHash = …; }` callsites transparently.

The patched branch is [`danisharora099/nixpkgs#patch/fetch-cargo-vendor-ua-e9f00bd8`](https://github.com/danisharora099/nixpkgs/tree/patch/fetch-cargo-vendor-ua-e9f00bd8) (single commit [`eaec81d3`](https://github.com/danisharora099/nixpkgs/commit/eaec81d3b8a8d2339e25c718a1650b2c45adf726), +20/-1 on one file). **Recommended follow-up for maintainers:** push that same commit to `logos-co/nixpkgs` (which already hosts patch branches, e.g. `patch/mingw-qt6`) and flip the owner in `flake.nix` — rev and narHash stay identical, so only the lock's `owner` field changes.

## Validation

**Before (pin `e9f00bd8`)** — minimal `rustPlatform.fetchCargoVendor` of a lockfile containing `bitflags 2.9.4` (the exact crate from the CI evidence), fresh store path:

```
> Exception: Failed to fetch file from https://crates.io/api/v1/crates/bitflags/2.9.4/download. Status code: 403
```

**After (patched `eaec81d3`)** — identical derivation, staging output force-deleted first:

```
ua-repro> Fetching https://crates.io/api/v1/crates/bitflags/2.9.4/download -> tarballs/bitflags-2.9.4.tar.gz
/nix/store/h41y5c2xdrlmfh61kh3i2rga9l4q9f4f-ua-repro-20260730-vendor
```

**CI-parity acid test** — scratch clone of `logos-co/eth-lez-atomic-swaps` (the repo from the #159 evidence), `nix build .#lgx-portable` in `swap-module/`, with the pre-seeded `swap-ffi` / `zerokit` vendor-staging, vendor, and compiled outputs `nix store delete`d so the crates.io fetches actually run cold: the full ~380-crate staging fetch completes with zero 403s, swap-ffi compiles, and the lgx bundle assembles end-to-end (`EXIT=0`). Full details + logs in the #159 comment.

Cross-validation: current nixos-unstable's official fetcher produces a byte-identical vendor staging (same FOD hash) as this patch on the same input — the patch is behaviorally equivalent to upstream.

## Two adjacent findings (out of scope here, but release CI needs them)

1. **`logos-delivery` pins its own nixpkgs** (`23d72dab`, 2026-02-07 — verified also UA-less), which is what vendors zerokit. That pin is outside this flake's follows chain, so zerokit vendoring stays broken until logos-delivery gets the same fix. A ready-made branch exists: [`patch/fetch-cargo-vendor-ua-23d72dab`](https://github.com/danisharora099/nixpkgs/tree/patch/fetch-cargo-vendor-ua-23d72dab) (used successfully in the acid test via `--override-input delivery_module/logos-delivery/nixpkgs`). Worth a sibling issue on logos-delivery.
2. **eth-lez-atomic-swaps' committed `cargoHash` is stale** (`sha256-Xu7WL+…`): a genuine cold fetch yields `sha256-lADceazcOPwMkeBwUElibZ5oMPsLD1gIZdVGkGQfX0E=` — confirmed independently by current nixos-unstable's official fetcher. The pre-seeded-store release workaround has been masking this; that repo needs the hash bump regardless of this PR.

Consumers pick this fix up by bumping their `logos-module-builder` input. Revert path is documented in the flake comment: return to `follows = "logos-nix/nixpkgs"` once logos-nix advances past 2026-04-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
