### PR TITLE
chore: re-pin qt-sdk + rust-sdk (emitters, ?any, jsonReturn)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786130730,
-        "narHash": "sha256-VTmXHQrjJCfRBDwpJvO6vbyuaE1Oi6P2ORgl9FmBUQc=",
+        "lastModified": 1786132651,
+        "narHash": "sha256-ZAUNQzOvxQ5H75Te35/89iq3oSno/3nZthTYLxHKK5w=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "8a9efdfb9d89b74f144fa94ec96a8827fb29a22c",
+        "rev": "3cd529704ccb14fb20ec8aac614a5c6fff236cb1",
         "type": "github"
       },
       "original": {
@@ -27440,17 +27440,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1786130744,
-        "narHash": "sha256-2+WuTZB/b4LOFHgD1/owkam6ROCAgUzLoKYFk7FpIro=",
+        "lastModified": 1786136791,
+        "narHash": "sha256-eJ9BeWRg0Ou+EjE2L1N0PbTsDebCbBqJvJC8MJYgI38=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "6310031e5f49a4584b59819cd4a379b030cd84c3",
+        "rev": "0b4b8edd5127378b78890297f5fcec738b81f8e2",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "6310031e5f49a4584b59819cd4a379b030cd84c3",
+        "rev": "0b4b8edd5127378b78890297f5fcec738b81f8e2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     # logos-module-builder input is cut with `follows` to break the cycle — we
     # only consume its lidl-gen package + source tree, never its tests. The other
     # branch-pinned test-only inputs are cut too so they aren't fetched.
-    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/6310031e5f49a4584b59819cd4a379b030cd84c3";
+    logos-rust-sdk.url = "github:logos-co/logos-rust-sdk/0b4b8edd5127378b78890297f5fcec738b81f8e2";
     logos-rust-sdk.inputs.logos-nix.follows = "logos-nix";
     logos-rust-sdk.inputs.logos-module-builder.follows = "logos-cpp-sdk";
     logos-rust-sdk.inputs.logos-logoscore-cli.follows = "logos-cpp-sdk";


### PR DESCRIPTION
Second bump after #187 — four more SDK PRs have merged since.

| input | from | to | brings |
|---|---|---|---|
| `logos-qt-sdk` | `8a9efdf` | `3cd5297` | qt-sdk#31 — `jsonReturn` shapes are already Qt types, stop converting |
| `logos-rust-sdk` | `6310031` | `0b4b8ed` | rust-sdk#36 (admit `Option<serde_json::Value>`, scope the optional-return refusal), #37 (refresh roundtrip goldens), #38 (typed event emitters speak records) |

## ⚠️ Breaking for one downstream, by design

rust-sdk#38 changes a **record** event emitter from `emit_x(&serde_json::Value)` to `emit_x(&Record)`.

`logos-test-modules/test-fullapi-ext-module-rust` calls it, so its source must change from

```rust
emit_blob_event(&v.to_json());
```

to

```rust
emit_blob_event(&v);
```

in the **same change that picks this builder up** — it cannot compile against both. That module's own comment described the old signature as a workaround:

> *"The emitter takes raw JSON even for a record parameter, so the record is encoded here through its own to_json"*

which is exactly what #38 removes.

## The wire is unchanged, and so is the conformance matrix

The author was already encoding through the record's `to_json`, and that is the encoder the generator now calls — byte-identical output. The conformance case `event/Record` in `logos-test-modules/conformance/ext-cases.json` pins the payload

```json
{"id": "e", "n": 7, "payload": {"_bytes": "aGk"}}
```

and is unaffected, **including the tagged bstr field**. `logos-logoscore-py` has no `blobEvent` references and drives everything over the wire, so it is unaffected too.

## Verification

`nix build .#checks.<system>.default` passes on the new pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)