### PR TITLE
chore: re-pin the SDK stack so logos-protocol is 0f26ffd everywhere

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27708,11 +27708,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786121828,
+        "lastModified": 1786124171,
         "narHash": "sha256-EzA+u5lFSvd/AxIoFytwtJHegIvWH4NDCJF9MK3JuQk=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "2cd511eca8c1ebec1789f63c5643fe37e2f3a06b",
+        "rev": "592af8aaf25c9d06f656e44e68f5bb709f6f39f3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -27708,11 +27708,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786114390,
-        "narHash": "sha256-ZgdL4wp8v5WNILkB5ClPwhEKQvvUvS2kPiDLaOw1ms4=",
+        "lastModified": 1786121828,
+        "narHash": "sha256-EzA+u5lFSvd/AxIoFytwtJHegIvWH4NDCJF9MK3JuQk=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "9aff419f582185a6e1b0504cb3dc61320987e874",
+        "rev": "2cd511eca8c1ebec1789f63c5643fe37e2f3a06b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784686952,
-        "narHash": "sha256-0QVyGF6cpDz8RLozz1qypS7a/k0w6yBs9zGlkZMxZe4=",
+        "lastModified": 1785971700,
+        "narHash": "sha256-Nj4wv/PyvY9Kyuv5rsop/fQ5utm1X52zWiXPeDXSJEA=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "bc46dbfc5e2fbbe259fbd30982bf563a772b918b",
+        "rev": "811d83407822091817719d8e46de26e548e23b19",
         "type": "github"
       },
       "original": {
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785763148,
-        "narHash": "sha256-/zW8Tt1pj4B6aRtaTKNnSbWvCNJq1SFsRuPKdj6W93I=",
+        "lastModified": 1786113947,
+        "narHash": "sha256-n9Lhe6vxyvkGSwlfT5HylTKsFVm5bkpRfUvTbWd6X2c=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "f3369faca4e06ac9f89895b11fdcc202f86f00c2",
+        "rev": "dfd46282a7b7d48075f890ace3a39a128e5b2576",
         "type": "github"
       },
       "original": {
@@ -2419,11 +2419,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785085094,
-        "narHash": "sha256-7FRDx7SptIKxgj5ha39FfZ1DzOb43xabTZG/zXibJKw=",
+        "lastModified": 1786113947,
+        "narHash": "sha256-n9Lhe6vxyvkGSwlfT5HylTKsFVm5bkpRfUvTbWd6X2c=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "8a40a9832251840d96e121abdc9e6bd760bc5afd",
+        "rev": "dfd46282a7b7d48075f890ace3a39a128e5b2576",
         "type": "github"
       },
       "original": {
@@ -4686,11 +4686,11 @@
         "process-stats": "process-stats_15"
       },
       "locked": {
-        "lastModified": 1785443983,
-        "narHash": "sha256-eRRAXlWcZs4gpK3Nny2CtvpD04bDE8OxA4baMZxhwBk=",
+        "lastModified": 1786113969,
+        "narHash": "sha256-9Mtr7ETZrvSHLrqsSfzaV9+ijAFiigrhwR37K2uBIRU=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "4ef9736a1e6a8c05de53fa13d9acf5f4d4570833",
+        "rev": "2f4162a97f3b6d8f469ac669cd0f198f604606ca",
         "type": "github"
       },
       "original": {
@@ -5033,11 +5033,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781653473,
-        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -25395,11 +25395,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785065460,
-        "narHash": "sha256-cp5Un0NBXwNoK/+atBLMl4NwCfDXzy0KMpyUOtK6pcc=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ae2f7e1b5842d62836091c6dc0c903508806456e",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {
@@ -25748,11 +25748,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785352565,
-        "narHash": "sha256-i5ynBtNk6Qe+YSHsa+O8DjnLpHXDVqyLGPxBAImipD8=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "4ee85b26a65e331821823f6435135c088a1bf447",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {
@@ -25773,11 +25773,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785261709,
-        "narHash": "sha256-dcI6zmGy5+99MB9TaN7KGJkbvDWV8WT+B/8b5UPLjkE=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "362b03fb1ec25b35ed5d630670f5fd2bd899b196",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {
@@ -25852,11 +25852,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784318366,
-        "narHash": "sha256-e3JsCum47Ztundm63DvBZhk10ERp/3MbzUyWMyHg6Kw=",
+        "lastModified": 1786030193,
+        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "1e96004711f36f13244c280c8478771b847baa4b",
+        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
         "type": "github"
       },
       "original": {
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785528949,
-        "narHash": "sha256-rbhraPiFA8tZeTgTjBNJtcj184WENXbUWQwuoEiZJJk=",
+        "lastModified": 1786113959,
+        "narHash": "sha256-c+UGVbHF6KIwuOMdy04QymCJ7nEWz+jOumVrtWX+wNw=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "cde7d42d19ad014030db7470f2f14505c4b857c3",
+        "rev": "36ed70db1b219aa0246df9382866126c06dc212b",
         "type": "github"
       },
       "original": {
@@ -27708,11 +27708,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785929901,
-        "narHash": "sha256-HgiLLQAhF79LGwyib1GLPULA07u/nPyIm0Peprd+/AM=",
+        "lastModified": 1786114390,
+        "narHash": "sha256-ZgdL4wp8v5WNILkB5ClPwhEKQvvUvS2kPiDLaOw1ms4=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "0d1b1775953e2262efc1634db071808c3910e1de",
+        "rev": "9aff419f582185a6e1b0504cb3dc61320987e874",
         "type": "github"
       },
       "original": {
@@ -29167,11 +29167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784792149,
-        "narHash": "sha256-EaIDz65Xs1eRc+qre0pWJh+53vFt2vqFqLYUhj2ixk8=",
+        "lastModified": 1786113978,
+        "narHash": "sha256-X3qVyaMqk3pA7rEdr9YIrvRNHjUBO75eNQXghBwDs5w=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "049978f144aa53d8b98ea2c0b164b0554c88c856",
+        "rev": "2b178f74ad1266d54113960aba22fbfa0370f9ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Final step of the chain that unifies `logos-protocol` on **0f26ffd** across every path that can put two revisions into one process.

On macOS, two statically-linked protocol revisions in one image get their weak definitions coalesced by dyld, so one image's code silently binds to the other's. The ABI difference here is real — `RpcValue`'s variant gained `uint64_t` **in the middle**, renumbering later alternatives, and `awaitCompletion` gained two parameters. Both changes are internal to the plain transport, so the mismatch is **source-compatible and never shows up at build time**. That is exactly why it has to be fixed by pinning rather than by the compiler.

## What changed

`flake.lock` only — **no `follows` lines added, `flake.nix` untouched**. The whole point of doing this by re-pinning is that the overrides become unnecessary, so this supersedes the `follows`-based approach in #185.

| input | before | after |
|---|---|---|
| `logos-cpp-sdk` | f3369fac | **dfd46282** |
| `logos-qt-sdk` | cde7d42d | **36ed70db** |
| `logos-view-module-runtime` | 049978f1 | **2b178f74** (its protocol 1e960047 → 0f26ffd) |
| `logos-standalone-app` | 0d1b1775 | **9aff419f** (its protocol 362b03fb → 0f26ffd; its liblogos 4ef9736a → 2f4162a9; that liblogos' protocol 4ee85b26 → 0f26ffd) |

## ⚠️ `logos-standalone-app` is pinned to an UNMERGED PR head — must be re-pinned

`logos-standalone-app` is pinned to **9aff419f**, which is the head of the still-open **logos-co/logos-standalone-app#34**, *not* a merge commit. This is deliberate and it is load-bearing, not cosmetic:

Root-pinning the six upstream repos was necessary but **not sufficient**. `logos-standalone-app` **master** (2b49bd1c2) still pins an old `logos-liblogos` (4ef9736a) whose own root protocol is **4ee85b26 (Jul 29)**. I verified this by running the update against master first — 3 of 4 acceptance paths passed and `logos-standalone-app -> logos-liblogos -> logos-protocol` still read `4ee85b26`. Only #34 fixes it.

**Once #34 lands, re-pin this to the merge commit.** The lock entry was written so that this is a one-liner with no `flake.nix` edit — `original` is deliberately left **bare** (tracks master), only `locked` carries the rev:

```
original: {"owner": "logos-co", "repo": "logos-standalone-app", "type": "github"}
locked  : {... "rev": "9aff419f582185a6e1b0504cb3dc61320987e874" ...}
```

so unpinning is just `nix flake update logos-standalone-app`. **Do not merge this before #34.**

## Acceptance — all four paths read 0f26ffd

`follows` entries in `flake.lock` are **path arrays resolved from the root**, not node names, so a naive resolver reports wrong revisions. I resolved them root-relative and **validated the resolver against Nix's own `nix flake metadata` tree first: 2896/2896 paths agree, 0 disagreements.**

```
PASS  logos-protocol                                            0f26ffdeef
PASS  logos-standalone-app -> logos-protocol                    0f26ffdeef
PASS  logos-view-module-runtime -> logos-protocol               0f26ffdeef
PASS  logos-standalone-app -> logos-liblogos -> logos-protocol  0f26ffdeef
```

Distinct reachable `logos-protocol` revisions: **10 → 7**; paths at 0f26ffd: **1 → 5**.

## Checks run (aarch64-darwin, real output)

All four derivations CI builds, with real counts:

| check | result |
|---|---|
| `default` | exit 0 — **All 256 tests passed** |
| `qml-integration` | exit 0 — 11 PASS, "All QML integration tests passed" |
| `static-extlib` | exit 0 — 9 PASS, "All static external library tests passed" |
| `test-framework-integration` | exit 0 — **10 passed** module tests + 2 integration PASS |

## Re-lock, checked under CI's Nix as well as mine

#185 passed every local check on Nix 2.32.4 and then failed on CI's **2.22.1** (`cachix/install-nix-action@v27`, still what the `test` job uses). So I ran 2.22.1 explicitly, in `docker nixos/nix:2.22.1`:

- **Consumes this committed lock** — `nix flake metadata` exit 0, full 2956-line tree, and the lock is **byte-identical afterwards** (`sha256-SYYUbHDxUb3FXtVucZupoK0FzTFyNBQ/zQs9J98FCmU=` before and after).
- **From-scratch re-lock** (`rm flake.lock && nix flake lock`) — exit 0, 1326896 bytes; the freshly-locked tree then evaluates, exit 0.
- Same from-scratch re-lock on local Nix 2.32.4 — exit 0, same 1326896 bytes, idempotent on rerun.

**One honest caveat on the from-scratch re-lock:** a fresh lock resolves `logos-standalone-app` to *master*, so it reproduces only 3 of the 4 acceptance paths until #34 merges. The re-lock proves locking *succeeds*; it does not yet reproduce the pin. That is the same unmerged-PR fact as above, and it resolves itself when #34 lands.

## Other verification

- **`logos-rust-sdk` did not move** — still `6d3e4c04b0a2`. It is pinned by rev in `flake.nix`, where `nix flake update` is a silent no-op; only the four named inputs were updated.
- **master's CI red was outage residue, not a real failure.** Both master runs for #182 were annotated `The job was not acquired by Runner of type hosted even after multiple attempts`. I re-ran them: **CI is now green (1m29s)**, so this PR has a clean baseline.

## Relationship to #185

#185 solved the same problem with two-level nested `follows`, which is the spelling that breaks on Nix 2.22.1. This achieves the same unification by re-pinning, adds no `follows`, and locks cleanly on 2.22.1. **#185 can be closed in favour of this — leaving that call to the author.**
