### PR TITLE
chore: re-pin logos-protocol for Codec<std::optional<T>>

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785352565,
-        "narHash": "sha256-i5ynBtNk6Qe+YSHsa+O8DjnLpHXDVqyLGPxBAImipD8=",
+        "lastModified": 1785470728,
+        "narHash": "sha256-K6rr5ycCWctvtUnktskjRlXHN3GuI7FEbz8/FX+pVY8=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "4ee85b26a65e331821823f6435135c088a1bf447",
+        "rev": "72754ab9b2ea8a43a3f04c5bdf1411673f3f489e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow-up to #177, which bumped cpp-sdk, rust-sdk and qt-sdk but **not** protocol.

This repo declares `logos-cpp-sdk.inputs.logos-protocol.follows` and `logos-qt-sdk.inputs.logos-protocol.follows` (`flake.nix:12,17`), so **its** protocol pin is authoritative for the whole closure. cpp-sdk's own pin of the protocol carrying `Codec<std::optional<T>>` (logos-protocol#37) is overridden and never reaches a module build.

The symptom is the generator doing its job and the module failing anyway:

```
error: implicit instantiation of undefined template
       'logos::detail::Codec<std::optional<std::string>>'
```

`logos-protocol` `4ee85b2` → `72754ab`. All five checks build.

### Why #177 looked complete

Every check passed there, because **nothing in this repo's own check set declares an optional field**. The omission was only observable from logos-test-modules, whose ext provider is the first thing in the tree to use one. A `follows` that unifies a dependency also hides when that dependency is behind.

Unblocks logos-test-modules#37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)