### PR TITLE
chore: re-pin all four SDKs to master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785507544,
-        "narHash": "sha256-ysZAx2Ru0vCcfSYFSXYUhyLTawn/o8IfvFE0n3AZ3OU=",
+        "lastModified": 1785763148,
+        "narHash": "sha256-/zW8Tt1pj4B6aRtaTKNnSbWvCNJq1SFsRuPKdj6W93I=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "44b92b0480aedb8dc1e60b23718d43cab14cfec7",
+        "rev": "f3369faca4e06ac9f89895b11fdcc202f86f00c2",
         "type": "github"
       },
       "original": {
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785470728,
-        "narHash": "sha256-K6rr5ycCWctvtUnktskjRlXHN3GuI7FEbz8/FX+pVY8=",
+        "lastModified": 1785523697,
+        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "72754ab9b2ea8a43a3f04c5bdf1411673f3f489e",
+        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
         "type": "github"
       },
       "original": {
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785493892,
-        "narHash": "sha256-X4wTVqUAFeWEZTY41kWh8mjPohye1a6JB+0sEVMZe58=",
+        "lastModified": 1785528949,
+        "narHash": "sha256-rbhraPiFA8tZeTgTjBNJtcj184WENXbUWQwuoEiZJJk=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "a3ee2fc30bb7b31968d39f90838d8940e41dc37d",
+        "rev": "cde7d42d19ad014030db7470f2f14505c4b857c3",
         "type": "github"
       },
       "original": {
@@ -27440,16 +27440,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785493201,
-        "narHash": "sha256-Mio9WcLzDlXQoV0PAnVGS4cMrFyYEO71RhdSUVFCJPU=",
+        "lastModified": 1785777210,
+        "narHash": "sha256-2mYG0m6lSyl+XiaY21cUNp+pW/0ENIcJzhWLvXiRUB0=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "8e5900d48516ca2e032660439476522a26972180",
+        "rev": "6d3e4c04b0a21ae9a8d4f954490fe8b13801e17f",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
-        "ref": "8e5900d48516",
+        "ref": "6d3e4c04b0a2",
         "repo": "logos-rust-sdk",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785523697,
-        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/8e5900d48516";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/6d3e4c04b0a2";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";


### PR DESCRIPTION
Supersedes #180 and #181 — both were opened before the SDKs moved again and are now stale. This is one re-pin of all four.

| input | | |
|---|---|---|
| `logos-protocol` | `72754ab` → `3a31c91` | off-strand socket close races (#38, #39) |
| `logos-cpp-sdk` | `44b92b0` → `f3369fa` | rejection surfacing, optional spellings, header-parser drops, async error channel + sync timeout (#129–#132) |
| `logos-qt-sdk` | `a3ee2fc` → `cde7d42` | its own protocol bump |
| `logos-rust-sdk` | `8e5900d` → `6d3e4c0` | per-call timeout entry points |

Until this lands, none of that work reaches a module build.

### Two things this repo has been caught by before

**`logos-rust-sdk` is pinned by rev** at `flake.nix:44`, where `nix flake update` is a silent no-op — that line is edited by hand.

**Bumping the root pin is not sufficient in general.** Every `logos-protocol` node in the resolved closure was checked with a *follows-aware* resolver (a `follows` entry in `flake.lock` is a path array resolved from the root, not a node name — a naive read reports the wrong revisions):

```
logos-protocol                 3a31c91d1322
logos-cpp-sdk/logos-protocol   3a31c91d1322
logos-qt-sdk/logos-protocol    3a31c91d1322
```

logos-logoscore-cli had a correct root pin and still segfaulted 4/2000 client calls, because liblogos brought its own older protocol.

### Verification

All five checks build: `default`, `static-extlib`, `rust-native-dep`, `test-framework-integration`, `qml-integration`. Worth running all of them — on an earlier bump here `default` passed while two others failed.

### Known downstream breakage, deliberate

cpp-sdk#127 makes an unrecognised C++ spelling a build error instead of a silent `any`. Two modules relied on that silence and need four declarations widened — `lez_core` (three `uint32_t` → `uint64_t`) and `libp2p_module` (`createXpr`'s services, which carries raw binary and is UTF-8-lossy today). PRs for both are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)