### PR TITLE
chore: re-pin logos-cpp-sdk for the type contract (no silent `any` admissions)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785493187,
-        "narHash": "sha256-yU/W4JcL0jRqvtBNxbN6QZ8EzTJDqTh3+JMYAuAiM7s=",
+        "lastModified": 1785507544,
+        "narHash": "sha256-ysZAx2Ru0vCcfSYFSXYUhyLTawn/o8IfvFE0n3AZ3OU=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "198f0317cadd3613de4b1a3a02fcd208c5e3431d",
+        "rev": "44b92b0480aedb8dc1e60b23718d43cab14cfec7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`logos-cpp-sdk` `198f031` → `44b92b0`, bringing logos-cpp-sdk#127:

- an unrecognised C++ spelling is a **build error naming the type and the fix**, instead of being published as the opaque `any`
- `invalid_args` on a wrong argument count — matching what logos-rust-sdk already emitted, closing a divergence where Rust returned an error object and C++ returned NULL (indistinguishable from a legitimate empty return)
- `std::unordered_map<std::string,T>` supported
- the last emitted base64 codec deleted

### Verification

All five checks build, so nothing in this repo's own check set declares an unrepresentable type.

But green checks don't prove the gate is *live*, so I probed it directly — a header with `uint32_t depth` is now rejected:

```
method 'narrowParam': parameter 'depth' is `uint32_t`, which has no LIDL type.
  LIDL numbers are 64-bit only. Declare it `uint64_t` (LIDL `uint`). Widening is
  source-compatible for every caller; a narrow type on the wire is not, which is
  why LIDL has none.
```

(My first probe passed — because I'd built the generator from a local checkout that wasn't on master. Worth mentioning since it's the failure mode this whole change exists to prevent: a check that can't fail.)

### Known downstream breakage — deliberate, not fixed here

Two modules relied on the old silence and stop building until four declarations are widened:

| repo | what |
|---|---|
| `logos-execution-zone-module` | `lez_core`: `restore_storage(depth)` and the `instruction` vectors of `send_generic_{public,private}_transaction` — `uint32_t` → `uint64_t` |
| `logos-libp2p-module` | `createXpr(services)`: the pair's second element carries **raw binary** and was published as `[any]`, i.e. UTF-8-lossy **today**. `{tstr: bstr}` keeps it byte-exact |

All pure widening, source-compatible for callers. The libp2p one is a data-corruption fix, not a typing nit. Worth warning those owners before this merges rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)