### PR TITLE
feat: allow postInstall to be a function of { system, pkgs }

### DIFF
--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -196,6 +196,14 @@ let
             then preConfigure { inherit externalLibs; }
             else preConfigure;
 
+          # postInstall may be a plain string OR a function of { system, pkgs } — the latter lets a module
+          # inject per-system artifacts (e.g. a helper bundle built for THIS system) into $out purely,
+          # without `builtins.currentSystem` (which throws in pure eval / breaks CI). Mirrors preConfigure.
+          userPostInstall =
+            if builtins.isFunction postInstall
+            then postInstall { inherit system pkgs; }
+            else postInstall;
+
           preConfigureStr = modulePreConfigure.compose {
             inherit config externalLibs protocolVersion;
             userPre = userPreConfigure;
@@ -203,7 +211,8 @@ let
             copyExternals = false;
           };
         in ({
-          inherit pkgs src config postInstall logosModule;
+          inherit pkgs src config logosModule;
+          postInstall = userPostInstall;
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
           inherit externalLibs;

--- a/lib/mkLogosQmlModule.nix
+++ b/lib/mkLogosQmlModule.nix
@@ -28,7 +28,9 @@
   # Optional: Custom preConfigure hook
   preConfigure ? "",
 
-  # Optional: Custom postInstall hook
+  # Optional: Custom postInstall hook. A plain string, OR a function `{ system, pkgs }: string` when the
+  # snippet needs per-system context (e.g. inject a helper bundle built for the current system) without
+  # `builtins.currentSystem` (which breaks pure eval / CI). Evaluated per-system in buildCppPlugin.
   postInstall ? "",
 
   # Optional: override the logos-standalone-app used for `nix run`.


### PR DESCRIPTION
## Problem
`postInstall` is a single string, baked once (outside the per-system loop). When a module's postInstall
needs to inject a **per-system** artifact into `$out` — e.g. a helper binary/bundle built for the current
system — the only way to select the right per-system derivation from that one string is
`builtins.currentSystem`, which **throws in pure eval** (`attribute 'currentSystem' missing`) and breaks
`nix build` in CI (the multi-variant release runners build each variant purely on its native runner).

## Fix
Let `postInstall` be **either a string or a function `{ system, pkgs }: string`**, evaluated per-system in
`buildCppPlugin` (where `system` + `pkgs` are already in scope). This mirrors the existing `preConfigure`
function-or-string handling right above it. Plain-string `postInstall` is unchanged — fully backward compatible.

```nix
# a module can now do, purely:
postInstall = { system, pkgs }: ''
  mkdir -p $out/lib/bin
  cp -a ${helperBundleFor system}/. $out/lib/bin/
'';
```

## Verified
Built a real consumer (receiver-basecamp, which ships a per-system ffplay/tor/privoxy bundle) against this
branch with a function `postInstall` and **`nix build .#lgx-portable` — no `--impure`** — succeeds and
produces the correctly-bundled `.lgx` per variant. Without this change the same flake needs `--impure`
(`currentSystem`) and fails the pure CI build.

Context: xAlisher/receiver-basecamp#80.