### PR TITLE
chore: re-pin logos-protocol for the off-strand socket close races (#38, #39)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785470728,
-        "narHash": "sha256-K6rr5ycCWctvtUnktskjRlXHN3GuI7FEbz8/FX+pVY8=",
+        "lastModified": 1785523697,
+        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "72754ab9b2ea8a43a3f04c5bdf1411673f3f489e",
+        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`logos-protocol` **72754ab9 → 3a31c91d**. One lock node, 3 lines.

The upstream range is exactly the two expected commits and nothing else:

| commit | fix |
|---|---|
| `4db061a` | close the RPC **socket** on the connection's strand, not the caller's thread (#38) |
| `3a31c91` | close the RPC **acceptor** on the server's strand, not the caller's thread (#39) |

Files touched upstream: `cpp/implementations/plain/rpc_connection.h`, `rpc_server.{h,cpp}`, plus protocol's own two new teardown tests. Both are off-strand close races: `RpcConnection::fail()` closed the socket on the caller's thread while every other stream access was serialised on `m_strand`, racing `kqueue_reactor::start_op`; `RpcServer::stop()` did the same to the acceptor while `doAccept()` re-armed `async_accept` from its own completion handler. Over `tcp` / `tcp_ssl` this segfaulted at teardown on ~0.45% of calls — a **false negative**, since the RPC completes and prints its correct result and only then crashes, so a caller that checks the exit code before parsing stdout reports a healthy call as failed.

## Why one node is the right change here

`flake.nix` already declares

```nix
logos-cpp-sdk.inputs.logos-protocol.follows = "logos-protocol";
logos-qt-sdk.inputs.logos-protocol.follows  = "logos-protocol";
```

so this repo's root pin is authoritative for the strand that gets linked into modules. Resolved edges before → after (a `follows` in `flake.lock` is a **path array resolved from the root node**, not a node name — resolving it as a name gives the wrong revisions):

| resolved path | master | this PR |
|---|---|---|
| `logos-protocol` | 72754ab9 | **3a31c91d** |
| `logos-cpp-sdk.logos-protocol` | 72754ab9 | **3a31c91d** |
| `logos-qt-sdk.logos-protocol` | 72754ab9 | **3a31c91d** |
| `logos-rust-sdk.logos-module-builder.logos-protocol` | 72754ab9 | **3a31c91d** |
| `logos-rust-sdk.logos-logoscore-cli.logos-protocol` | 72754ab9 | **3a31c91d** |
| `logos-test-framework.logos-cpp-sdk.logos-protocol` | 72754ab9 | **3a31c91d** |

Six edges, one node. `logos-rust-sdk` has **no `logos-protocol` input of its own** — verified in the source of its `flake.nix` at exactly the rev pinned here (`8e5900d48516`): root inputs are `logos-nix`, `nixpkgs`, `logos-lidl`, `logos-module-builder`, `logos-logoscore-cli`, and the file states the pin is reached via `logos-module-builder.inputs.logos-protocol` (it reads `logos_protocol.h` for the version string and links `logos-protocol.packages.${system}.logos-protocol`). In this closure both of rust-sdk's carriers are cycle-cut to `logos-cpp-sdk`, whose protocol follows root — so the bump reaches it and nothing needs bumping there.

**No cpp-sdk / qt-sdk re-pin in this PR.** logos-cpp-sdk#128 and logos-qt-sdk#26 are still open; re-pinning to unmerged commits is not possible. Those re-pins are a follow-up once they land — and they are not needed for the protocol strand, since both inputs' protocol edges already `follows` root.

## The fix is in the artifact, not just the lock

`logos-protocol` builds as a **static archive**, so a green lock proves nothing on its own. Symbol counts on the actual binaries the checks produce (aarch64-darwin):

| artifact | `closeStreamOnStrand` | `closeAcceptorOnStrand` | `logos::plain` syms |
|---|---|---|---|
| `rust_native_dep_module_plugin.dylib` (a module built by this builder) | 0 → **16** | 0 → **10** | 857 → **897** |
| `.test_framework_module_tests-wrapped` (C++ unit-test binary) | 0 → **16** | 0 → **10** | 857 → **897** |

So both a Rust cdylib module and a C++ binary compiled through this builder pick up #38 and #39.

*(Read the `-wrapped` binary, not `bin/<name>`: the unwrapped path is the Nix C wrapper — it shows 0 protocol symbols and its only diff across the bump is its own embedded store path.)*

## All five checks — baseline and after

Run individually on aarch64-darwin, master `ed0cde5` vs this commit:

| check | master | this PR | output path |
|---|---|---|---|
| `default` | pass | **pass** | identical |
| `static-extlib` | pass | **pass** | identical |
| `qml-integration` | pass | **pass** | identical |
| `test-framework-integration` | pass | **pass** | **changed** (rebuilt) |
| `rust-native-dep` | pass | **pass** | **changed** (rebuilt) |

The identical output paths are the interesting half: `default` is pure Nix eval, `static-extlib` is a set of `cmake -P` scripts that never build a module, and `qml-integration` builds a QML-only module with no C++ compile — none of the three has protocol anywhere in its derivation, so the bump provably cannot regress or fix them. Only the two that actually compile against the SDK rebuilt, and both are green.

⚠️ **`ci.yml` runs only four of the five** — `rust-native-dep` is not in the workflow, and it is the one whose artifact most directly demonstrates the fix. Worth adding separately.

## Residual protocol strands — enumerated, and one is exactly the class of bug this chain exists to fix

The closure has **25 distinct `logos-protocol` nodes across 55 resolved edges on 10 revisions**. Bumping the root moves 6 of them. The rest, and what they mean:

**1. `logos-standalone-app.logos-liblogos` brings its own protocol, with no `follows`.** Node `logos-liblogos_8` (`4ef9736a`) pins `logos-protocol` **4ee85b26** directly — the exact stale rev logos-liblogos#172 bumps. This is not lock noise; it is in the shipped binary. The standalone host this builder wires into `nix run` for `type: ui` / `ui_qml` modules:

```
liblogos_core.dylib            closeStreamOnStrand=0  closeAcceptorOnStrand=0  logos::plain=857
capability_module_plugin.dylib closeStreamOnStrand=0  closeAcceptorOnStrand=0  logos::plain=855
```

So after this PR a module developer running `nix run` gets a **module** with fixed protocol (897/16/10) loaded into a **host** with pre-fix protocol (857/0/0) — the same three-protocols-in-one-process shape as logoscore-cli#81.

I did not patch it here, and I did measure the workaround. Adding

```nix
logos-standalone-app.inputs.logos-protocol.follows = "logos-protocol";
logos-standalone-app.inputs.logos-liblogos.inputs.logos-protocol.follows = "logos-protocol";
```

builds fine and moves `liblogos_core.dylib` to **897 / 16 / 10** — but `capability_module_plugin.dylib` **stays at 855 / 0 / 0**, because capability-module reaches protocol through its own `logos-module-builder` pin (`6401e30a`), three hops deep. The workaround is therefore partial, and the durable fix is the chain already in flight: land liblogos#172, re-pin `logos-standalone-app` (and `logos-capability-module`), then re-pin them here. Left out on purpose so this PR stays a one-node bump; happy to add the two lines if a reviewer prefers the interim mitigation.

**2. `logos-test-framework.logos-protocol` = `d5d58e7e` — inert.** The package is header/source-only (`cmake/`, `include/`, `src/`, zero compiled artifacts), and `mkLogosModuleTests` is handed *this builder's* `logos-qt-sdk` / `logos-protocol`. Measured consequence: the test binary it produces carries **897 / 16 / 10**, i.e. the new protocol, not `d5d58e7e`. That also explains why the `typeIsOptional` pairing hazard flagged on `logos-test-framework.logos-qt-sdk` (`6c9a0de1`, cpp-sdk-follows-root × pre-#7 lidl `8c95d4f`) does not fire: that node is never realised.

**3. `logos-standalone-app.logos-protocol` = `362b03fb`, `logos-view-module-runtime.logos-protocol` = `1e960047`** — same residual class as (1), reached only through the standalone/UI host, not through anything a module links.

**4. Everything below depth 3** (`logos-standalone-app.logos-capability-module.logos-module-builder.logos-standalone-app…`, 14 further `logos-liblogos` nodes on `64de644e` / `be7c8fd8` / `68e408a5` / `94af58c8`) is the module-builder ↔ standalone-app ↔ capability-module recursion. Nix records those nodes; no derivation reaches them.

## Merge order

1. logos-liblogos#172
2. logos-cpp-sdk#128
3. logos-qt-sdk#26
4. **logos-module-builder — this PR**
5. follow-ups: re-pin `logos-cpp-sdk` / `logos-qt-sdk` here once 2 and 3 land; re-pin `logos-qt-sdk`'s own cpp-sdk (qt-sdk#26 note); and the `logos-standalone-app` / `logos-capability-module` strand in (1) above

This PR is independent of 1–3 for the protocol strand — nothing in it depends on those merging first.
