### PR TITLE
chore(deps): relock logos-rust-sdk onto the teardown exports (#45)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4468,11 +4468,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268611,
-        "narHash": "sha256-SHs8N2bOoS8tk7ViWppPAvpELtLeDLzlKsjjHQbVxIw=",
+        "lastModified": 1787312984,
+        "narHash": "sha256-5tUekequUlrzhG7C005bm20zALXpLPw2K2SYl2eZL1I=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "8d440403b618dbcc3ae2474adda3733dce583eee",
+        "rev": "49dbb0768a9a18cfaf264cc3ecfa55cca2630157",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
logos-rust-sdk 8d44040 -> 49dbb07
```

Fixes master, red since #204.

## What broke

Adding an export to the module-impl C ABI is a three-repo change: logos-protocol
**declares** it, the logos-plugin-qt cdylib glue **calls** it, and each language SDK
**defines** it. #204 moved the first two — protocol `f4407ff -> 0d2a3c0` (ABI 0.5, the
teardown pair) and plugin-qt/core `9b2c64e -> 55713b9` — and left `logos-rust-sdk` at
`8d44040`, the one repo that owed the definition, because that fix
(logos-co/logos-rust-sdk#45) was still an open PR.

So every Rust module built through this builder came out with
`logos_module_about_to_unload` and `logos_module_set_unload_done_callback` undefined.
That links clean — an undefined symbol in an ELF shared object is legal, and the Rust
side arrives as a static archive, so nothing complains at build time. Then nixpkgs
hardens with `-Wl,-z,now`, `dlopen` has to bind eagerly, and the module fails to load.

macOS links plugins `-undefined dynamic_lookup` and never binds, so it stayed green
throughout and proved nothing.

The `#if LOGOS_PROTOCOL_VERSION_MINOR >= 5` guard in the glue does not catch this: it
tracks the version of the headers the *glue* compiled against, not whether *this*
cdylib exports the symbol. Host-new + cdylib-old is exactly the case it lets through.

## How it presented

[Run 32441757256](https://github.com/logos-co/logos-module-builder/actions/runs/32441757256):
ubuntu 117 passed / **14 failed**, macOS fully green. The tell is quiet — the load still
reports success:

```
FAIL  ./logos/bin/logoscore load-module cpp_frontdesk_module
      expected 'rust_orchestrator_module' not found in output
      actual: {"dependencies_loaded":["cpp_counter_module"],...,"status":"ok"}
```

The Rust dependency is simply **absent** from `dependencies_loaded`, and every call after
it fails `METHOD_FAILED` / `RPC_FAILED`. All 14 failures cascade from two such loads; every
C++-only doctest passed. A name missing from `dependencies_loaded` on Linux only is a
cdylib that failed `dlopen`.

## Verification

Not inferred from the green check — `nm -g` on the built `rust_native_dep` plugin, same
subject built both ways:

| logos-rust-sdk | `logos_module_about_to_unload` | `logos_module_set_unload_done_callback` |
|---|---|---|
| `8d44040` (pre-fix, null control) | `U` — undefined | `U` — undefined |
| `49dbb07` (this PR) | `T` — defined | `T` — defined |

The symbols are *referenced* in both builds, which independently confirms the glue does
emit the calls. The generated scaffold now carries both `#[no_mangle] pub extern "C"`
definitions, and `checks.rust-native-dep` is green.

## Note for next time

**logos-rust-sdk must be relocked before, or with, any lock that carries protocol >= 0.5** —
never after. A lock bump is not a routine chore commit when the ABI moves; bumping
protocol + plugin-qt without rust-sdk is what breaks every Rust module, and CI on macOS
will not tell you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)