### PR TITLE
chore: re-pin the SDK stack for the off-strand close-race fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785507544,
-        "narHash": "sha256-ysZAx2Ru0vCcfSYFSXYUhyLTawn/o8IfvFE0n3AZ3OU=",
+        "lastModified": 1785528309,
+        "narHash": "sha256-dz/zZVFwHsM8zvkfuWOm9x9J2b+ridUbvS1IIc876ZQ=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "44b92b0480aedb8dc1e60b23718d43cab14cfec7",
+        "rev": "8c3d7d4253bdf2f9b2e4a9a3faaff6c1772fc1d8",
         "type": "github"
       },
       "original": {
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785470728,
-        "narHash": "sha256-K6rr5ycCWctvtUnktskjRlXHN3GuI7FEbz8/FX+pVY8=",
+        "lastModified": 1785523697,
+        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "72754ab9b2ea8a43a3f04c5bdf1411673f3f489e",
+        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
         "type": "github"
       },
       "original": {
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785493892,
-        "narHash": "sha256-X4wTVqUAFeWEZTY41kWh8mjPohye1a6JB+0sEVMZe58=",
+        "lastModified": 1785528949,
+        "narHash": "sha256-rbhraPiFA8tZeTgTjBNJtcj184WENXbUWQwuoEiZJJk=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "a3ee2fc30bb7b31968d39f90838d8940e41dc37d",
+        "rev": "cde7d42d19ad014030db7470f2f14505c4b857c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Last link in the protocol chain. logos-liblogos, logos-cpp-sdk and logos-qt-sdk masters are all on `3a31c91` already; this repo's protocol pin is authoritative for its closure via the cpp-sdk/qt-sdk `follows`.

| input | | |
|---|---|---|
| `logos-protocol` | `72754ab` → `3a31c91` | #38 `RpcConnection::fail`, #39 `RpcServer` acceptor |
| `logos-cpp-sdk` | `44b92b0` → `8c3d7d4` | its own protocol bump (#128) |
| `logos-qt-sdk` | `a3ee2fc` → `cde7d42` | its own protocol bump (#26) |

### The bug

`RpcConnection::fail()` closed the socket on the **caller's thread** while every other stream access was serialized on `m_strand` — a strand serializes handlers, not a raw call from outside it. It raced `kqueue_reactor::start_op` and crashed the client on teardown in **~0.45% of calls** over `tcp`/`tcp_ssl` (zero on `local`/QtRO).

It is a **false negative**, which is why it went unnoticed: the RPC completes and prints its correct result, then teardown segfaults — so any caller checking the exit code before parsing stdout reports a healthy call as failed. #39 is the same bug class on the server's acceptor.

### Every protocol node agrees

```
logos-protocol                 -> 3a31c91d1322
logos-cpp-sdk/logos-protocol   -> 3a31c91d1322
logos-qt-sdk/logos-protocol    -> 3a31c91d1322
```

Checked with a **follows-aware** resolver. A `follows` entry in `flake.lock` is a path array resolved from the root, not a node name; a naive reading reports the wrong revisions, which already produced one wrong conclusion in this work.

**Bumping only the root pin is not sufficient in general.** logos-logoscore-cli had its root pin correct and still segfaulted 4/2000 client calls, because `logos-liblogos` is linked into it and brought its own older protocol — three protocols in one image (logoscore-cli#81). liblogos is now fixed at source, so that per-consumer workaround is no longer load-bearing.

### Verification

All five checks build: `default`, `static-extlib`, `rust-native-dep`, `test-framework-integration`, `qml-integration`. Worth running all of them — two failed on an earlier bump in this repo where `default` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)