### PR TITLE
feat(windows): stage declared runtime files, and read <drv>/bin

### DIFF
--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -261,6 +261,47 @@ let
         externalInputs = defaultResolvedExternalLibs;
       };
 
+      # metadata `include`: runtime files a module needs BESIDE its plugin but
+      # never links against -- in practice, dlopen'd libraries.
+      #
+      # Nothing else can stage these. The Windows DLL walk
+      # (logos-plugin-qt postFixup -> linkDLLsInfolder) is IMPORT-TABLE driven,
+      # so a library reached only through dlopen appears in no table and is
+      # invisible to it; on Unix there is equally no DT_NEEDED entry to follow.
+      # delivery_module hit exactly this with libpq: declared, needed at
+      # runtime, and silently absent from the module output.
+      #
+      # Sources are the module's own runtime nix packages and its resolved
+      # external libs; both `lib/` and `bin/` are searched, because a Windows
+      # shared library's runtime half lives in bin/ by convention.
+      #
+      # A name that matches nothing is NORMAL, not an error: the list is a
+      # deliberate cross-platform superset (modules name the .so, .dylib and
+      # .dll spellings side by side), so at most one spelling can ever match.
+      #
+      # Runs BEFORE the module's own postInstall, so author hooks can react to
+      # what was staged, and before the Windows postFixup, so linkDLLsInfolder
+      # then also walks the staged library's OWN imports (libpq pulls in
+      # libssl/libcrypto that way).
+      stageIncludedRuntimeFiles =
+        let
+          sources = runtimePkgs ++ lib.attrValues defaultResolvedExternalLibs;
+        in
+        lib.optionalString (config.include != [ ] && sources != [ ]) ''
+          echo "Staging declared runtime files (metadata 'include')..."
+          mkdir -p $out/lib
+          for _inc_name in ${lib.escapeShellArgs config.include}; do
+            for _inc_root in ${lib.escapeShellArgs (map toString sources)}; do
+              for _inc_sub in lib bin; do
+                if [ -e "$_inc_root/$_inc_sub/$_inc_name" ]; then
+                  cp -Lf "$_inc_root/$_inc_sub/$_inc_name" "$out/lib/" 2>/dev/null \
+                    && echo "  staged $_inc_name" && break 2
+                fi
+              done
+            done
+          done
+        '';
+
       # Resolve SDK deps for this system — injected into the backend
       logosSdk = logos-cpp-sdk.packages.${system}.default;
       # Build-platform half of the SDK. logos-cpp-generator is invoked by BARE
@@ -497,7 +538,8 @@ let
         # The backend only knows about Qt + logosModule (interface.h).
         # SDK (generator, lib, headers) is injected via extra* args.
         in ({
-          inherit pkgs src config postInstall logosModule;
+          inherit pkgs src config logosModule;
+          postInstall = stageIncludedRuntimeFiles + postInstall;
           preConfigure = preConfigureStr;
           moduleDeps = resolvedModuleDeps;
           inherit externalLibs;

--- a/lib/modulePreConfigure.nix
+++ b/lib/modulePreConfigure.nix
@@ -25,6 +25,15 @@ let
             if [ -d "${v}/lib" ]; then
               cp -f "${v}"/lib/* lib/ 2>/dev/null || true
             fi
+            # Windows ships a shared library's runtime half in bin/ (CMake's
+            # RUNTIME destination). Mirror of the staging in
+            # logos-plugin-qt/lib/buildPlugin.nix -- see the longer note there
+            # for why only this library's own files are taken, not all of bin/.
+            if [ -d "${v}/bin" ]; then
+              for f in "${v}"/bin/lib${name}.dll "${v}"/bin/${name}.dll; do
+                [ -f "$f" ] && cp -fL "$f" lib/ 2>/dev/null || true
+              done
+            fi
             if [ -d "${v}/include" ]; then
               cp -f "${v}"/include/*.h lib/ 2>/dev/null || true
             fi


### PR DESCRIPTION
Two changes, both about runtime libraries that reach a module's output through
nothing the build can infer.

## 1. `metadata.json`'s `include` field now does something

Today it is **inert**. It is parsed at `parseMetadata.nix:31` and read by
nothing — it drives no copy, no error, not even a log line — and
`nix-bundle-lgx/bundle.sh` omits it from the manifest key allowlist. Three
modules declare it (`logos-delivery-module`, `logos-storage-module`,
`logos-libp2p-module`), so the intent has been recorded for a while; only the
implementation was missing.

This implements what it always advertised: each declared filename is looked up in
the module's runtime nix packages and its resolved external libraries — in both
`lib/` and `bin/` — and copied into `$out/lib`.

**Nothing else can do this job.** The Windows DLL walk (logos-plugin-qt's
`postFixup` → `linkDLLsInfolder`) is **import-table driven**, so a library
reached only through `dlopen` appears in no import table and is invisible to it.
On Unix there is equally no `DT_NEEDED` entry to follow. `delivery_module` hit
exactly this with **libpq**: declared, needed at runtime, and silently absent
from the module output.

Three details that matter:

- **A name matching nothing is normal, not an error.** The list is a deliberate
  cross-platform superset — `libpq.so`, `libpq.so.5`, `libpq.dylib`,
  `libpq.5.dylib`, `libpq.dll` are all listed side by side, so at most one
  spelling can ever match. Failing on a miss would break every platform.
- **It runs before the module's own `postInstall`**, so author hooks can react to
  what was staged.
- **It runs before the Windows `postFixup`**, so `linkDLLsInfolder` then also
  walks the staged library's *own* imports — `libpq.dll` pulls in
  `libssl`/`libcrypto` that way, transitively, rather than needing a second fix.

## 2. `copyExternalLibsToLib` also reads `<drv>/bin`

Mirror of logos-co/logos-plugin-qt#18 for the tests/QML staging path. A library
following the Windows convention ships its runtime half in `bin/` (CMake's
`RUNTIME` destination). Matching only `*.dll` keeps the branch inherently
Windows-only, which matters here because this file only receives `lib` — there is
no `pkgs` to test `hostPlatform` against, and this avoids threading one through
`compose`.

## Verification

Cross-built `logos-delivery-module` for `x86_64-windows`. The module output gains
`libpq.dll`, and the build log shows the staging picking exactly the two names
that exist on this platform while silently skipping the `.so`/`.dylib` spellings:

```
Staging declared runtime files (metadata 'include')...
  staged liblogosdelivery.dll
  staged libpq.dll
```

On real Windows 10.0.26200 the resulting plugin loads and dispatches:

```
$ logoscore.exe load-module delivery_module
{"module":"delivery_module","status":"ok","version":"0.1.3"}

$ logoscore.exe call delivery_module version
{"method":"version","module":"delivery_module","result":"1.1.0 (...)","status":"ok"}
```

## Blast radius

Modules with an empty `include` and no external libraries emit identical text and
do not rebuild. Modules that **do** declare `include` will start staging their
listed files — that is the intent, but it is a behaviour change for
`logos-storage-module` and `logos-libp2p-module`, worth a look before this
merges.

## Ordering

Depends on logos-co/logos-plugin-qt#18, which covers the plugin build path (this
repo's `copyExternalLibsToLib` is the tests/QML path; `mkLogosModule` sets
`copyExternals = false` for plugin builds because buildPlugin already stages).
Land that one first, then re-pin.

Also related: logos-messaging/logos-delivery#4125, the Windows cross-build that
produces a `bin/`-layout library and the `libpq` these changes stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
