### PR TITLE
Add a Nim cdylib authoring path (codegen.nim)

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -726,6 +726,17 @@ function(logos_module)
                 else()
                     target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE pthread dl m)
                 endif()
+                # External libraries the Nim staticlib's FFI references (metadata
+                # codegen.nim.link) — e.g. secp256k1 — linked AFTER the archive so
+                # its undefined symbols resolve. Their lib dirs come from
+                # nix.packages.runtime (plugin buildInputs → NIX_LDFLAGS).
+                if(DEFINED LOGOS_MODULE_NIM_LINK_LIBS AND NOT LOGOS_MODULE_NIM_LINK_LIBS STREQUAL "")
+                    foreach(_nl IN LISTS LOGOS_MODULE_NIM_LINK_LIBS)
+                        if(NOT _nl STREQUAL "")
+                            target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${_nl})
+                        endif()
+                    endforeach()
+                endif()
             else()
                 message(FATAL_ERROR
                     "Nim static library '${_nimlib}' (a codegen.nim module) was not "

--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -697,6 +697,45 @@ function(logos_module)
         endforeach()
     endif()
 
+    # Nim static archives. Set by mkLogosModule when a cdylib module is authored
+    # in Nim (metadata codegen.nim): the builder compiles the Nim sources to a
+    # staticlib and stages it in lib/. The archive provides the logos_module_*
+    # exports the generated glue calls; its lp_*/protocol undefineds resolve
+    # against logos-protocol (re-mentioned after the archive for single-pass
+    # linkers). Plain link — the Nim runtime is initialised by a load-time
+    # constructor in the archive, not whole-archive inclusion. Nim's stdlib
+    # leaves pthread/dl/m undefined in a staticlib.
+    if(DEFINED LOGOS_MODULE_NIM_STATIC_LIBS AND NOT LOGOS_MODULE_NIM_STATIC_LIBS STREQUAL "")
+        set(_LOGOS_NIM_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+        foreach(_nimlib IN LISTS LOGOS_MODULE_NIM_STATIC_LIBS)
+            if(_nimlib STREQUAL "")
+                continue()
+            endif()
+            find_library(_LOGOS_NIM_${_nimlib}
+                NAMES lib${_nimlib}.a ${_nimlib}
+                PATHS ${_LOGOS_NIM_LIB_DIR} NO_DEFAULT_PATH)
+            if(_LOGOS_NIM_${_nimlib})
+                target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${_LOGOS_NIM_${_nimlib}})
+                if(TARGET logos-protocol::logos_protocol)
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos-protocol::logos_protocol)
+                elseif(TARGET logos_protocol)
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE logos_protocol)
+                endif()
+                if(APPLE)
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE pthread)
+                else()
+                    target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE pthread dl m)
+                endif()
+            else()
+                message(FATAL_ERROR
+                    "Nim static library '${_nimlib}' (a codegen.nim module) was not "
+                    "found in ${_LOGOS_NIM_LIB_DIR}. The builder stages the compiled "
+                    "staticlib there before the plugin link; this usually means the "
+                    "Nim build or staging step did not run.")
+            endif()
+        endforeach()
+    endif()
+
     # Link additional libraries
     foreach(lib ${MODULE_LINK_LIBRARIES})
         target_link_libraries(${MODULE_NAME}_module_plugin PRIVATE ${lib})

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -529,6 +529,49 @@ let
         cp ${rustStaticLib}/lib/lib${rustStaticName}.a lib/
       '';
 
+      # ── Nim cdylib authoring (codegen.nim) ─────────────────────────────────
+      # The Nim analog of the Rust cdylib path above. A Nim module compiles its
+      # core to a staticlib exporting the module-impl C ABI (logos_module_*),
+      # staged into lib/ where LogosModule.cmake's LOGOS_MODULE_NIM_STATIC_LIBS
+      # block links it — exactly as codegen.rust stages a Rust crate. The Nim
+      # surface is hand-written today (the ADR-008 fallback); a Nim lidl-gen will
+      # generate it from the .lidl later. No SDK input needed for the P0 surface
+      # (stdlib only); nim.packages hooks can add nimble deps when they arrive.
+      isNimModule = (config.codegen or {}) ? nim;
+      nimCfg = (config.codegen or {}).nim or {};
+      nimCrateDir =
+        "${src}/${nimCfg.crate or (throw "codegen.nim must set 'crate' (the Nim sources dir) in ${config.name}")}";
+      nimMain = nimCfg.main or "${config.name}.nim";
+      nimStaticName = nimCfg.staticlib or (lib.replaceStrings ["-"] ["_"] config.name);
+      nimStaticLib =
+        if !isNimModule then null
+        else pkgs.stdenv.mkDerivation {
+          pname = "lib${nimStaticName}";
+          version = config.version;
+          src = nimCrateDir;
+          nativeBuildInputs = [ pkgs.nim ];
+          buildPhase = ''
+            runHook preBuild
+            export HOME=$TMPDIR
+            nim c --app:staticlib --noMain --mm:orc -d:useMalloc -d:release \
+              --nimcache:$TMPDIR/nimcache --out:lib${nimStaticName}.a "${nimMain}"
+            runHook postBuild
+          '';
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/lib
+            cp lib${nimStaticName}.a $out/lib/
+            runHook postInstall
+          '';
+        };
+
+      # Stage the compiled staticlib where LogosModule.cmake's
+      # LOGOS_MODULE_NIM_STATIC_LIBS block finds it (the plugin build's lib/).
+      nimStaging = lib.optionalString isNimModule ''
+        mkdir -p lib
+        cp ${nimStaticLib}/lib/lib${nimStaticName}.a lib/
+      '';
+
 
       # Backend arguments for a given external-lib variant ("default" or
       # "portable"). Shared by buildVariant (compiles the plugin) and the
@@ -548,7 +591,7 @@ let
           # block links it — the builder-driven replacement for the per-flake
           # buildRustPackage + cp the author used to write by hand.
           userPreConfigure =
-            rustStaging + (
+            rustStaging + nimStaging + (
               if builtins.isFunction preConfigure
               then preConfigure { inherit externalLibs; }
               else preConfigure);
@@ -620,7 +663,8 @@ let
             "-DLOGOS_QT_SDK_ROOT=${logosQtSdk}"
             "-DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg}"
           ] ++ goCmakeFlags ++ apiStyleCmakeFlags
-            ++ lib.optionals isRustModule [ "-DLOGOS_MODULE_RUST_STATIC_LIBS=${rustStaticName}" ];
+            ++ lib.optionals isRustModule [ "-DLOGOS_MODULE_RUST_STATIC_LIBS=${rustStaticName}" ]
+            ++ lib.optionals isNimModule [ "-DLOGOS_MODULE_NIM_STATIC_LIBS=${nimStaticName}" ];
           extraEnv = {
             LOGOS_CPP_SDK_ROOT = "${logosSdk}";
             LOGOS_QT_SDK_ROOT = "${logosQtSdk}";

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -548,13 +548,17 @@ let
         else pkgs.stdenv.mkDerivation {
           pname = "lib${nimStaticName}";
           version = config.version;
-          src = nimCrateDir;
+          # Stage the WHOLE module source (not just the crate dir) so the crate's
+          # sibling imports (e.g. `import ../src/...`) resolve — the Nim core of a
+          # module is typically more than one directory.
+          src = src;
           nativeBuildInputs = [ pkgs.nim ];
           buildPhase = ''
             runHook preBuild
             export HOME=$TMPDIR
             nim c --app:staticlib --noMain --mm:orc -d:useMalloc -d:release \
-              --nimcache:$TMPDIR/nimcache --out:lib${nimStaticName}.a "${nimMain}"
+              --nimcache:$TMPDIR/nimcache --out:lib${nimStaticName}.a \
+              "${nimCfg.crate}/${nimMain}"
             runHook postBuild
           '';
           installPhase = ''

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -668,7 +668,9 @@ let
             "-DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg}"
           ] ++ goCmakeFlags ++ apiStyleCmakeFlags
             ++ lib.optionals isRustModule [ "-DLOGOS_MODULE_RUST_STATIC_LIBS=${rustStaticName}" ]
-            ++ lib.optionals isNimModule [ "-DLOGOS_MODULE_NIM_STATIC_LIBS=${nimStaticName}" ];
+            ++ lib.optionals isNimModule ([ "-DLOGOS_MODULE_NIM_STATIC_LIBS=${nimStaticName}" ]
+               ++ lib.optional ((nimCfg.link or []) != [])
+                    "-DLOGOS_MODULE_NIM_LINK_LIBS=${lib.concatStringsSep ";" (nimCfg.link or [])}");
           extraEnv = {
             LOGOS_CPP_SDK_ROOT = "${logosSdk}";
             LOGOS_QT_SDK_ROOT = "${logosQtSdk}";


### PR DESCRIPTION
Mirror the `codegen.rust` cdylib path for Nim, so a module can be authored with a Nim core behind its `.lidl` contract.

When metadata declares `codegen.nim`, the builder:
- compiles the named Nim sources to a staticlib (`nim c --app:staticlib --noMain --mm:orc -d:useMalloc`) exporting the module-impl C ABI (`logos_module_*`),
- stages it into `lib/`,
- links it via a new `LOGOS_MODULE_NIM_STATIC_LIBS` cmake block that parallels the Rust one (adds `logos-protocol` + `pthread`/`dl`/`m` for Nim's staticlib undefineds).

No SDK input is required (Nim stdlib only); `nix.rust`-style hooks for nimble deps can follow.

**Changes**
- `lib/mkLogosModule.nix`: `isNimModule` / `codegen.nim` → `nimStaticLib`, `nimStaging` into `lib/`, and `-DLOGOS_MODULE_NIM_STATIC_LIBS` on the plugin build. Additive and gated — existing Rust/universal/Go paths are untouched.
- `cmake/LogosModule.cmake`: the parallel Nim link block.

**Verified end to end**: a Nim module (`health`/`echo`) builds to `.lgx` and loads + dispatches in `logoscore` via `lgpm`.

Motivation: the Muster module is a Nim core behind a published `muster.lidl`; this is the "Nim SDK gap" its plan names as a bounded contribution back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)