### PR TITLE
chore: bump logos-protocol + logos-qt-sdk (handshake surface)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786030193,
-        "narHash": "sha256-Z5rxmZBMJsNsUSb37ljbDMKrtrds9Enw5oPJcf8wbVU=",
+        "lastModified": 1786157921,
+        "narHash": "sha256-1zGckJPBA+O5e8uYXKpU6oBiJYFURpcBkNw74G2jan4=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "0f26ffdeef18fb9582dc0a95e2bee482464da40d",
+        "rev": "c1b0a0f554cd5197a974db7d6f805fc87ff07457",
         "type": "github"
       },
       "original": {
@@ -26583,11 +26583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786132651,
-        "narHash": "sha256-ZAUNQzOvxQ5H75Te35/89iq3oSno/3nZthTYLxHKK5w=",
+        "lastModified": 1786160726,
+        "narHash": "sha256-u7J0endCh5+D+uQEgOg+quYNXJXpbCcqQChaNhwd7n4=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "3cd529704ccb14fb20ec8aac614a5c6fff236cb1",
+        "rev": "60d7a08313d66cae129faa104749c562106b4c72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Carries the ui-host startup-wedge fix to every module this builder produces.

| input | from | to |
|---|---|---|
| `logos-protocol` | `0f26ffd` | **`c1b0a0f5`** (logos-co/logos-protocol#42) |
| `logos-qt-sdk` | `3cd5297` | **`60d7a083`** (logos-co/logos-qt-sdk#28) |

## The bug being carried

capability_module, serving `requestModule(wallet_ui → wallet_backend_module)`, had to acquire the target's QtRO replica to push it a token — but the target was itself blocked in a synchronous `requestModule` back to capability. Closed loop, captured with both sides naming each other:

```
[capability_module]      Timeout waiting for replica: "wallet_backend_module"
[wallet_backend_module]  Timeout waiting for replica: "capability_module"
```

ui-host misses the standalone app's hard 10 s readiness deadline and is SIGKILLed (code 9) before either 20 s acquire even expires — the acquire budget is twice the deadline, so the race is unwinnable once entered.

## Evidence

Measured on a native Linux host against the real wallet-ui app bundle, fresh `--user-dir` per run:

| condition | baseline | fixed | one-tailed p |
|---|---|---|---|
| sequential, unloaded | 5 / 20 | 0 / 20 | 0.024 |
| interleaved (alternates arm *and* order) | 5 / 46 | 0 / 46 | 0.028 |
| **protocol+qt-sdk alone**, capability at old pin | **6 / 25** | **0 / 25** | **0.011** |
| pooled, exact stratified | 10 / 66 | 0 / 66 | **0.00066** |

Plus the full 26-action wallet-ui e2e doctest passing. Scope, stated honestly: **greatly reduces**, not eliminates — 0/66 admits a residual up to ~4.4%, on one host. CPU contention *suppressed* the race (baseline 0/14 under load), so "constrained CI hardware is worse" has no established sign.

## Why logos-cpp-sdk is NOT bumped

It stays at `dfd4628`. An earlier pre-flight failed here with `lidlCheckRecords` undeclared in `qt-generator`, which looked like a cpp-sdk skew — module-builder forces `logos-qt-sdk.inputs.logos-cpp-sdk.follows`, and `dfd4628` is *newer* than qt-sdk's `198f031`. That was an artifact: the pre-flight forced qt-sdk#28's **unmerged** head (based on the older `cde7d42`) into module-builder while its own inputs stayed put. Post-merge, qt-sdk master pins `198f031` itself and the combination composes.

Verified rather than assumed: built `logos-capability-module` through this builder, and the resulting plugin carries `ModuleHandshakeProxy` (32), `seedHandshakeTrustAnchor` (2), `refused the token for` (1) and `publishes no handshake surface` (1) — i.e. all four consumer/publisher paths.

## Next

Unblocks logos-co/logos-capability-module#22, whose only flake input is this builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)