### PR TITLE
fix(cross): fail loudly when a dep publishes nothing for the target system

### DIFF
--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -80,40 +80,10 @@ let
       # buildPlugin.nix always types "qt" — the `headers-lp` entry exists so an
       # lp consumer that ever reaches this path fails with a real message
       # instead of a "cannot coerce a set to a string" from the header copy.
-      moduleInputs = lib.filterAttrs (n: _: builtins.elem n legacyHeaderDepNames) flakeInputs;
-      resolvedModuleDeps = lib.mapAttrs (depName: input:
-        let
-          ps = input.packages.${system} or null;
-          fallback = if input ? packages.${system}.default
-                     then input.packages.${system}.default else input;
-          staleLpDep = reason: throw ''
-            logos-module-builder: dependency '${depName}' cannot be consumed by an lp (Qt-free) module.
-
-            '${depName}' is taking the transitional header-copy path (it publishes
-            no `lidl` output), and
-              ${reason}.
-            So the only headers it offers are Qt-typed. Copying those into a
-            Qt-free translation unit fails deep inside a generated source file
-            with a wall of unrelated-looking Qt type errors, so this build stops
-            here instead.
-
-            Fix: rebuild / re-pin '${depName}' against a current logos-module-builder.
-            Any module built by one publishes a `lidl` contract (preferred — it
-            skips the header copy entirely) as well as a `headers-lp` output.
-          '';
-        in
-        if ps != null then {
-          default     = ps.default;
-          lib         = ps.lib or ps.default;
-          headers-qt  = ps.headers-qt or ps.include or ps.default;
-          headers-lp  = ps.headers-lp or (staleLpDep "its packages.${system} exposes no `headers-lp`");
-        } else {
-          default     = fallback;
-          lib         = fallback;
-          headers-qt  = fallback;
-          headers-lp  = staleLpDep "the flake input is a bare derivation with no packages.${system} attrset";
-        }
-      ) moduleInputs;
+      resolvedModuleDeps = common.resolveLegacyHeaderDeps {
+        inherit system flakeInputs;
+        depNames = legacyHeaderDepNames;
+      };
 
       # Resolve a single externalLibInputs entry for a given variant.
       # Supports both simple (bare flake input) and structured ({ input, packages }) formats.

--- a/lib/common.nix
+++ b/lib/common.nix
@@ -78,9 +78,26 @@ let
              + "x86_64-windows target (requested "
              + toString (builtins.length extraOverlays) + ").")
     else
-      logos-nix.lib.mkWindowsPkgs { buildSystem = "x86_64-linux"; };
+      logos-nix.lib.mkWindowsPkgs { buildSystem = windowsBuildSystem; };
 
   mkPkgs = mkPkgsWith [ ];
+
+  # The build platform Windows artifacts are produced FROM.
+  #
+  # Single-sourced from logos-nix, which owns the decision and the reasoning
+  # for it (`windowsBuildSystems`: wine does not exist for aarch64-darwin, and
+  # upstream only exercises mingw cross from x86_64-linux). It was previously
+  # a bare "x86_64-linux" literal repeated here in two places -- a second copy
+  # of someone else's constant, free to drift from it.
+  #
+  # Deliberately NOT the evaluating system. Pinning it keeps
+  # `packages.x86_64-windows.*` one well-defined derivation no matter who
+  # evaluates it, so a Darwin and a Linux checkout agree and share a cache; a
+  # Darwin dev realises it through a Linux remote builder. Widening this is a
+  # change to `windowsBuildSystems` in logos-nix, not an edit here.
+  windowsBuildSystem =
+    if logos-nix == null then "x86_64-linux"
+    else lib.head logos-nix.lib.windowsBuildSystems;
 
   # The system a build for `target` actually RUNS on. Host TOOLS -- the code
   # generators, moc, repc -- must come from here, never from the target set:
@@ -88,7 +105,90 @@ let
   # Linux builder cannot execute ("logos-cpp-generator: command not found").
   # Identity for every native system, so callers need no isWindows test.
   buildSystemFor = target:
-    if target == "x86_64-windows" then "x86_64-linux" else target;
+    if target == "x86_64-windows" then windowsBuildSystem else target;
+
+  # Resolve the TRANSITIONAL header-copy dependencies (deps publishing no `lidl`
+  # contract) from flake inputs, as a struct exposing the dep's plugin (.lib)
+  # plus the header variant matching the consumer's --api-style.
+  #
+  # ONE implementation on purpose. This logic used to be copy-pasted into
+  # mkLogosModule.nix (core modules) and buildCppPlugin.nix (ui_qml view
+  # modules), and a fix applied to one silently missed the other -- which is
+  # exactly how the missing-system case below went unnoticed for view modules.
+  # Remove the whole thing once every module publishes a `lidl` output.
+  resolveLegacyHeaderDeps = { system, flakeInputs, depNames }:
+    lib.mapAttrs (depName: input:
+      let
+        # An lp (Qt-free) consumer must NOT silently fall back to a Qt-typed
+        # header set. The wrappers would declare QString/QVariantMap while the
+        # consumer's own codegen ran with `--api-style lp`, so the build dies
+        # deep inside a generated TU with a wall of unrelated-looking Qt type
+        # errors. Lazy: only fires if an lp consumer really reads `headers-lp`.
+        staleLpDep = reason: throw ''
+          logos-module-builder: dependency '${depName}' cannot be consumed by an lp (Qt-free) module.
+
+          '${depName}' is taking the transitional header-copy path (it publishes
+          no `lidl` output), and
+            ${reason}.
+          So the only headers it offers are Qt-typed. Copying those into a
+          Qt-free translation unit fails deep inside a generated source file
+          with a wall of unrelated-looking Qt type errors, so this build stops
+          here instead.
+
+          Fix: rebuild / re-pin '${depName}' against a current logos-module-builder.
+          Any module built by one publishes a `lidl` contract (preferred — it
+          skips the header copy entirely) as well as a `headers-lp` output.
+        '';
+
+        # A dep flake that publishes `packages` but nothing for THIS system is an
+        # error, not a fallback. Degrading to `input` hands the plugin build the
+        # dependency's SOURCE TREE as its header root, and the failure surfaces
+        # far away as `fatal error: <dep>_api.h: No such file or directory` in a
+        # generated TU -- or, worse, silently succeeds against whatever stale
+        # headers happen to be checked in.
+        #
+        # This is how chat_ui's Windows build failed: chat_module v0.2.2
+        # publishes only the four native systems, so an x86_64-windows consumer
+        # resolved its headers to the chat_module checkout.
+        #
+        # Only a genuinely bare-derivation input (no `packages` attr at all) may
+        # take the fallback path -- the pre-refactor shape it exists for.
+        ps =
+          if input ? packages && !(input.packages ? ${system}) then
+            throw ''
+              logos-module-builder: dependency '${depName}' publishes no packages for ${system}.
+
+              It exposes: ${lib.concatStringsSep ", " (builtins.attrNames input.packages)}
+
+              '${depName}' is taking the transitional header-copy path (it
+              publishes no `lidl` output), so this build needs its compiled
+              headers for ${system} and there are none.
+
+              Fix: give '${depName}' a ${system} target and re-pin it. For a
+              cross target that means adding ${system} to the systems list its
+              flake folds `packages` over -- mkLogosModule already understands
+              the target, so it is usually a one-line change in that flake.
+            ''
+          else input.packages.${system} or null;
+
+        # Pre-version of this refactor: input was the raw flake-output derivation
+        # (not a packages set). Preserve that path so an external flake-input dep
+        # still works.
+        fallback = if input ? packages.${system}.default
+                   then input.packages.${system}.default else input;
+      in
+      if ps != null then {
+        default     = ps.default;
+        lib         = ps.lib or ps.default;
+        headers-qt  = ps.headers-qt or ps.include or ps.default;
+        headers-lp  = ps.headers-lp or (staleLpDep "its packages.${system} exposes no `headers-lp`");
+      } else {
+        default     = fallback;
+        lib         = fallback;
+        headers-qt  = fallback;
+        headers-lp  = staleLpDep "the flake input is a bare derivation with no packages.${system} attrset";
+      }
+    ) (lib.filterAttrs (n: _: builtins.elem n depNames) flakeInputs);
 
   # Helper to run a function for all systems
   forAllSystems = _nixpkgs: f:
@@ -98,7 +198,7 @@ let
     });
 
 in {
-  inherit systems mkPkgs mkPkgsWith forAllSystems buildSystemFor;
+  inherit systems mkPkgs mkPkgsWith forAllSystems buildSystemFor resolveLegacyHeaderDeps;
 
   inherit collectAllModuleDeps;
 

--- a/lib/common.nix
+++ b/lib/common.nix
@@ -28,13 +28,35 @@ let
         else
           nix-bundle-lgx.bundlers.${system}.default drv;
 
-      direct = lib.mapAttrs (_: input:
+      direct = lib.mapAttrs (depName: input:
         if input ? packages.${system}.lgx
         then input.packages.${system}.lgx
         else if input ? packages.${system}.lib
         then autoBundleLgx input.packages.${system}.lib
         else if input ? packages.${system}.default
         then autoBundleLgx input.packages.${system}.default
+        # A flake that publishes `packages` but nothing usable for THIS system is
+        # an error, not a fallback -- the same hazard the autoBundleLgx throws
+        # above already guard against, one level out. Falling through to `input`
+        # puts the dependency's SOURCE TREE into the app bundle where an LGX
+        # package belongs: mkStandaloneApp then ships a directory of .cpp files
+        # in place of a module and the failure only shows up at runtime, as a
+        # module that never loads.
+        #
+        # Only a genuinely bare-derivation input (no `packages` attr at all) may
+        # take the fallback below.
+        else if input ? packages then
+          builtins.throw ''
+            collectAllModuleDeps: dependency '${depName}' publishes no usable package for ${system}.
+
+            It exposes systems: ${lib.concatStringsSep ", " (builtins.attrNames input.packages)}
+            ${lib.optionalString (input.packages ? ${system})
+              "and for ${system}: ${lib.concatStringsSep ", " (builtins.attrNames input.packages.${system})} (none of lgx / lib / default)"}
+
+            Fix: give '${depName}' a ${system} target and re-pin it, or publish an
+            `lgx`/`lib`/`default` output for it. For a cross target that is usually
+            a one-line change to the systems list its flake folds `packages` over.
+          ''
         else input
       ) depInputs;
 

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -155,55 +155,11 @@ let
       # as a struct so the plugin builder can pick BOTH the dep's
       # plugin .dylib AND the right header variant for its own
       # --api-style without re-running the codegen at consume time.
-      # Backward-compatible fallbacks let older deps (which only
-      # expose `default`) still work for a QT consumer — they get
-      # treated as Qt-typed. An lp consumer gets no such fallback:
-      # Qt-typed headers cannot serve it, so it throws (see staleLpDep).
-      moduleInputs = lib.filterAttrs (n: _: builtins.elem n legacyHeaderDepNames) flakeInputs;
-      resolvedModuleDeps = lib.mapAttrs (depName: input:
-        let
-          ps = input.packages.${system} or null;
-          # Pre-version of this refactor: input was the raw flake-output
-          # derivation (not a packages set). Preserve that path so an
-          # external flake-input dep still works.
-          fallback = if input ? packages.${system}.default
-                     then input.packages.${system}.default else input;
-          # An lp (Qt-free) consumer must NOT silently fall back to a Qt-typed
-          # header set. The wrappers would declare QString/QVariantMap while the
-          # consumer's own codegen ran with `--api-style lp`, so the build dies
-          # deep inside a generated TU with a wall of unrelated-looking Qt type
-          # errors. Fail here instead, where we can say what is actually wrong.
-          # Lazy: this only fires if an lp consumer really reads `headers-lp`.
-          staleLpDep = reason: throw ''
-            logos-module-builder: dependency '${depName}' cannot be consumed by an lp (Qt-free) module.
-
-            '${depName}' is taking the transitional header-copy path (it publishes
-            no `lidl` output), and
-              ${reason}.
-            So the only headers it offers are Qt-typed. Copying those into a
-            Qt-free translation unit fails deep inside a generated source file
-            with a wall of unrelated-looking Qt type errors, so this build stops
-            here instead.
-
-            Fix: rebuild / re-pin '${depName}' against a current logos-module-builder.
-            Any module built by one publishes a `lidl` contract (preferred — it
-            skips the header copy entirely) as well as a `headers-lp` output.
-          '';
-        in
-        if ps != null then {
-          default     = ps.default;
-          lib         = ps.lib or ps.default;
-          headers-qt  = ps.headers-qt or ps.include or ps.default;
-          # lp (Qt-free) variant for core universal consumers. No Qt fallback —
-          # see staleLpDep above.
-          headers-lp  = ps.headers-lp or (staleLpDep "its packages.${system} exposes no `headers-lp`");
-        } else {
-          default     = fallback;
-          lib         = fallback;
-          headers-qt  = fallback;
-          headers-lp  = staleLpDep "the flake input is a bare derivation with no packages.${system} attrset";
-        }
-      ) moduleInputs;
+      # Shared with buildCppPlugin (view modules) — see common.nix.
+      resolvedModuleDeps = common.resolveLegacyHeaderDeps {
+        inherit system flakeInputs;
+        depNames = legacyHeaderDepNames;
+      };
 
       # Resolve interface dependencies (method/event contracts) to concrete
       # definition-file paths. A LOCAL interface lives in this repo's `src`;


### PR DESCRIPTION
Three fixes, all the same shape, all found while chasing why `chat_ui`'s Windows build died on `fatal error: chat_module_api.h: No such file or directory`.

## The silent fallback

Resolving a transitional header-copy dependency did `input.packages.${system} or null`, and on null fell back to `input` itself. For a flake input that is the dependency's **source tree** — so the plugin build gets a header root with no generated headers in it, and fails far away inside a generated TU. Or, worse, succeeds against whatever stale headers happen to be checked in.

`chat_module` 0.2.2 publishes only the four native systems, so every `x86_64-windows` consumer silently resolved its headers to the chat_module checkout. The symptom pointed at an include path; the cause was three layers up.

A flake that publishes `packages` but nothing for this system is now an error:

```
error: logos-module-builder: dependency 'chat_module' publishes no packages for x86_64-windows.

It exposes: aarch64-darwin, aarch64-linux, x86_64-darwin, x86_64-linux

'chat_module' is taking the transitional header-copy path (it publishes no
`lidl` output), so this build needs its compiled headers for x86_64-windows
and there are none.

Fix: give 'chat_module' a x86_64-windows target and re-pin it. ...
```

The fallback survives only for a genuinely bare-derivation input (no `packages` attr at all), which is the pre-refactor shape it exists for.

## The same hole in collectAllModuleDeps

One level out, `collectAllModuleDeps` fell through to `input` when a dependency published no usable package for the target — putting the dep's **source tree** where an LGX package belongs. `mkStandaloneApp` then ships a directory of `.cpp` files in place of a module, and it only shows up at runtime as a module that never loads.

The two `autoBundleLgx` throws immediately above already guard the adjacent case, with the comment *"a silent fallback would cause mkStandaloneApp to silently omit the dependency at runtime"*. This closes the remaining hole in the same function.

## One resolver, not two

The header-copy logic was copy-pasted into `mkLogosModule.nix` (core modules) and `buildCppPlugin.nix` (ui_qml view modules). It now lives once in `common.nix` and both call it.

This is not tidying. `chat_ui` is a view module, so the first version of this fix — applied only to `mkLogosModule.nix` — left the exact case that motivated it untouched, and the verification run caught it still resolving happily. Two copies of a resolver is how that happens.

## Single-sourced Windows build platform

`"x86_64-linux"` was repeated as a literal in two places in `common.nix`; it now comes from logos-nix's `windowsBuildSystems`, which is where the decision and its reasoning already live.

Pinning it rather than using the *evaluating* system is deliberate, and worth stating since it can read as a limitation: it keeps `packages.x86_64-windows.*` one well-defined derivation no matter who evaluates it, so a Darwin and a Linux checkout agree and share a cache. A Darwin dev realises it through a Linux remote builder — which is what nixpkgs' own mingw cross assumes too. Widening it is now a one-line change in logos-nix rather than an edit here.

## Verification

Before/after evaluation with both trees exported the same way (`git archive`), so the only variable is the change:

| subject | before | after |
|---|---|---|
| `chat_ui` `apps.x86_64-linux` (the `collectAllModuleDeps` path) | `s0mxf9yz…` | `s0mxf9yz…` — byte-identical |
| `chat_ui` `packages.x86_64-linux` | `4ip9ygq…` | `4ip9ygq…` — byte-identical |
| `capability_module` x86_64-linux / x86_64-windows | drv | **only** `LOGOS_MODULE_BUILDER_ROOT` differs |
| `chat_ui` `packages.x86_64-windows` | resolved to the source tree | throws the message above |

`chat_ui`'s `apps` output is the one that matters for the second fix — it is a real UI module with dependencies, and it exercises `collectAllModuleDeps` end to end.

For `capability_module` I diffed the derivations rather than just the hashes: `inputDrvs`, `inputSrcs` and every other `env` key are identical, and the sole delta is the builder's own source path, which necessarily moves whenever any file in this repo changes.

## Follow-up

`chat_module` gains its `x86_64-windows` target in logos-co/logos-chat-module#65 and its follow-on, which is what makes the first error above stop firing for `chat_ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)