### PR TITLE
fix: cut view-module-runtime and standalone's liblogos to our logos-protocol

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785507544,
-        "narHash": "sha256-ysZAx2Ru0vCcfSYFSXYUhyLTawn/o8IfvFE0n3AZ3OU=",
+        "lastModified": 1785763148,
+        "narHash": "sha256-/zW8Tt1pj4B6aRtaTKNnSbWvCNJq1SFsRuPKdj6W93I=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "44b92b0480aedb8dc1e60b23718d43cab14cfec7",
+        "rev": "f3369faca4e06ac9f89895b11fdcc202f86f00c2",
         "type": "github"
       },
       "original": {
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785470728,
-        "narHash": "sha256-K6rr5ycCWctvtUnktskjRlXHN3GuI7FEbz8/FX+pVY8=",
+        "lastModified": 1785523697,
+        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "72754ab9b2ea8a43a3f04c5bdf1411673f3f489e",
+        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
         "type": "github"
       },
       "original": {
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785493892,
-        "narHash": "sha256-X4wTVqUAFeWEZTY41kWh8mjPohye1a6JB+0sEVMZe58=",
+        "lastModified": 1785528949,
+        "narHash": "sha256-rbhraPiFA8tZeTgTjBNJtcj184WENXbUWQwuoEiZJJk=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "a3ee2fc30bb7b31968d39f90838d8940e41dc37d",
+        "rev": "cde7d42d19ad014030db7470f2f14505c4b857c3",
         "type": "github"
       },
       "original": {
@@ -27440,16 +27440,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785493201,
-        "narHash": "sha256-Mio9WcLzDlXQoV0PAnVGS4cMrFyYEO71RhdSUVFCJPU=",
+        "lastModified": 1785777210,
+        "narHash": "sha256-2mYG0m6lSyl+XiaY21cUNp+pW/0ENIcJzhWLvXiRUB0=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "8e5900d48516ca2e032660439476522a26972180",
+        "rev": "6d3e4c04b0a21ae9a8d4f954490fe8b13801e17f",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
-        "ref": "8e5900d48516",
+        "ref": "6d3e4c04b0a2",
         "repo": "logos-rust-sdk",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3569,7 +3569,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_24",
+        "logos-protocol": "logos-protocol_23",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -4675,7 +4675,9 @@
         "logos-module-loader": "logos-module-loader_6",
         "logos-nix": "logos-nix_614",
         "logos-package-manager": "logos-package-manager_29",
-        "logos-protocol": "logos-protocol_21",
+        "logos-protocol": [
+          "logos-protocol"
+        ],
         "logos-qt-sdk": "logos-qt-sdk_16",
         "nixpkgs": [
           "logos-standalone-app",
@@ -19741,11 +19743,11 @@
         "nixpkgs": "nixpkgs_621"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19759,11 +19761,11 @@
         "nixpkgs": "nixpkgs_622"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19777,24 +19779,6 @@
         "nixpkgs": "nixpkgs_623"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_624": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_624"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -19808,9 +19792,9 @@
         "type": "github"
       }
     },
-    "logos-nix_625": {
+    "logos-nix_624": {
       "inputs": {
-        "nixpkgs": "nixpkgs_625"
+        "nixpkgs": "nixpkgs_624"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -19818,6 +19802,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_625": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_625"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19849,11 +19851,11 @@
         "nixpkgs": "nixpkgs_627"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19921,11 +19923,11 @@
         "nixpkgs": "nixpkgs_630"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19957,11 +19959,11 @@
         "nixpkgs": "nixpkgs_632"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19993,11 +19995,11 @@
         "nixpkgs": "nixpkgs_634"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20065,11 +20067,11 @@
         "nixpkgs": "nixpkgs_638"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20083,11 +20085,11 @@
         "nixpkgs": "nixpkgs_639"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20117,24 +20119,6 @@
     "logos-nix_640": {
       "inputs": {
         "nixpkgs": "nixpkgs_640"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_641": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_641"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -21689,7 +21673,7 @@
     },
     "logos-package-manager_30": {
       "inputs": {
-        "logos-nix": "logos-nix_634",
+        "logos-nix": "logos-nix_633",
         "logos-package": "logos-package_74",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_107",
@@ -24201,7 +24185,7 @@
     },
     "logos-package_72": {
       "inputs": {
-        "logos-nix": "logos-nix_626",
+        "logos-nix": "logos-nix_625",
         "nixpkgs": [
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -24226,7 +24210,7 @@
     },
     "logos-package_73": {
       "inputs": {
-        "logos-nix": "logos-nix_631",
+        "logos-nix": "logos-nix_630",
         "nixpkgs": [
           "nix-bundle-lgx",
           "logos-package",
@@ -24250,7 +24234,7 @@
     },
     "logos-package_74": {
       "inputs": {
-        "logos-nix": "logos-nix_635",
+        "logos-nix": "logos-nix_634",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -24275,7 +24259,7 @@
     },
     "logos-package_75": {
       "inputs": {
-        "logos-nix": "logos-nix_640",
+        "logos-nix": "logos-nix_639",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -25738,31 +25722,6 @@
     },
     "logos-protocol_21": {
       "inputs": {
-        "logos-nix": "logos-nix_620",
-        "nixpkgs": [
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785352565,
-        "narHash": "sha256-i5ynBtNk6Qe+YSHsa+O8DjnLpHXDVqyLGPxBAImipD8=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "4ee85b26a65e331821823f6435135c088a1bf447",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_22": {
-      "inputs": {
         "logos-nix": [
           "logos-standalone-app",
           "logos-nix"
@@ -25786,7 +25745,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_23": {
+    "logos-protocol_22": {
       "inputs": {
         "logos-nix": [
           "logos-test-framework",
@@ -25811,7 +25770,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_24": {
+    "logos-protocol_23": {
       "inputs": {
         "logos-nix": [
           "logos-view-module-runtime",
@@ -25832,31 +25791,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "d5d58e7e230768505c683150f651358612abd442",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_25": {
-      "inputs": {
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1784318366,
-        "narHash": "sha256-e3JsCum47Ztundm63DvBZhk10ERp/3MbzUyWMyHg6Kw=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "1e96004711f36f13244c280c8478771b847baa4b",
         "type": "github"
       },
       "original": {
@@ -26289,7 +26223,7 @@
     },
     "logos-qt-mcp_15": {
       "inputs": {
-        "logos-nix": "logos-nix_624",
+        "logos-nix": "logos-nix_623",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -26918,7 +26852,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_32",
-        "logos-nix": "logos-nix_621",
+        "logos-nix": "logos-nix_620",
         "logos-protocol": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -27693,8 +27627,8 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_8",
-        "logos-nix": "logos-nix_623",
-        "logos-protocol": "logos-protocol_22",
+        "logos-nix": "logos-nix_622",
+        "logos-protocol": "logos-protocol_21",
         "logos-qt-mcp": "logos-qt-mcp_15",
         "logos-qt-sdk": "logos-qt-sdk_17",
         "logos-view-module-runtime": [
@@ -28542,8 +28476,8 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_628",
-        "logos-protocol": "logos-protocol_23",
+        "logos-nix": "logos-nix_627",
+        "logos-protocol": "logos-protocol_22",
         "logos-qt-sdk": "logos-qt-sdk_18",
         "nixpkgs": [
           "logos-test-framework",
@@ -29157,8 +29091,10 @@
     "logos-view-module-runtime_15": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_60",
-        "logos-nix": "logos-nix_629",
-        "logos-protocol": "logos-protocol_25",
+        "logos-nix": "logos-nix_628",
+        "logos-protocol": [
+          "logos-protocol"
+        ],
         "logos-qt-sdk": "logos-qt-sdk_19",
         "nixpkgs": [
           "logos-view-module-runtime",
@@ -30419,7 +30355,7 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_636",
+        "logos-nix": "logos-nix_635",
         "nix-bundle-dir": "nix-bundle-dir_106",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -30824,7 +30760,7 @@
     },
     "nix-bundle-dir_104": {
       "inputs": {
-        "logos-nix": "logos-nix_627",
+        "logos-nix": "logos-nix_626",
         "nixpkgs": [
           "logos-standalone-app",
           "nix-bundle-lgx",
@@ -30849,7 +30785,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-        "logos-nix": "logos-nix_632",
+        "logos-nix": "logos-nix_631",
         "nixpkgs": [
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -30873,7 +30809,7 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-        "logos-nix": "logos-nix_637",
+        "logos-nix": "logos-nix_636",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -30897,7 +30833,7 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-        "logos-nix": "logos-nix_638",
+        "logos-nix": "logos-nix_637",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -30922,7 +30858,7 @@
     },
     "nix-bundle-dir_108": {
       "inputs": {
-        "logos-nix": "logos-nix_641",
+        "logos-nix": "logos-nix_640",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -35448,7 +35384,7 @@
     },
     "nix-bundle-lgx_43": {
       "inputs": {
-        "logos-nix": "logos-nix_625",
+        "logos-nix": "logos-nix_624",
         "logos-package": "logos-package_72",
         "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
@@ -35474,7 +35410,7 @@
     },
     "nix-bundle-lgx_44": {
       "inputs": {
-        "logos-nix": "logos-nix_630",
+        "logos-nix": "logos-nix_629",
         "logos-package": "logos-package_73",
         "nix-bundle-dir": "nix-bundle-dir_105",
         "nixpkgs": [
@@ -35499,7 +35435,7 @@
     },
     "nix-bundle-lgx_45": {
       "inputs": {
-        "logos-nix": "logos-nix_639",
+        "logos-nix": "logos-nix_638",
         "logos-package": "logos-package_75",
         "nix-bundle-dir": "nix-bundle-dir_108",
         "nixpkgs": [
@@ -35892,7 +35828,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_633",
+        "logos-nix": "logos-nix_632",
         "logos-package-manager": "logos-package-manager_30",
         "nix-bundle-lgx": "nix-bundle-lgx_45",
         "nixpkgs": [
@@ -45923,22 +45859,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_641": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_65": {
       "locked": {
         "lastModified": 1759036355,
@@ -46750,7 +46670,7 @@
     },
     "process-stats_15": {
       "inputs": {
-        "logos-nix": "logos-nix_622",
+        "logos-nix": "logos-nix_621",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",

--- a/flake.lock
+++ b/flake.lock
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785523697,
-        "narHash": "sha256-8WdoCJDLNR/aLkcmeY8CeAZlTIN8ulG/7N1ZFEVDdsQ=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "3a31c91d1322dae053bbe28b6e3f441fabcc2162",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/8e5900d48516";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/6d3e4c04b0a2";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,17 @@
     logos-standalone-app.url = "github:logos-co/logos-standalone-app";
     logos-standalone-app.inputs.logos-design-system.follows = "logos-design-system";
     logos-standalone-app.inputs.logos-view-module-runtime.follows = "logos-view-module-runtime";
+    # ui-host (from the view-module-runtime) and a ui_qml plugin built here are
+    # loaded into ONE process, and so are liblogos_core and a type:"ui" plugin.
+    # Both pairs statically link logos-protocol and export its symbols weakly, so
+    # dyld coalesces them and one image's code silently binds to the other's. Cut
+    # both peers to OUR logos-protocol so only one revision is ever live.
+    logos-view-module-runtime.inputs.logos-protocol.follows = "logos-protocol";
+    # Nested on purpose: the in-process peer of a type:"ui" plugin is
+    # liblogos_core, which comes from standalone's logos-liblogos — the
+    # standalone binary itself carries no logos::plain symbols, so cutting
+    # `logos-standalone-app.inputs.logos-protocol` alone would be a no-op.
+    logos-standalone-app.inputs.logos-liblogos.inputs.logos-protocol.follows = "logos-protocol";
     # Test framework for module unit tests
     logos-test-framework.url = "github:logos-co/logos-test-framework";
     logos-test-framework.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";

--- a/flake.nix
+++ b/flake.nix
@@ -33,16 +33,28 @@
     logos-standalone-app.inputs.logos-design-system.follows = "logos-design-system";
     logos-standalone-app.inputs.logos-view-module-runtime.follows = "logos-view-module-runtime";
     # ui-host (from the view-module-runtime) and a ui_qml plugin built here are
-    # loaded into ONE process, and so are liblogos_core and a type:"ui" plugin.
-    # Both pairs statically link logos-protocol and export its symbols weakly, so
-    # dyld coalesces them and one image's code silently binds to the other's. Cut
-    # both peers to OUR logos-protocol so only one revision is ever live.
+    # loaded into ONE process. Both statically link logos-protocol and export its
+    # symbols weakly, so dyld coalesces them and one image's code silently binds
+    # to the other's — measured at 225 shared weak definitions, 42 of them
+    # RpcConnection/RpcValue instantiations, across an ABI change (RpcValue's
+    # variant gained uint64_t in the MIDDLE, renumbering later alternatives).
+    # Cutting ui-host to our logos-protocol puts that pair on one revision.
     logos-view-module-runtime.inputs.logos-protocol.follows = "logos-protocol";
-    # Nested on purpose: the in-process peer of a type:"ui" plugin is
-    # liblogos_core, which comes from standalone's logos-liblogos — the
-    # standalone binary itself carries no logos::plain symbols, so cutting
-    # `logos-standalone-app.inputs.logos-protocol` alone would be a no-op.
+    # Nested on purpose. The peer that matters is liblogos_core, which comes from
+    # standalone's logos-liblogos, NOT from standalone's own logos-protocol — the
+    # standalone binary carries no logos::plain symbols at all, so cutting
+    # `logos-standalone-app.inputs.logos-protocol` would be an exact no-op.
+    # Concretely this moves logos_host_qt — the process that dlopens the core
+    # modules this builder builds — onto our revision. It also covers the legacy
+    # type:"ui" path, where mainwindow.cpp QPluginLoader-loads a plugin in-process
+    # beside liblogos_core (255 shared weak defs), though no module uses that type
+    # today, so that half is unexercised.
     logos-standalone-app.inputs.logos-liblogos.inputs.logos-protocol.follows = "logos-protocol";
+    # NOT one revision everywhere: capability_module ships prebuilt inside
+    # standalone-app at an older protocol and neither line reaches it, so
+    # logos_host_qt still mixes revisions (227 shared weak defs). That pair was
+    # already layout-incompatible before this change — this narrows the problem,
+    # it does not eliminate it.
     # Test framework for module unit tests
     logos-test-framework.url = "github:logos-co/logos-test-framework";
     logos-test-framework.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";


### PR DESCRIPTION
> **Stacked on #182.** Branched off `d22ed12` (the head of `chore/repin-all-sdks`), targets `master`.
> **Merge this after #182.** On its own the diff is two `follows` lines; against master before #182 it would relock onto the old protocol.

Two lines in `flake.nix`, beside the ones that already exist for `logos-cpp-sdk` and `logos-qt-sdk`:

```nix
logos-view-module-runtime.inputs.logos-protocol.follows = "logos-protocol";
logos-standalone-app.inputs.logos-liblogos.inputs.logos-protocol.follows = "logos-protocol";
```

---

## The defect

On macOS, two different `logos-protocol` revisions end up in **one process**, and dyld coalesces
their weak definitions — so one image's code silently binds to the other's.

The builder already cuts `logos-cpp-sdk` and `logos-qt-sdk` to its own `logos-protocol`. It does not
cut the two inputs that get **loaded into the same address space as a plugin this builder produces**:

| in-process pair | who provides the peer | protocol it carried |
|---|---|---|
| `ui-host` + a `type: "ui_qml"` plugin | `logos-view-module-runtime` | `1e96004` (Jul 17) |
| `liblogos_core.dylib` + a `type: "ui"` plugin | `logos-standalone-app` → `logos-liblogos` | `4ee85b26` (Jul 29) |

The plugin side, built by this builder, is at `0f26ffd`. Both sides statically link protocol and
export its symbols weakly, and nothing suppresses that — there is no `-fvisibility=hidden`,
`-Bsymbolic`, version script or `--exclude-libs` anywhere in this repo's `cmake/` or `lib/`, or in
protocol's `cpp/`.

### Measured, before this change

Built the `ui-qml-backend` template as a probe and compared the two Mach-O images:

```
ui-host weak defs :  251        (MH_WEAK_DEFINES | MH_BINDS_TO_WEAK, flags 0x00a18085)
plugin  weak defs :  262        (MH_WEAK_DEFINES | MH_BINDS_TO_WEAK, flags 0x00918085)
SHARED weak defs  :  225
  boost::asio            176
  logos::plain::RpcConnection  42
  QtPrivate::MetaObjectForType   9
  PluginRegistry::registryMutex  2
  LogosTransportConfigGlobal::defaultStorage  2

ui-host  logos::plain::PlainLogosObject::awaitCompletion(QString const&, int)
plugin   logos::plain::PlainLogosObject::awaitCompletion(QString const&, int, QString const&, logos::CallError*)
```

And live, inside a running `ui-host` (the app launched headless with the probe plugin):

```
$ vmmap <ui-host pid> | grep nix/store
/nix/store/kj46gr3…-logos-view-module-runtime-1.0.0/bin/.ui-host-wrapped
/nix/store/sl5si8f…-logos-ui_example-plugin-dir/ui_example_plugin.dylib

(lldb) image lookup -rs LogosObjectErrorChannel
  ui_example_plugin.dylib`typeinfo for LogosObjectErrorChannel      ← plugin only; that type
  ui_example_plugin.dylib`typeinfo name for LogosObjectErrorChannel   exists only at 0f26ffd

(lldb) image lookup -rs awaitCompletion
  .ui-host-wrapped`…awaitCompletion(QString const&, int)
  ui_example_plugin.dylib`…awaitCompletion(QString const&, int, QString const&, logos::CallError*)
```

Two revisions, one process. And the coalescing itself, arithmetically:

```
(lldb) expr (void*)dlsym((void*)-2, "_ZGVN5boost4asio6detail10call_stack<…strand_impl…>4top_E")
(void *) $0 = 0x0000000100bbc618

ui-host  slide 0x00ad0000  + static 0x1000ec618 = 0x100bbc618   ← this one wins
plugin   slide 0x102d2c000 + static 0x001094f0  = 0x102e354f0   ← never reached
```

### Why it matters — the revisions differ by a real ABI change, not just additions

`RpcValue`'s variant gained an alternative **in the middle**, which renumbers every index after it:

```diff
     using Variant = std::variant<
         std::monostate,   // null
         bool,
         int64_t,
+        uint64_t,         // ONLY for values above int64max — see makeInteger()
         double,
         std::string,
         RpcBytes, RpcList, RpcMap
     >;
```

and `awaitCompletion` went from 2 parameters to 4.

The sharpest consequence is that `rpc_connection.h`'s **close-vs-start-op race fix is half-applied**
in the mixed process. `0f26ffd` added `m_stopped` re-checks inside `doRead()`'s completion handler,
inside the lambda `writeFrame()` posts to the strand, and at the top of `doWrite()` — and added
`closeStream()` / `closeStreamOnStrand()`. Those first three live in `RpcConnection<Stream>`
template instantiations, i.e. weak definitions, and they are in the shared set:

```
$ comm -12 <ui-host weak defs> <plugin weak defs> | c++filt | grep RpcConnection | grep -E 'doRead|doWrite|writeFrame'
… RpcConnection<…tcp…>::writeFrame(std::vector<unsigned char>)::'lambda'()…
… RpcConnection<…ssl…>::doRead()::'lambda'(error_code const&, size_t)…
… RpcConnection<…tcp…>::doWrite()::'lambda'(error_code const&, size_t)…
   (14 such trampolines, tcp and ssl instantiations)

$ nm … | grep -c closeStreamOnStrand
ui-host: 0        plugin: 16      ← the other half of the fix stays plugin-local
```

So the plugin's read/write trampolines bind to ui-host's **unfixed** Jul-17 code while
`closeStreamOnStrand` does not exist there at all. Dormant on the QtRO path exercised today; live
the moment a `ui_qml` module selects a plain transport.

This is pre-existing, not caused by the protocol bump in #182 — the bump only widens the drift.

## Why the second line is nested

`logos-standalone-app.inputs.logos-protocol.follows` compiles, and is an exact **no-op** for this
problem: the standalone binary carries no `logos::plain` symbols at all. The peer that matters is
`liblogos_core.dylib`, which comes from `logos-standalone-app.inputs.logos-liblogos`.

What the nested line demonstrably achieves is moving **`logos_host_qt`** — the process that dlopens
the core modules this builder builds at `0f26ffd` — from `4ee85b26` onto our revision.

It also covers the legacy `type: "ui"` path, where `mainwindow.cpp` `QPluginLoader`-loads a plugin
in-process beside `liblogos_core` (255 shared weak defs, and `mkLogosModule.nix:733` wires
`apps.default` to `logos-standalone-app` precisely for that type). That half is real but
**unexercised**: no module in the workspace uses `type: "ui"` today, and for the `ui_qml` case the
doctest does cover, `liblogos_core` sits alone in the standalone process — the replica factory
exports no `logos::plain` symbols, so nothing coalesces there. Measured on the built app:

```
logos-standalone-app binary   logos::plain symbols: 0     weak logos::plain defs: 0
liblogos_core.dylib           logos::plain symbols: 857   weak defs: 297
                              awaitCompletion(QString const&, int)   ← protocol 4ee85b26
                              255 weak defs shared with a plugin built here
```

Cutting standalone's own `logos-protocol` would move a revision nothing loads. The nested spelling
cuts the one that is actually co-resident.

## The lock change

`nix flake lock` reports exactly the two edges and nothing else:

```
• Updated input 'logos-standalone-app/logos-liblogos/logos-protocol':
    'github:logos-co/logos-protocol/4ee85b26…' (2026-07-29)  →  follows 'logos-protocol'
• Updated input 'logos-view-module-runtime/logos-protocol':
    'github:logos-co/logos-protocol/1e96004…' (2026-07-17)   →  follows 'logos-protocol'
• Removed 5 now-orphaned sub-inputs of those two nodes (their logos-nix / nixpkgs)
```

Walking the whole locked graph before and after: **2 edges changed, 5 removed, 0 added, 0 revisions
moved.** The only repo whose set of locked revisions changes at all is `logos-protocol`, and only by
losing the two nodes above — `1e9600471` and `4ee85b26a` are no longer reachable.

## Verification

Everything below ran on `aarch64-darwin` against this branch.

**Builds.** `logos-view-module-runtime`, `logos-liblogos`/`logos-standalone-app` and a `ui_qml`
plugin all compile against `0f26ffd`, built with `--option substitute false` so nothing could be
faked by a cache hit. `nix path-info` confirms every `logos` path in the resulting standalone-app
closure is `ultimate: true` (built here, zero signatures) — **4 built locally, 0 substituted**.
`--rebuild` on view-module-runtime recompiles all 9 units cleanly. (It also reports
`may not be deterministic`; the *unfixed* derivation reports the same, so that is pre-existing and
unrelated to this change.)

**The coalescing is gone.** Same probe, rebuilt, same detection method:

```
                            BEFORE                          AFTER
ui-host  awaitCompletion    (QString const&, int)           (QString const&, int, QString const&, logos::CallError*)
plugin   awaitCompletion    (QString const&, int, …)        (QString const&, int, QString const&, logos::CallError*)
ui-host  LogosObjectErrorChannel syms   0                   2
plugin   LogosObjectErrorChannel syms   2                   2
VERDICT                     *** MIXED ***                   SAME protocol revision in both images
```

Confirmed live too — `image lookup` in the running `ui-host` now finds `LogosObjectErrorChannel` in
**both** images and one single `awaitCompletion` signature. The method is discriminating: it reports
`MIXED` on the unfixed tree and `SAME` here, so a clean result means something.

Shared weak definitions **rise** 225 → 257 (boost::asio 176 → 178, `RpcConnection` 42 → 44). That is
expected and is not a regression: two images at the *same* revision share more instantiations. What
disappears is the cross-revision mix.

**Doc-test.** `doctests/ui-typed-backend.test.yaml` is the real coverage here — it scaffolds a
`type: ui_qml` + `interface: universal` module against this commit, launches the app, and drives the
QML view through the inspector, i.e. it exercises exactly the ui-host + plugin process this PR is
about:

```
nix run github:logos-co/logos-doctest -- run doctests/ui-typed-backend.test.yaml \
  --release-for logos-module-builder=e92a58e152fe3a494a1b9c991340f6803a53410f

  PASS  Build it
  PASS  (icon fixture)
  PASS  Lock and build
  PASS  Launch and drive the app          ← 7 UI actions via logos-qt-mcp

  Results: 4 passed, 0 failed, 0 skipped (of 4 run)
```

(Deliberately **not** citing `nix flake check` as regression evidence: none of the 5 checks builds
view-module-runtime, standalone-app or ui-host, and 3 of the 5 contain no `logos-protocol`
derivation at all. It would pass vacuously.)

## Cost

This is not free. Forcing `logos-liblogos` onto our protocol invalidates paths that are currently
cached — 18 derivations in the standalone-app closure change hash, of which the real compiles are
`logos-protocol-lib`, `logos-qt-sdk-lib`, `logos-liblogos-{build,bin}`, the
`logos-module-loader-qt-{build,bin,lib}` chain, `logos-cpp-sdk-generator` and
`logos-view-module-runtime`. Roughly the same number drops out on the other side, so the closure size
is unchanged (1609 → 1606 derivations) — **no path-count reduction is being claimed here**, only
that the pairs above stop mixing revisions.

## What this does NOT fix

Review re-probed the running processes and found the first version of this description overclaimed.
`logos_host_qt` runs the host at `0f26ffd` alongside `capability_module`, which `logos-standalone-app`
ships **prebuilt** at `664b43f` — neither `follows` line reaches it, so that process still mixes
revisions (227 shared weak definitions, 42 of them `RpcConnection`/`RpcValue`). That pair was already
layout-incompatible before this change: `RpcValue`'s `uint64_t` insertion landed between `664b43f` and
`4ee85b26`. So this narrows the problem rather than eliminating it, and "only one revision is ever
live" would be false.

