### PR TITLE
feat(windows): cross-compile Rust modules to x86_64-pc-windows-gnu

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -654,9 +654,29 @@ function(logos_module)
                 elseif(TARGET logos_protocol)
                     target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos_protocol)
                 endif()
+                # Native libraries Rust's `std` leaves undefined in a staticlib.
+                # These are per-platform and NOT interchangeable: the old
+                # two-way APPLE/else split silently meant "else == Linux" and
+                # put `pthread dl` on the Windows link line, where `dl` does not
+                # exist at all and `pthread` lives in a separate
+                # mingw_w64-pthreads package that is not on the sysroot search
+                # path -- so a Rust module could never link for Windows.
                 if(APPLE)
                     target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE
                         "-framework CoreFoundation" "-framework Security")
+                elseif(WIN32)
+                    # Derived from the archive's own undefined symbols, not
+                    # guessed: BCryptGenRandom -> bcrypt; Nt*/Rtl* (file I/O and
+                    # the unwinder) -> ntdll; GetUserProfileDirectoryW ->
+                    # userenv; WaitOnAddress/WakeByAddress* -> synchronization
+                    # (kernel32's mingw import lib does not carry them); the
+                    # WSA*/socket set -> ws2_32. `ProcessPrng` needs nothing
+                    # here -- std bundles its own bcryptprimitives import stubs
+                    # inside the archive. Qt happens to drag several of these in
+                    # already, but naming them keeps the Rust link independent
+                    # of Qt's link interface.
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE
+                        ws2_32 bcrypt ntdll userenv synchronization advapi32)
                 else()
                     target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE pthread dl)
                 endif()

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -92,6 +92,12 @@ let
     let
       pkgs = common.mkPkgs system;
 
+      # Rust target triple when `system` is a cross pseudo-system; null natively.
+      # Every cross branch below keys off this being non-null, so a native build
+      # takes exactly the code path it did before.
+      rustCrossTarget =
+        if system == "x86_64-windows" then "x86_64-pc-windows-gnu" else null;
+
       # Rust toolchain for the crate compile. Default = the pinned nixpkgs rustc,
       # so non-Rust modules and Rust modules without a `nix.rust.toolchain` are
       # unchanged. When a module sets `nix.rust.toolchain` (e.g. "1.96.0") and the
@@ -102,10 +108,48 @@ let
         if config.nix_rust.toolchain != null && rust-overlay != null
         then
           let
-            rpkgs = common.mkPkgsWith [ (import rust-overlay) ] system;
-            toolchain = rpkgs.rust-bin.stable.${config.nix_rust.toolchain}.default;
-          in rpkgs.makeRustPlatform { cargo = toolchain; rustc = toolchain; }
+            # The toolchain must RUN on the builder and merely TARGET `system`.
+            # Asking the CROSS set for rust-bin evaluates
+            # `targetPackages.threads.package` (nixpkgs all-packages.nix) --
+            # an attribute only the MinGW branch touches and that the cross set
+            # does not define -- and mkPkgsWith refuses overlays for
+            # x86_64-windows for the same "that is not the set you asked for"
+            # reason. Taking it from the BUILD system sidesteps both, and is
+            # what a cross toolchain should be regardless.
+            # buildSystemFor is the identity on every native system, so this is
+            # a no-op there.
+            bpkgs = common.mkPkgsWith [ (import rust-overlay) ] (common.buildSystemFor system);
+            base = bpkgs.rust-bin.stable.${config.nix_rust.toolchain}.default;
+            toolchain =
+              if rustCrossTarget == null
+              then base
+              else base.override { targets = [ rustCrossTarget ]; };
+          in bpkgs.makeRustPlatform { cargo = toolchain; rustc = toolchain; }
         else pkgs.rustPlatform;
+
+      # Cross wiring for the crate compile. The derivation runs in the BUILD
+      # platform's stdenv (see rustPlatform above), so nothing sets these for us.
+      rustCrossEnv =
+        if rustCrossTarget == null then { }
+        else
+          let
+            cc = pkgs.stdenv.cc;  # `pkgs` is the TARGET set: the mingw wrapper
+            u = builtins.replaceStrings [ "-" ] [ "_" ] rustCrossTarget;
+            U = lib.toUpper u;
+          in {
+            CARGO_BUILD_TARGET = rustCrossTarget;
+            "CARGO_TARGET_${U}_LINKER" = "${cc}/bin/${cc.targetPrefix}cc";
+            # windows-gnu std links `-l:libpthread.a`, but nixpkgs builds
+            # mingw-w64 against mcfgthread, which ships no pthreads at all.
+            "CARGO_TARGET_${U}_RUSTFLAGS" = "-L native=${pkgs.windows.pthreads}/lib";
+            # cc-rs keys its toolchain off CC_<triple>/CXX_/AR_ with dashes
+            # replaced by underscores. Without these a build script compiles its
+            # bundled C for the BUILDER and the link then fails on undefined
+            # symbols -- silently, because the archive is still produced.
+            "CC_${u}" = "${cc}/bin/${cc.targetPrefix}cc";
+            "CXX_${u}" = "${cc}/bin/${cc.targetPrefix}c++";
+            "AR_${u}" = "${cc.bintools}/bin/${cc.targetPrefix}ar";
+          };
 
       # ── Concrete dependency classification ─────────────────────────────────
       # A dependency's typed `modules().<dep>` wrapper is generated from its
@@ -250,7 +294,11 @@ let
       # (host tools), runtime -> buildInputs (link libs). Resolved with the same
       # dotted-path getPkg as buildPkgs/runtimePkgs. Fed only to rustStaticLib,
       # not the C++ plugin link.
-      rustNativeBuildPkgs = map (getPkg pkgs) (lib.filter builtins.isString config.nix_rust.packages.build);
+      # buildPackages, not pkgs: these are TOOLS that run on the builder
+      # (pkg-config, perl, protobuf, cmake). Under cross, resolving them from
+      # the target set would try to build each one FOR Windows. Identity on
+      # every native system, so no native derivation changes.
+      rustNativeBuildPkgs = map (getPkg pkgs.buildPackages) (lib.filter builtins.isString config.nix_rust.packages.build);
       rustBuildPkgs       = map (getPkg pkgs) (lib.filter builtins.isString config.nix_rust.packages.runtime);
 
       # Pre-resolve default variant external libs (always needed, avoids
@@ -344,7 +392,12 @@ let
         else if logos-rust-sdk == null
         then throw "codegen.rust module '${config.name}' requires logos-module-builder to be built with a logos-rust-sdk input (it provides the lidl-gen generator + the SDK source). Update the builder."
         else logos-rust-sdk;
-      rustGen = if !isRustModule then null else rustSdk.packages.${system}.lidl-gen;
+      # lidl-gen is a build-time TOOL: it runs on the builder to emit the Rust
+      # scaffold. Resolving it from the TARGET set asks logos-rust-sdk for an
+      # x86_64-windows attribute it does not publish -- and which would be an
+      # unrunnable PE if it did. buildSystemFor is the identity natively.
+      rustGen = if !isRustModule then null
+                else rustSdk.packages.${common.buildSystemFor system}.lidl-gen;
 
       # The dep contracts that feed the Rust generator: the same resolved
       # concrete + interface deps the C++ generator gets. Concrete deps →
@@ -416,7 +469,7 @@ let
 
       rustStaticLib =
         if !isRustModule then null
-        else rustPlatform.buildRustPackage {
+        else rustPlatform.buildRustPackage ({
           pname = rustStaticName;
           version = config.version;
           src = rustCrateSrc;
@@ -428,11 +481,34 @@ let
           # External system build deps for the crate compile — from metadata
           # `nix.rust` plus the programmatic escape-hatch args. Empty by default,
           # so modules with no native deps build exactly as before.
-          nativeBuildInputs = rustNativeBuildPkgs ++ rustExtraNativeBuildInputs;
+          nativeBuildInputs = rustNativeBuildPkgs ++ rustExtraNativeBuildInputs
+            # The cc-rs / linker wiring above names the cross compiler by store
+            # path, but build scripts also expect it on PATH.
+            ++ lib.optional (rustCrossTarget != null) pkgs.stdenv.cc;
           buildInputs = rustBuildPkgs ++ rustExtraBuildInputs;
-          env = config.nix_rust.env // rustEnv;
+          env = config.nix_rust.env // rustEnv // rustCrossEnv;
           doCheck = false;
-        };
+        }
+        # nixpkgs' cargoBuildHook derives `--target` from the stdenv's HOST
+        # platform, and this derivation deliberately runs in the BUILD
+        # platform's stdenv (see rustPlatform above) so that the toolchain is
+        # runnable. Left alone it therefore builds for the BUILDER -- silently,
+        # producing a perfectly good Linux archive that then fails to link into
+        # a PE. Drive cargo directly for the cross case instead.
+        // lib.optionalAttrs (rustCrossTarget != null) {
+          buildPhase = ''
+            runHook preBuild
+            export CARGO_HOME=$TMPDIR/cargo
+            cargo build --release --offline --target ${rustCrossTarget}
+            runHook postBuild
+          '';
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/lib
+            cp target/${rustCrossTarget}/release/lib${rustStaticName}.a $out/lib/
+            runHook postInstall
+          '';
+        });
 
       # Stage the compiled staticlib where LogosModule.cmake's
       # LOGOS_MODULE_RUST_STATIC_LIBS block finds it (the plugin build's lib/).


### PR DESCRIPTION
A `codegen.rust` module could not be built for Windows at all. Two independent halves were missing — either one alone was fatal.

## The crate compile

The Rust toolchain has to **run on the builder** and merely **target** Windows, so it now comes from the build system with `targets = [ "x86_64-pc-windows-gnu" ]`. Asking the cross set for `rust-bin` evaluates `targetPackages.threads.package`, an attribute only the MinGW branch defines.

That choice has a consequence worth calling out, because it fails *silently*: nixpkgs' `cargoBuildHook` derives `--target` from the stdenv's **host** platform. Left alone it therefore builds for the builder and produces a perfectly good **Linux** archive that only fails much later, at the PE link. The cross case drives cargo directly instead.

Alongside that:

- `CC_/CXX_/AR_<triple>` are set so cc-rs compiles build-script C for Windows too (without them a build script compiles its bundled C for the builder, and the archive is still produced — so this also fails silently).
- `nix.rust` build packages resolve from `buildPackages`; they are host tools (`pkg-config`, `perl`, `protobuf`, `cmake`), and from the target set nix would try to build each one *for Windows*.
- `lidl-gen` resolves from the build system — it is a generator that runs on the builder, not a shipped artifact.

## The plugin link

`LogosModule.cmake` chose the native libraries Rust's `std` leaves undefined in a staticlib with a **two-way** `if(APPLE)/else()`. So "else" silently meant "Linux", and `pthread dl` went onto the Windows link line: `dl` does not exist on Windows, and `pthread` lives in a separate `mingw_w64-pthreads` package that is not on the mingw sysroot search path (nixpkgs builds mingw-w64 against mcfgthread).

The new `elseif(WIN32)` list is **derived from the archive's own undefined symbols**, not guessed:

| Undefined symbol | Library |
|---|---|
| `BCryptGenRandom` | `bcrypt` |
| `Nt*` / `Rtl*` (file I/O + unwinder) | `ntdll` |
| `GetUserProfileDirectoryW` | `userenv` |
| `WaitOnAddress`, `WakeByAddress*` | `synchronization` — kernel32's mingw import lib does **not** carry them |
| `WSA*`, `socket`, `getaddrinfo` | `ws2_32` |
| `ProcessPrng` | *nothing* — std bundles its own `bcryptprimitives` import stubs inside the archive |

The finished DLL's import table confirms every one of these is genuinely reached and none is redundant. Qt happens to drag several in anyway, so a build could appear to work for the wrong reason; naming them keeps the Rust link independent of Qt's link interface.

## Native builds are unchanged

Every cross branch keys off `rustCrossTarget != null`, and `buildSystemFor` is the identity on native systems, so a native build takes exactly the path it did before.

## Verification

`keystore_module` and `token_list_module`, both targets, all four green:

| | `x86_64-windows` | `x86_64-linux` |
|---|---|---|
| `keystore_module` | ✅ | ✅ |
| `token_list_module` | ✅ | ✅ |

Both Windows outputs are PE32+ x86-64 plugin DLLs exporting `qt_plugin_instance` / `qt_plugin_query_metadata_v2`, with the Rust really linked in — verified by crate-specific strings: `eth-keystore-0.5.0`, `coins-bip39-0.12.0`, `alloy-signer-local-1.6.3` in one; `ring-0.17.14`, `rustls`, `webpki-0.103.13`, `hyper-1.10.1`, `reqwest-0.12.28` in the other.

These two were chosen as subjects deliberately. `logos-chat-module` cannot evidence anything about Windows right now: it fails identically on a **native** build with four `E0053` errors from the logos-rust-sdk 0.2.0 → 0.3.0 migration.

## Note for other Rust modules

`aws-lc-sys` does not cross to mingw — it compiles `third_party/jitterentropy`, whose `jitterentropy-base-user.h` includes `<sched.h>`, for the Windows target. That is aws-lc-sys failing to gate a POSIX-only entropy source out of its Windows file list, so no amount of toolchain wiring fixes it. Use the rustls `ring` provider instead (`default-features = false, features = ["ring"]`). Triage with `grep -E '^name = "(aws-lc-sys|ring)"' Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)