### PR TITLE
chore: re-pin qt-sdk + rust-sdk to the merged optionality work

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786113959,
-        "narHash": "sha256-c+UGVbHF6KIwuOMdy04QymCJ7nEWz+jOumVrtWX+wNw=",
+        "lastModified": 1786130730,
+        "narHash": "sha256-VTmXHQrjJCfRBDwpJvO6vbyuaE1Oi6P2ORgl9FmBUQc=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "36ed70db1b219aa0246df9382866126c06dc212b",
+        "rev": "8a9efdfb9d89b74f144fa94ec96a8827fb29a22c",
         "type": "github"
       },
       "original": {
@@ -27440,16 +27440,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785777210,
-        "narHash": "sha256-2mYG0m6lSyl+XiaY21cUNp+pW/0ENIcJzhWLvXiRUB0=",
+        "lastModified": 1786130744,
+        "narHash": "sha256-2+WuTZB/b4LOFHgD1/owkam6ROCAgUzLoKYFk7FpIro=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "6d3e4c04b0a21ae9a8d4f954490fe8b13801e17f",
+        "rev": "6310031e5f49a4584b59819cd4a379b030cd84c3",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
-        "ref": "6d3e4c04b0a2",
+        "ref": "6310031e5f49",
         "repo": "logos-rust-sdk",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -27449,8 +27449,8 @@
       },
       "original": {
         "owner": "logos-co",
-        "ref": "6310031e5f49",
         "repo": "logos-rust-sdk",
+        "rev": "6310031e5f49a4584b59819cd4a379b030cd84c3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/6310031e5f49";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/6310031e5f49a4584b59819cd4a379b030cd84c3";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/6d3e4c04b0a2";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/6310031e5f49";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";


### PR DESCRIPTION
## Why

`?T` optionality is now complete across all seven surfaces, but **no module can use it until the builder pins the two SDKs that carry the last two pieces.**

| input | from | to | brings |
|---|---|---|---|
| `logos-qt-sdk` | `36ed70d` | `8a9efdf` | logos-qt-sdk#29 (optional params on every Qt surface, `-> ?T` refused) + #30 (goldens are valid C++) |
| `logos-rust-sdk` | `6d3e4c0` | `6310031` | logos-rust-sdk#35 (`Option<T>` in the Rust-first frontend) |

## Note on the rust-sdk pin

`logos-rust-sdk` is pinned **by rev** rather than tracking master, so `nix flake update logos-rust-sdk` alone does not move it — the URL is bumped in `flake.nix` too. (`logos-qt-sdk` is unpinned and moved by the lock update alone.)

## Follows integrity

`logos-qt-sdk`'s `follows` for `logos-protocol` and `logos-cpp-sdk` still resolve to the **root** nodes. Verified by resolving `nodes[root].inputs` rather than trusting node names — flake.lock keys are deduplicated, so a node named `logos-qt-sdk` is not necessarily the one the root actually uses.

## Verification

```
nix build .#checks.<system>.default   # passes on the new pins
```

Once this lands, the workspace pin follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)