### PR TITLE
docs: drop unused krb5 from nix.packages.runtime examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,10 +228,15 @@ Packages needed at runtime.
 "nix": {
   "packages": {
     "build": ["protobuf", "abseil-cpp"],
-    "runtime": ["zstd", "krb5"]
+    "runtime": ["zstd"]
   }
 }
 ```
+
+List only what the module actually links against or `dlopen`s. Every entry is
+evaluated for the *target* platform, so an unused package can break a cross
+build even though it is harmless natively — a package whose closure is not
+available for the target makes the whole module fail to evaluate.
 
 Package names can be dotted for nested packages:
 
@@ -421,7 +426,7 @@ A chat module that depends on waku, uses protobuf, and exposes its API to other 
   "nix": {
     "packages": {
       "build": ["protobuf", "abseil-cpp"],
-      "runtime": ["zstd", "krb5"]
+      "runtime": ["zstd"]
     },
     "external_libraries": [],
     "cmake": {

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -176,7 +176,7 @@ ls -la result/include/
   "nix": {
     "packages": {
       "build": ["protobuf", "abseil-cpp"],
-      "runtime": ["zstd", "krb5"]
+      "runtime": ["zstd"]
     },
     "external_libraries": [],
     "cmake": {


### PR DESCRIPTION
Drops `krb5` from the three `nix.packages.runtime` examples in the docs, and adds a
short note about what belongs in that list.

### Why

`krb5` was never a real dependency of anything in these examples — it is a Kerberos
implementation, and nothing in a chat/protobuf module links against it or `dlopen`s
it. It most likely entered the docs by being copied out of a much older
`buildInputs` list.

Because it is in the docs it got copied verbatim into module `metadata.json` files
across the org. Eight modules currently carry the identical line

```json
"runtime": ["qt6.qtdeclarative", "zstd", "krb5", "abseil-cpp"]
```

none of which reference Kerberos or GSSAPI anywhere in their sources.

It is not merely dead weight. It breaks Windows cross builds: `krb5` pulls in a
transitive `bash`, whose `meta.platforms` excludes mingw, so evaluation fails
outright. Reproduced against the nixpkgs these modules pin
(`e9f00bd893984bc8ce46c895c3bf7cac95331127`):

```
$ nix eval --raw --expr '... pkgs.pkgsCross.mingwW64.krb5.outPath'
error: Package 'bash-5.3p3' ... is not available on the requested hostPlatform:
         hostPlatform.system = "x86_64-windows"
       , refusing to evaluate.
```

The other entries in that copied list are fine — `pkgsCross.mingwW64.zstd` and
`pkgsCross.mingwW64.abseil-cpp` both evaluate. `krb5` is the only one in the list
that is both unused *and* mingw-hostile.

`logos-basecamp` already works around this with an explicit
`lib.optional (!stdenv.hostPlatform.isWindows) pkgs.krb5` guard. The modules that
copied the docs example have no such guard.

(To be clear about scope: dropping `krb5` removes one self-inflicted blocker. It is
not on its own sufficient to cross-build a Qt UI module — stock
`pkgsCross.mingwW64.qt6.qtdeclarative` refuses to evaluate too, on `libglvnd`,
which is what the Windows Qt overlay exists to handle.)

### What changed

- `docs/configuration.md` — `nix.packages.runtime` example, and the "Complete
  Example" chat module: `["zstd", "krb5"]` → `["zstd"]`.
- `docs/migration.md` — same, in the "Simple Module" migration example.
- `docs/configuration.md` — added a note under `nix.packages.runtime` explaining
  that entries are evaluated for the *target* platform, so an unused package can
  break a cross build even though it is harmless natively.

`zstd` is kept: it is a plausible runtime library for a module in that example, and
unlike `krb5` it cross-evaluates fine.

### Scope

Docs only — no `lib/`, `cmake/`, or template changes. The four templates under
`templates/` already ship `"runtime": []`, so scaffolded modules were never
affected; the docs were the only propagation vector.

Companion PRs remove the copied `krb5` entry from the affected modules, one per
repo.
