### PR TITLE
chore: re-pin the SDK stack for LIDL optional support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785458512,
-        "narHash": "sha256-y+2TXyW2FPLxO/xs98wxeUtsQGXcIl0rMveZJ0ozIeY=",
+        "lastModified": 1785493187,
+        "narHash": "sha256-yU/W4JcL0jRqvtBNxbN6QZ8EzTJDqTh3+JMYAuAiM7s=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "5d0a99a182574f5c096cca42306daeb3b8343df6",
+        "rev": "198f0317cadd3613de4b1a3a02fcd208c5e3431d",
         "type": "github"
       },
       "original": {
@@ -4751,11 +4751,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781653473,
-        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -5130,11 +5130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781653473,
-        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -5545,11 +5545,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781653473,
-        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785467016,
-        "narHash": "sha256-lUNyiMxY6QEmKbp8PKEw3+DLZziIkLMKcQgx6UfVrZ4=",
+        "lastModified": 1785493892,
+        "narHash": "sha256-X4wTVqUAFeWEZTY41kWh8mjPohye1a6JB+0sEVMZe58=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "783234575106b2d5062d75f89cd705b7874b5735",
+        "rev": "a3ee2fc30bb7b31968d39f90838d8940e41dc37d",
         "type": "github"
       },
       "original": {
@@ -27440,17 +27440,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1785339813,
-        "narHash": "sha256-yAxm6rX5FrryazA1GalZIR6Ki8wZyT4Gw8BdcSK8Rl8=",
+        "lastModified": 1785493201,
+        "narHash": "sha256-Mio9WcLzDlXQoV0PAnVGS4cMrFyYEO71RhdSUVFCJPU=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "e43eb3d7520cd175ba9386475022a3dcd909925b",
+        "rev": "8e5900d48516ca2e032660439476522a26972180",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "8e5900d48516",
         "repo": "logos-rust-sdk",
-        "rev": "e43eb3d7520cd175ba9386475022a3dcd909925b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/e43eb3d7520cd175ba9386475022a3dcd909925b";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/8e5900d48516";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";


### PR DESCRIPTION
Carries the merged LIDL optional stack downstream.

| input | | |
|---|---|---|
| `logos-cpp-sdk` | `5d0a99a` → `198f031` | cdylib gate, record codecs, header parser |
| `logos-rust-sdk` | `e43eb3d` → `8e5900d` | `Ty::Opt`, `Option<T>` emission |
| `logos-qt-sdk` | `7832345` → `a3ee2fc` | re-pins its own lidl to match cpp-sdk's frontend |

**`logos-rust-sdk` is pinned by rev in `flake.nix:44`**, where `nix flake update` is a silent no-op — that line is edited by hand. This workspace has been caught by that before.

### What the first attempt caught

`rust-native-dep` and `test-framework-integration` failed on the first try:

```
lidl_compat.h:41: error: no member named 'typeIsOptional' in namespace 'lidl'
```

`logos-qt-generator` compiles cpp-sdk's shipped `share/lidl-frontend/`, but qt-sdk pinned its own, older `logos-lidl`. Fixed upstream in logos-qt-sdk#25, which this bump carries.

Worth noting `default` passed in that failing run — stopping at the first check would have shipped a broken pin set. **All five build now.**

Unblocks logos-test-modules#37 (the optional conformance cases), which needs this to build its ext providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)