### PR TITLE
feat(windows): give a cross Rust module winpthreads, headers and archive

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -675,8 +675,15 @@ function(logos_module)
                     # inside the archive. Qt happens to drag several of these in
                     # already, but naming them keeps the Rust link independent
                     # of Qt's link interface.
+                    # `pthread` is winpthreads, which mkLogosModule adds as a
+                    # build input for a cross Rust module (see the note there).
+                    # It is NOT part of the mingw sysroot -- nixpkgs builds mingw
+                    # against mcfgthread -- but a crate's vendored C can still
+                    # want it: aws-lc-sys compiles aws-lc's thread_pthread.c.
+                    # ld pulls archive members on demand, so naming it costs
+                    # nothing for a module that references no pthread symbol.
                     target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE
-                        ws2_32 bcrypt ntdll userenv synchronization advapi32)
+                        ws2_32 bcrypt ntdll userenv synchronization advapi32 pthread)
                 else()
                     target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE pthread dl)
                 endif()

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -149,6 +149,21 @@ let
             "CC_${u}" = "${cc}/bin/${cc.targetPrefix}cc";
             "CXX_${u}" = "${cc}/bin/${cc.targetPrefix}c++";
             "AR_${u}" = "${cc.bintools}/bin/${cc.targetPrefix}ar";
+            # The header half of the same pthreads story as RUSTFLAGS above.
+            # mingw-w64 DOES ship <sched.h>, <pthread.h> and <semaphore.h> --
+            # but in the winpthreads package, which is not on the default
+            # sysroot include path because nixpkgs builds mingw against
+            # mcfgthread. A crate's vendored C that reaches for them therefore
+            # fails with a bare "fatal error: sched.h: No such file or
+            # directory" that reads like the platform is unsupported when it is
+            # only unwired. aws-lc-sys hits exactly this, compiling
+            # jitterentropy for the Windows target.
+            #
+            # cc-rs appends CFLAGS_<triple>/CXXFLAGS_<triple> to the compiler
+            # invocations it drives, so this reaches build-script C without
+            # touching the Rust compile.
+            "CFLAGS_${u}" = "-I${pkgs.windows.pthreads}/include";
+            "CXXFLAGS_${u}" = "-I${pkgs.windows.pthreads}/include";
           };
 
       # ── Concrete dependency classification ─────────────────────────────────
@@ -622,7 +637,20 @@ let
           # pkgs.jq is target-typed too and jq runs in preConfigure
           # (modulePreConfigure.nix:203). buildPackages == pkgs natively.
           extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdkBuild logosQtGenerator pkgs.buildPackages.jq ];
-          extraBuildInputs = extraBuildInputs ++ runtimePkgs ++ [ logosQtSdk logosProtocolPkg ];
+          extraBuildInputs = extraBuildInputs ++ runtimePkgs ++ [ logosQtSdk logosProtocolPkg ]
+            # A Rust staticlib's vendored C may want winpthreads: with <sched.h>
+            # reachable, aws-lc-sys compiles aws-lc's thread_pthread.c and the
+            # plugin link then needs pthread_rwlock_*, pthread_once, sched_yield.
+            # aws-lc assumes the standard mingw environment, where winpthreads is
+            # simply present; nixpkgs builds mingw against mcfgthread, so it is a
+            # separate package on no default path. As a buildInput its lib/ lands
+            # on NIX_LDFLAGS, which is what lets the `pthread` named by
+            # LogosModule.cmake's WIN32 branch resolve.
+            #
+            # Cross Rust modules only, and free for the ones that do not need it:
+            # ld pulls archive members on demand, so a module referencing no
+            # pthread symbol links exactly as before.
+            ++ lib.optional (isRustModule && rustCrossTarget != null) pkgs.windows.pthreads;
           # Qt splits each module's TOOLS (repc, moc, qmltyperegistrar) into a
           # SEPARATE package that must run on the BUILD machine. Without these
           # flags find_package(Qt6 COMPONENTS RemoteObjects) fails on a


### PR DESCRIPTION
nixpkgs builds mingw-w64 against **mcfgthread**, so winpthreads is a separate package on no default path. Plenty of vendored C assumes the standard mingw environment, where it is simply present.

`aws-lc-sys` is the case that surfaced this, and it matters because a module cannot route around it: `aws-lc-rs` arrives through third-party crates —

- `rustls` ← `hyper-rustls` ← `reqwest 0.12` ← libchat's `components`
- `rustls` ← `reqwest 0.13` ← `alloy-provider` ← `alloy` ← `hashgraph-like-consensus` ← `de-mls`

— and Cargo features are additive, so a consumer cannot switch rustls to `ring` from its own manifest. (Modules that declare reqwest themselves, like `token_list_module`, already resolve `ring` and were never affected.)

## Two halves, and the first alone is a trap

**Headers.** Without them the build dies on `fatal error: sched.h: No such file or directory`, which reads like the platform is unsupported when it is only unwired — mingw-w64 ships `sched.h`, `pthread.h` and `semaphore.h`, just in the winpthreads package. cc-rs appends `CFLAGS_<triple>`/`CXXFLAGS_<triple>` to the compiler invocations it drives, so this reaches build-script C without touching the Rust compile.

**The archive.** Fixing only the headers moves the failure rather than removing it: with `<sched.h>` reachable, aws-lc compiles aws-lc's `thread_pthread.c`, and the plugin link then wants `pthread_rwlock_*`, `pthread_once`, `pthread_key_create`, `sched_yield`. So winpthreads also goes in as a `buildInput` — its `lib/` lands on `NIX_LDFLAGS` — and `LogosModule.cmake`'s WIN32 branch names `pthread`.

The linker half of this same story (`-L native=<pthreads>/lib` for windows-gnu `std`) landed in #197; this completes it.

## Cost for modules that don't need it: none

`ld` pulls archive members on demand, so naming `pthread` is free. Verified rather than assumed — `keystore_module`'s Windows plugin imports no `libwinpthread` and stages no pthread DLL:

```
=== keystore: does it now import winpthread? ===
0
=== staged pthread dll? ===
(none)
```

and both its targets still build (`x86_64-windows` rc=0, `x86_64-linux` rc=0).

Native builds are untouched: every branch is guarded by `rustCrossTarget != null`.

## Verification

`chat_module` — the module that could not cross at all before this — now produces a 40 MB PE32+ x86-64 plugin exporting `qt_plugin_instance` / `qt_plugin_query_metadata_v2`, with the crypto stack really linked in (`aws-lc-rs-1.17.0`, `rustls-0.23.41`, `de-mls-4.0.0`, `hashgraph-like-consensus-0.6.0`, `libchat`) and `libwinpthread-1.dll` staged into its DLL closure by the existing import-table walk.

## For review

The resulting image carries **both** `libmcfgthread-2.dll` (libstdc++) and `libwinpthread-1.dll` (aws-lc). Both are thin layers over Win32 primitives and coexist in ordinary mingw distributions, so this should be fine — but I want to flag it rather than bury it, and the DLL has not yet been exercised on real Windows. A green link is not a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)