### PR TITLE
chore(deps): bump logos-cpp-sdk to 9d50829 (deferred generated event subscriptions)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1625,11 +1625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786113947,
-        "narHash": "sha256-n9Lhe6vxyvkGSwlfT5HylTKsFVm5bkpRfUvTbWd6X2c=",
+        "lastModified": 1786388838,
+        "narHash": "sha256-X8CD/kD/+SEspCVCc0MzSoOphUqfFab8pNtCN3z/Qtc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "dfd46282a7b7d48075f890ace3a39a128e5b2576",
+        "rev": "9d508292eb03cc5922ef7b1e0cf747de501427a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
**Without this, logos-co/logos-cpp-sdk#134 reaches nothing.** Every module built through `mkLogosModule` takes its generated dependency wrappers from this repo's `logos-cpp-sdk` pin, which was still `dfd4628` — predating both #134 and #135.

So real modules kept emitting the old shape:

```cpp
LogosObject* origin = ensureReplica();   // blocking requestObject
if (!origin) return false;               // PERMANENT, never retried
```

which asks *"is this module reachable right now"* at the one moment the answer is no — every C++ consumer subscribes from `init()`, `onContextReady()` or a backend constructor, all of which run while the dependency's host has been spawned and has not yet called `listen()`.

## Why the current state is the worst of the two orders

That guard was **dead code for years**, because `isConnected()` returned an always-true latch and the call fell through to a blocking wait that usually succeeded, slowly. logos-co/logos-protocol#47 made `isConnected()` truthful — which turns the same code into an **instant, permanent, silent failure**.

#190 pinned the new protocol here. This PR pins the generator that copes with it. Having the first without the second is strictly worse than having neither, and that is the state this repo has been in since #190 merged.

## Already proven green in this exact combination

logos-co/logos-cpp-sdk#134's doc-tests built their modules against module-builder master (protocol `0183e8c`) with `logos-cpp-sdk` overridden to `9d50829` — which is precisely what this lock now produces. The Qt spec passed there:

```
PASS  The subscription made at init was accepted
PASS  The event crossed the boundary into the Qt-typed subscriber
PASS  Exactly once
```

`flake.lock` only; no source change. Resulting pins:

```
root.logos-cpp-sdk      -> 9d50829
root.logos-protocol     -> 0183e8c
cpp-sdk.logos-protocol  -> 0183e8c   (via follows)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)