### PR TITLE
chore(deps): bump the SDK chain onto master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3298,11 +3298,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1787270089,
+        "narHash": "sha256-GYaGET2WTGChyl3bJVXE4ioapC3aLILK4tQI/C29FSY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "rev": "667990f28c1736ac902ac1d2cb46a0aeaf42467a",
         "type": "github"
       },
       "original": {
@@ -9236,11 +9236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10811,11 +10811,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -11266,11 +11266,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -43990,11 +43990,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787268499,
+        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
         "type": "github"
       },
       "original": {
@@ -44889,11 +44889,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787268499,
+        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
         "type": "github"
       },
       "original": {
@@ -45946,11 +45946,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787267788,
+        "narHash": "sha256-naE4VE+F0zLsCfa/9hL7+RRRW49Pg1HisH3kOymHaKU=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "0d2a3c06bfb6c5c9701da84f77afe4aab86403c6",
         "type": "github"
       },
       "original": {
@@ -48673,11 +48673,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "lastModified": 1787268585,
+        "narHash": "sha256-yDh1GpHNWAo7JlGvR83paJhFTCNLjDnLtxRxNl/1RzE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "rev": "4a1104cabb5647ef8524809c7021104e050cb529",
         "type": "github"
       },
       "original": {
@@ -50806,11 +50806,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787192832,
-        "narHash": "sha256-OOKWEtVLRZ0an2mMLGb/V1bCwVnW/vJkzNqln5KQvN0=",
+        "lastModified": 1787268611,
+        "narHash": "sha256-SHs8N2bOoS8tk7ViWppPAvpELtLeDLzlKsjjHQbVxIw=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "a3d0d719e396bb5a8805527eb88702bcb400d2e5",
+        "rev": "8d440403b618dbcc3ae2474adda3733dce583eee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Lock-only bump of the SDK chain onto current masters, so modules pick up work that has landed across the stack and been stuck behind this lock.

| input | from | to |
|---|---|---|
| `logos-cpp-sdk` | `95d7b3a9c5ef` | `667990f28c17` |
| `logos-plugin-core` | `9b2c64e5a480` | `55713b9c799a` |
| `logos-plugin-qt` | `9b2c64e5a480` | `55713b9c799a` |
| `logos-protocol` | `f4407ff4854b` | `0d2a3c06bfb6` |
| `logos-qt-sdk` | `19c844f28b33` | `4a1104cabb56` |
| `logos-rust-sdk` | `a3d0d719e396` | `8d440403b618` |
## What this actually carries into module builds

- **`<name>AsyncResult` on the Qt-free (lp) consumer surface** ([cpp-sdk#142](https://github.com/logos-co/logos-cpp-sdk/pull/142)) — a Qt-free module can finally tell a failed async call from a provider that legitimately returned nothing. It was withheld for years of commits because `lp_invoke_async` hard-coded `ok = 1`; logos-protocol#40 fixed that.
- **Provider rejections reach the caller's error channel.** A provider that ran and *refused* answers `{"code": "dispatch_failed", …}` as its **result**, not as a transport error, so every consumer decoded it into a default — `0`, `""`, an empty list. Now folded on the C++ sync and `AsyncResult` surfaces (cpp-sdk#142) and on all four Rust consumer paths ([rust-sdk#44](https://github.com/logos-co/logos-rust-sdk/pull/44)).
- **Two client-creation races fixed, from opposite directions.** `logos::LpClient` had no synchronization on lazy creation; rust-sdk's `shared_client()` held its cache mutex *across* `lp_client_create`. Both are wrong for the same reason — that call blocks on the Qt main thread, so a lock held across it deadlocks against a main thread waiting on the lock.
- **`LpBridge` drops its second `lp_client`** ([qt-sdk#36](https://github.com/logos-co/logos-qt-sdk/pull/36)) — one fewer transport connection per `(origin, target)`, plus the never-destroyed leak that came with it.

## Scope

**`flake.nix` is untouched** — no `follows` changes, no input URL changes ride along. This is one file.

Worth noting for anyone who tried this bump earlier and hit a wall: it used to require a generator migration, because `logos-qt-generator --backend cdylib` was removed when the provider glue moved to `logos-qt-host-generator`. That migration already landed here (both call sites switched, `LOGOS_QT_HOST_ROOT` wired into the test builder, and the CMake probe moved off the retired `logos_api.h` sentinel to `logos_qt_wire.h`), which is why this is now lock-only.

## Verification

All five checks green on `aarch64-darwin`: `default`, `qml-integration`, `rust-native-dep`, `static-extlib`, `test-framework-integration`.

`rust-native-dep` and `test-framework-integration` are the two that matter — I confirmed both fail against these masters *without* the migration above (`--backend cdylib was removed…` and `LOGOS_QT_HOST_ROOT is not set…` respectively), so they genuinely exercise the bump rather than passing regardless of it. `default` and `static-extlib` build the same derivation either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
