### PR TITLE
chore: stop producing and requesting the std header variant

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -298,12 +298,13 @@ function(logos_module)
             )
         endif()
         
-        # LOGOS_API_STYLE selects between Qt-typed and std-typed
-        # wrapper signatures on the generated `<Module>` client class.
-        # Defaults to "qt" — every existing handcrafted module keeps
-        # its Qt-typed LogosModules. Universal modules (those declaring
-        # `interface: "universal"` in metadata.json) get this set to
-        # "std" automatically by mkLogosModule.nix.
+        # LOGOS_API_STYLE selects between Qt-typed and lp (Qt-free,
+        # logos-protocol C ABI) wrapper signatures on the generated
+        # `<Module>` client class. Defaults to "qt" — every existing
+        # handcrafted module keeps its Qt-typed LogosModules. Core
+        # universal modules (those declaring `interface: "universal"`
+        # in metadata.json, minus `type: ui_qml` view backends) get this
+        # set to "lp" automatically by mkLogosModule.nix.
         if(NOT DEFINED LOGOS_API_STYLE OR LOGOS_API_STYLE STREQUAL "")
             set(LOGOS_API_STYLE "qt")
         endif()

--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -72,27 +72,46 @@ let
       legacyHeaderDepNames = lib.filter (name: !(depIsLidl name)) config.dependencies;
 
       # Resolve the TRANSITIONAL header-copy deps from inputs. Each entry is a
-      # struct exposing the dep's plugin (.lib) plus both header variants
-      # (.headers-qt / .headers-std) so the plugin builder can pick the one
+      # struct exposing the dep's plugin (.lib) plus the header variants
+      # (.headers-qt / .headers-lp) so the plugin builder can pick the one
       # matching its own --api-style. See the matching block in mkLogosModule.nix
       # for the full rationale + fallback chain. Remove once all deps publish LIDL.
+      # Everything built through here is a view module (type: ui_qml), which
+      # buildPlugin.nix always types "qt" — the `headers-lp` entry exists so an
+      # lp consumer that ever reaches this path fails with a real message
+      # instead of a "cannot coerce a set to a string" from the header copy.
       moduleInputs = lib.filterAttrs (n: _: builtins.elem n legacyHeaderDepNames) flakeInputs;
-      resolvedModuleDeps = lib.mapAttrs (_: input:
+      resolvedModuleDeps = lib.mapAttrs (depName: input:
         let
           ps = input.packages.${system} or null;
           fallback = if input ? packages.${system}.default
                      then input.packages.${system}.default else input;
+          staleLpDep = reason: throw ''
+            logos-module-builder: dependency '${depName}' cannot be consumed by an lp (Qt-free) module.
+
+            '${depName}' is taking the transitional header-copy path (it publishes
+            no `lidl` output), and
+              ${reason}.
+            So the only headers it offers are Qt-typed. Copying those into a
+            Qt-free translation unit fails deep inside a generated source file
+            with a wall of unrelated-looking Qt type errors, so this build stops
+            here instead.
+
+            Fix: rebuild / re-pin '${depName}' against a current logos-module-builder.
+            Any module built by one publishes a `lidl` contract (preferred — it
+            skips the header copy entirely) as well as a `headers-lp` output.
+          '';
         in
         if ps != null then {
           default     = ps.default;
           lib         = ps.lib or ps.default;
           headers-qt  = ps.headers-qt or ps.include or ps.default;
-          headers-std = ps.headers-std or ps.headers-qt or ps.include or ps.default;
+          headers-lp  = ps.headers-lp or (staleLpDep "its packages.${system} exposes no `headers-lp`");
         } else {
           default     = fallback;
           lib         = fallback;
           headers-qt  = fallback;
-          headers-std = fallback;
+          headers-lp  = staleLpDep "the flake input is a bare derivation with no packages.${system} attrset";
         }
       ) moduleInputs;
 

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -156,9 +156,11 @@ let
       # plugin .dylib AND the right header variant for its own
       # --api-style without re-running the codegen at consume time.
       # Backward-compatible fallbacks let older deps (which only
-      # expose `default`) still work — they get treated as Qt-typed.
+      # expose `default`) still work for a QT consumer — they get
+      # treated as Qt-typed. An lp consumer gets no such fallback:
+      # Qt-typed headers cannot serve it, so it throws (see staleLpDep).
       moduleInputs = lib.filterAttrs (n: _: builtins.elem n legacyHeaderDepNames) flakeInputs;
-      resolvedModuleDeps = lib.mapAttrs (_: input:
+      resolvedModuleDeps = lib.mapAttrs (depName: input:
         let
           ps = input.packages.${system} or null;
           # Pre-version of this refactor: input was the raw flake-output
@@ -166,21 +168,40 @@ let
           # external flake-input dep still works.
           fallback = if input ? packages.${system}.default
                      then input.packages.${system}.default else input;
+          # An lp (Qt-free) consumer must NOT silently fall back to a Qt-typed
+          # header set. The wrappers would declare QString/QVariantMap while the
+          # consumer's own codegen ran with `--api-style lp`, so the build dies
+          # deep inside a generated TU with a wall of unrelated-looking Qt type
+          # errors. Fail here instead, where we can say what is actually wrong.
+          # Lazy: this only fires if an lp consumer really reads `headers-lp`.
+          staleLpDep = reason: throw ''
+            logos-module-builder: dependency '${depName}' cannot be consumed by an lp (Qt-free) module.
+
+            '${depName}' is taking the transitional header-copy path (it publishes
+            no `lidl` output), and
+              ${reason}.
+            So the only headers it offers are Qt-typed. Copying those into a
+            Qt-free translation unit fails deep inside a generated source file
+            with a wall of unrelated-looking Qt type errors, so this build stops
+            here instead.
+
+            Fix: rebuild / re-pin '${depName}' against a current logos-module-builder.
+            Any module built by one publishes a `lidl` contract (preferred — it
+            skips the header copy entirely) as well as a `headers-lp` output.
+          '';
         in
         if ps != null then {
           default     = ps.default;
           lib         = ps.lib or ps.default;
           headers-qt  = ps.headers-qt or ps.include or ps.default;
-          headers-std = ps.headers-std or ps.headers-qt or ps.include or ps.default;
-          # lp (Qt-free) variant for core universal consumers. Falls back to
-          # std/qt for a dep built by an older builder that predates headers-lp.
-          headers-lp  = ps.headers-lp or ps.headers-std or ps.headers-qt or ps.include or ps.default;
+          # lp (Qt-free) variant for core universal consumers. No Qt fallback —
+          # see staleLpDep above.
+          headers-lp  = ps.headers-lp or (staleLpDep "its packages.${system} exposes no `headers-lp`");
         } else {
           default     = fallback;
           lib         = fallback;
           headers-qt  = fallback;
-          headers-std = fallback;
-          headers-lp  = fallback;
+          headers-lp  = staleLpDep "the flake input is a bare derivation with no packages.${system} attrset";
         }
       ) moduleInputs;
 
@@ -511,8 +532,8 @@ let
       # `nix develop` shell (which exports LOGOS_*_ROOT) without re-running codegen.
       moduleGenerate = selectedBackend.generate (mkPluginArgs "default");
 
-      # Three header variants per module — Qt-typed, std-typed, and lp
-      # (Qt-free, logos-protocol C ABI). Each is its own Nix derivation, so a
+      # Two header variants per module — Qt-typed and lp (Qt-free,
+      # logos-protocol C ABI). Each is its own Nix derivation, so a
       # downstream module only realises the one its `--api-style` actually
       # consumes. The lp variant lets a core universal (header-first cdylib)
       # module copy a Qt-free typed wrapper for a LEGACY dependency that
@@ -520,15 +541,14 @@ let
       # dep's built plugin, so it works regardless of how the dep was
       # authored). Default output (`include`) stays the Qt variant for
       # backward compatibility with consumers that read `${dep}/include`.
+      # (A third `std` variant — std-typed signatures but still marshalling
+      # through QVariant, so never actually Qt-free — used to be built here.
+      # `buildPlugin.nix` only ever selects "qt" or "lp", so it had no
+      # consumer; it was retired rather than rebuilt for every module.)
       moduleIncludeQt = selectedBackend.buildHeaders {
         inherit pkgs src config logosSdk;
         pluginLib = moduleLib;
         apiStyle = "qt";
-      };
-      moduleIncludeStd = selectedBackend.buildHeaders {
-        inherit pkgs src config logosSdk;
-        pluginLib = moduleLib;
-        apiStyle = "std";
       };
       moduleIncludeLp = selectedBackend.buildHeaders {
         inherit pkgs src config logosSdk;
@@ -594,14 +614,12 @@ let
       "${config.name}-lib" = moduleLib;
       "${config.name}-include" = moduleIncludeQt;
       "${config.name}-headers-qt"  = moduleIncludeQt;
-      "${config.name}-headers-std" = moduleIncludeStd;
       "${config.name}-headers-lp"  = moduleIncludeLp;
 
       # Short aliases (e.g., nix build .#lib)
       lib = moduleLib;
       include = moduleIncludeQt;
       headers-qt  = moduleIncludeQt;
-      headers-std = moduleIncludeStd;
       headers-lp  = moduleIncludeLp;
 
       # Default package - combined lib + include (nix build)


### PR DESCRIPTION
**Merge FIRST**, before logos-cpp-sdk `std/retire-clean`. This is the "stop calling" half; that one is the "drop support" half. Reversed, module builds break in the gap.

### What was actually wrong

`mkLogosModule.nix:531` passed `apiStyle = "std"` to `buildHeaders`, so **every module in the tree built a `headers-std` derivation** — and nothing ever consumed it. The only interpolated selector, `buildPlugin.nix:59` `dep."headers-${apiStyle}"`, resolves `apiStyle` from `buildPlugin.nix:44-46`, which computes only `"lp"` or `"qt"`. `"std"` is unreachable on every branch.

So this deletes wasted build work, not just dead config.

### The fallback rung

`headers-lp = ps.headers-lp or ps.headers-std or ps.headers-qt or ...` was **not** simply truncated. A stale external dep falling through to `headers-qt` hands an lp (Qt-free) consumer Qt-typed headers — a confusing compile error instead of a clean one. It now throws with an actionable message. Verified against synthetic probe flakes:

| scenario | result |
|---|---|
| new builder + lp consumer + stale dep | `error: dependency 'stale_dep' cannot be consumed by an lp (Qt-free) module` + fix |
| **old** builder, identical inputs | builds — the silent Qt degradation |
| new builder + **qt** consumer + stale dep | builds (throw is lazy; no Qt regression) |

### Verification

- Every module's closure re-checked: `headers-std` count **0**; outputs are `headers-lp` / `headers-qt`.
- The one live legacy-header-copy consumer (`test_context_module_cpp`) resolves `headers-lp` and stops before the retired rung.

### Known follow-up, not fixed here

`logos-plugin-qt/lib/buildHeaders.nix:93-96` swallows the generator's exit code (`|| { echo Warning...; touch .no-api; }`). A failing generator therefore yields a **silently empty header set** rather than a build failure. Not triggered by this PR, but it means generator errors in this path are invisible in general. Worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)