### PR TITLE
fix: a protocol version that will not parse must not silently vanish

### DIFF
--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -472,6 +472,40 @@ let
         if rustDeriveMode then "${derivedLidl}/${config.name}.lidl"
         else "${src}/${config.codegen.lidl}";
 
+      # A Rust module's EXPORT SET is decided by this string: lidl-gen gates
+      # logos_module_grant_host_services on >= 0.3 and the teardown pair on
+      # >= 0.5. So it cannot be optional here the way it is for metadata
+      # stamping below, where null legitimately means "pre-protocol, load as
+      # legacy".
+      #
+      # It used to be passed as
+      #     ${lib.optionalString (protocolVersion != null) "--protocol-version ..."}
+      # which does not make a bad version WRONG — it makes the flag VANISH.
+      # lidl-gen then falls back to "0.1.0", emits the seven founding exports,
+      # and exits 0. Every Rust module in the workspace would quietly regenerate
+      # incomplete, link cleanly, and fail at dlopen() on Linux with an
+      # undefined symbol — invisible on macOS, and three repos away from here.
+      #
+      # checks.module-impl-abi-nm DETECTS that by reading the built plugin's
+      # symbol table. This is the other half: refuse at the point of the
+      # mistake, so it never reaches a build. The two causes need different
+      # messages because they are different bugs.
+      rustProtocolVersion =
+        if protocolVersion != null then protocolVersion
+        else if logos-protocol == null then
+          throw ("logos-module-builder: module '" + config.name + "' is a Rust "
+            + "cdylib (codegen.rust), but this builder has no logos-protocol "
+            + "input, so the module-impl C ABI version it must generate against "
+            + "is unknown. Generating anyway would emit the pre-0.3 export set "
+            + "and produce a module that fails to dlopen.")
+        else
+          throw ("logos-module-builder: could not read "
+            + "LOGOS_PROTOCOL_VERSION_STRING from ${logos-protocol}/cpp/"
+            + "logos_protocol.h, needed to generate the Rust cdylib scaffold "
+            + "for '" + config.name + "'. The header moved or changed shape — "
+            + "fix the parse above; do NOT let it fall back, because the "
+            + "fallback silently emits an incomplete module-impl C ABI.");
+
       rustScaffold =
         if !isRustModule then null
         else pkgs.runCommand "logos-${config.name}-rust-scaffold" {
@@ -480,7 +514,7 @@ let
           mkdir -p $out
           logos-lidl-gen "${rustLidlPath}" --provider ${lib.optionalString rustDeriveMode "--no-trait"} \
             ${lib.optionalString ((config.concurrency or "single") == "multi") "--concurrency multi"} ${rustDepFlags} \
-            ${lib.optionalString (protocolVersion != null) "--protocol-version ${protocolVersion}"} \
+            --protocol-version ${rustProtocolVersion} \
             -o "$out/provider_gen.rs"
         '';
 
@@ -909,19 +943,6 @@ let
         logos-view-module.packages.${common.buildSystemFor system}.logos-view-templates;
       logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
-
-      # The logos-protocol semver — parsed from the protocol header the
-      # whole stack links. Stamped into every module's embedded metadata
-      # (see modulePreConfigure.stampProtocolVersion). null (no stamp) only
-      # if the input is somehow absent — modules then load as "legacy".
-      protocolVersion =
-        if logos-protocol == null then null
-        else
-          let
-            header = builtins.readFile "${logos-protocol}/cpp/logos_protocol.h";
-            parts = builtins.split "LOGOS_PROTOCOL_VERSION_STRING \"([^\"]*)\"" header;
-          in if builtins.length parts < 2 then null
-             else builtins.head (builtins.elemAt parts 1);
 
       backendShell = selectedBackend.devShellInputs pkgs { inherit logosModule; };
       buildPkgs = map (getPkg pkgs) config.nix_packages.build;


### PR DESCRIPTION
The prevention half of [#207](https://github.com/logos-co/logos-module-builder/pull/207), which added detection.

## The bug

A Rust module's **export set** is decided by the `--protocol-version` string: `lidl-gen` gates `logos_module_grant_host_services` on ≥ 0.3 and the teardown pair on ≥ 0.5. It was passed as

```nix
${lib.optionalString (protocolVersion != null) "--protocol-version ${protocolVersion}"}
```

and that does not make a bad version *wrong* — **it makes the flag vanish**. `lidl-gen` then falls back to `"0.1.0"`, emits the seven founding exports, and exits 0.

Every Rust module in the workspace would quietly regenerate incomplete, link cleanly, and fail at `dlopen` on Linux with an undefined symbol — invisible on macOS, three repos away from the cause, and reported by the runtime as a module that *loaded*.

`protocolVersion` goes null in two different situations, and they are two different bugs, so they now throw with two different messages: no `logos-protocol` input at all (a caller error), versus a header that did not parse (a bug in the regex directly above it). Neither is a thing to fall back from.

Metadata stamping is untouched — null there legitimately means "pre-protocol, load as legacy".

## Proven

Renaming the macro in the split pattern used to produce a silently-broken plugin that only `checks.module-impl-abi-nm` caught. It now produces:

```
error: logos-module-builder: could not read LOGOS_PROTOCOL_VERSION_STRING from
/nix/store/...-source/cpp/logos_protocol.h, needed to generate the Rust cdylib
scaffold for 'rust_native_dep_module'. The header moved or changed shape — fix
the parse above; do NOT let it fall back, because the fallback silently emits
an incomplete module-impl C ABI.
```

## Also: a dead duplicate of the same parse

It sat in the `devShells` block with no consumer anywhere in it. An exhaustive grep finds exactly four mentions of `protocolVersion`: this definition, its two uses in `packages`, and that orphan — which is how I confirmed it was dead rather than shadowed. A duplicated, half-dead parse of the value this entire failure mode hinges on is not something to leave lying around.

All eight checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)