### PR TITLE
chore(deps): bump logos-protocol to 0183e8c

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25335,11 +25335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786157921,
-        "narHash": "sha256-1zGckJPBA+O5e8uYXKpU6oBiJYFURpcBkNw74G2jan4=",
+        "lastModified": 1786381943,
+        "narHash": "sha256-/EsIMBCNs3BvssVP/lImCFjEar++cAtusMT7KSoe4VU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "c1b0a0f554cd5197a974db7d6f805fc87ff07457",
+        "rev": "0183e8c26aa3e98ed3603258f2f640385bf61954",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Every module built through `mkLogosModule` compiles its generated dependency wrappers against **this repo's** protocol pin, not against whatever the consumer repo pins — `logos-cpp-sdk.inputs.logos-protocol.follows` and `logos-qt-sdk.inputs.logos-protocol.follows` both point at it (`flake.nix:12,17`).

So a generator that begins emitting a newer protocol symbol **cannot** be validated by bumping the SDK alone. The emitted call has nothing to bind to.

That is not hypothetical — it is why logos-co/logos-cpp-sdk#134 is red right now. It makes the generated Qt wrapper call `onEventWhenAvailable()`, bumped its own `flake.lock` to a protocol that has it, and still failed:

```
generated_code/notifier_module_api.cpp:63:22: error:
  'class LogosAPIClient' has no member named 'onEventWhenAvailable'
```

because the module build resolved protocol through **this** repo's `0f26ffd`.

## The pin

`0183e8c` is `logos-protocol` master with #47, #53 and #55 merged.

Deliberately **not** the first commit that introduces `onEventWhenAvailable`. #47's tip also carries the `tryAcquireNow` use-after-free fix: probing a not-yet-reachable module freed a QtRO facade that was still registered in a shared replica implementation's `m_parentsNeedingConnect`, and generated Qt consumers subscribe in precisely the shape that triggers it — one `on<Event>` per declared event, from `init()`. A lower pin would let modules compile and then crash in the event loop rather than at the call site.

## Blast radius

One node, three consumers — the `follows` mean root, `logos-cpp-sdk` and `logos-qt-sdk` all move together:

```
root.logos-protocol          -> 0183e8c
logos-cpp-sdk.logos-protocol -> 0183e8c
logos-qt-sdk.logos-protocol  -> 0183e8c
```

`flake.lock` only; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)