### PR TITLE
feat(metadata): platform-keyed overlays in metadata.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -460,6 +460,183 @@ Additional libraries to link.
 }
 ```
 
+## Platform-Specific Fields (`"platforms"`)
+
+Some fields differ per target. A module may declare an **ordered list** of
+selector-keyed overlays, at the top level and inside the `"nix"` block:
+
+```json
+{
+  "name": "my_module",
+  "include": [],
+
+  "platforms": [
+    { "when": { "os": "linux" },   "include": ["libcore.so"] },
+    { "when": { "os": "darwin" },  "include": ["libcore.dylib"] },
+    { "when": { "os": "windows" }, "include": ["libcore.dll"] }
+  ],
+
+  "nix": {
+    "packages": { "runtime": ["nlohmann_json"] },
+    "platforms": [
+      { "when": { "os": "linux" },
+        "packages": { "runtime": ["krb5"] } }
+    ]
+  }
+}
+```
+
+Note the **empty base** for `include`, and the Linux `.so` sitting in an overlay
+alongside the other two. That is not stylistic. **Lists concatenate**, so
+writing the `.so` in the base —
+
+```json
+"include": ["libcore.so"],
+"platforms": [ { "when": { "os": "darwin" }, "include": ["libcore.dylib"] } ]
+```
+
+— resolves on darwin to `["libcore.so", "libcore.dylib"]`: a cross-platform
+superset, which is the exact thing this feature exists to eliminate. `libcore.so`
+is not a default that darwin happens to add to, it is the **Linux value**, so it
+belongs in the Linux overlay. A value belongs in the base only when it is
+genuinely correct on every target.
+
+The base still carries everything that does not vary — `nix.packages.runtime`
+above keeps `nlohmann_json` on all targets and gains `krb5` on Linux only.
+
+### The selector (`when`)
+
+| Key | Reachable values |
+|---|---|
+| `os` | `linux`, `darwin`, `windows` |
+| `architecture` | `x86_64`, `aarch64` |
+| `abi` | `gnu`, `unknown` |
+
+Each key is **independently optional**: `os` alone selects every architecture on
+that OS, `architecture` alone selects that architecture everywhere, and all
+three together name one variant. An **empty `when` is an error** — an overlay
+that matched everything would just be the base config.
+
+Common aliases are accepted and canonicalised: `arm64` → `aarch64`, `macos` →
+`darwin`, `win32` → `windows`. **An unrecognised or unreachable value is an
+error, not a non-match** — a selector that could never fire is always a bug, and
+finding it at eval time is the entire point of the feature.
+
+Two things about `abi` are worth knowing before you use it:
+
+* The Windows target is **mingw** (`x86_64-w64-mingw32`), so its `abi` is `gnu`,
+  not `msvc`.
+* Because of that, `abi` is **not** an OS discriminator: `{"abi": "gnu"}` alone
+  matches x86_64-linux, aarch64-linux **and** the Windows cross. Say
+  `{"os": "windows"}` if that is what you mean.
+
+### How overlays merge
+
+**Every** matching overlay applies, in **declaration order**:
+
+| Shape | Rule |
+|---|---|
+| list | base ++ overlay₁ ++ overlay₂ … (**no dedup**) |
+| scalar (string/number/bool) | last matching overlay wins |
+| object | merged key by key; base-only keys survive |
+| `null` in an overlay | **error** — there is no removal operator; restructure the base |
+| type mismatch with the base | **error** |
+
+Objects **recurse** rather than overwrite, and that is worth being explicit
+about because "scalars and objects overwrite" is the simpler rule and it is the
+wrong one. Every overlay-able key under `nix` *is* an object — `packages` is
+`{build, runtime}`, `cmake` is four lists, `rust` is `{packages, env,
+toolchain}` — so whole-object overwrite would make
+
+```json
+"packages": { "build": ["pkg-config"], "runtime": ["nlohmann_json"] },
+"platforms": [ { "when": {"os":"linux"}, "packages": { "runtime": ["krb5"] } } ]
+```
+
+silently **drop** `packages.build` and the base `runtime` entry on Linux. It
+would also make "lists concatenate" unreachable for the whole `nix` block: no
+list is ever a direct child of `packages`/`cmake`/`rust`, so the merge would
+never descend far enough to meet one. Recursion is what lets the two rules
+compose — descend through the objects, apply the list/scalar rule at the leaf
+where the author actually wrote a value.
+
+Ordering is **declaration** order, never specificity. Write the general entry
+first and the specific one last — reversing these two genuinely reverses the
+answer, and nothing will warn you:
+
+```json
+"nix": {
+  "platforms": [
+    { "when": { "os": "windows" }, "rust": { "toolchain": "1.95.0" } },
+    { "when": { "os": "windows", "architecture": "x86_64", "abi": "gnu" },
+      "rust": { "toolchain": "1.96.0" } }
+  ]
+}
+```
+
+### What may vary by platform
+
+| Level | Fields |
+|---|---|
+| top level | `include` |
+| inside `nix` | `packages`, `external_libraries`, `cmake`, `rust` |
+
+Anything else is refused, and the refusals are deliberate:
+
+* `name`, `version`, `type`, `interface` are module **identity** and select the
+  build backend — they are read before a target is even chosen.
+* `codegen`, `interface_dependencies`, `dependency_overrides` decide the
+  generated **contract**. A Linux consumer calling a Windows provider built from
+  a different contract is an interface-hash mismatch at runtime.
+* `host_services` is a **security** declaration checked against a hardcoded
+  allowlist. A privilege set that varies by platform means auditing one build
+  tells you nothing about the other.
+* `concurrency` — the author owns thread safety for `"multi"`; correctness must
+  not depend on which host produced the binary.
+* `icon`, `view`, `category`, `description` are pure manifest fields resolved on
+  the installing machine.
+
+`main` and `dependencies` are refused for a **different** reason, and the
+distinction matters if you were about to work around it: they are not refused on
+principle — a per-target `main` is a coherent thing to want — but because
+resolving them today would change the **build** and not the **shipped module**.
+
+The metadata.json that ships is the **source file, copied verbatim**:
+`mkLogosQmlModule` does `cp <configFile> $out/lib/metadata.json`, and the core
+path embeds the same source file via `configure_file` + `Q_PLUGIN_METADATA`.
+Nothing between the parse and the artifact ever writes the resolved tree back
+out. So a platform-keyed `main` would build one plugin and ship a manifest naming
+another; and a platform-keyed `dependencies` would be resolved for the flake
+inputs while the `LogosModules` umbrella — generated at build time by
+`logos-plugin-qt/lib/buildPlugin.nix` straight out of the raw `dependencies`
+array in that file — carried the base list, so an overlay-added dependency would
+be built and linked and then have no member on `modules()`.
+
+Both become admissible once the build tree carries the resolved tree: the jq
+stamp in `lib/modulePreConfigure.nix` (the one that already splices
+`logos_protocol_version` in) also splicing the resolved values and doing
+`del(.platforms)`, and `mkLogosQmlModule` copying that stamped file rather than
+the source. Until then, put the value in the base — a plugin's file **extension**
+is already handled centrally by `common.getPluginFilename`, which is the case a
+per-target `main` would otherwise serve.
+
+`nix.external_libraries` is a list of **objects folded by `name`**. Overlays
+concatenate, so declaring the same `name` in both the base and a matching
+overlay is refused — move the whole entry into the overlays that want it.
+
+### Caveats
+
+* A `platforms` key is read from **exactly two places**: the top level and
+  `nix`. Writing one anywhere else — `nix.packages.platforms`,
+  `nix.rust.platforms`, inside an `external_libraries` entry — is a **hard
+  error** naming the path, rather than an overlay that is quietly skipped.
+* `include` is safe to platform-key because it is purely a build-time staging
+  list, read once by `mkLogosModule` and by nothing at runtime. The shipped
+  manifest still contains the unresolved `include` and the `platforms` list
+  itself; no runtime reader looks at either.
+* `nix.cmake.*` is parsed and resolved but **not yet consumed by any build
+  code**. A `cmake.extra_link_libraries` overlay configures nothing today.
+
 ## Complete Example
 
 A chat module that depends on waku, uses protobuf, and exposes its API to other modules:

--- a/docs/nix-api.md
+++ b/docs/nix-api.md
@@ -358,16 +358,48 @@ Parse a `metadata.json` file.
 
 ### parseModuleConfig
 
-Parse JSON content and apply defaults.
+Parse JSON content and apply defaults, resolving any `platforms` overlays for
+the given target.
 
 ```nix
 let
-  config = logos-module-builder.lib.parseMetadata.parseModuleConfig
-    (builtins.readFile ./metadata.json);
+  parseMetadata = logos-module-builder.lib.parseMetadata;
+  config = parseMetadata.parseModuleConfig {
+    json     = builtins.readFile ./metadata.json;
+    platform = parseMetadata.platformForSystem system;   # inside forAllSystems
+  };
 in {
   inherit (config) name version type category description;
   inherit (config) dependencies nix_packages external_libraries cmake;
 }
+```
+
+`platform` is **required**. It may be `null`, which means "no target known" —
+the parse then succeeds, but any field a `platforms` overlay declares throws
+when read instead of quietly returning the base value. That is the shape the
+builders use above `forAllSystems`, where only platform-invariant fields
+(`name`, `version`, `type`, `interface`) are needed.
+
+### platformForSystem
+
+Turn a nix system string into the `{ os, architecture, abi }` triple that
+`when` selectors are matched against.
+
+```nix
+logos-module-builder.lib.parseMetadata.platformForSystem "x86_64-windows"
+# { os = "windows"; architecture = "x86_64"; abi = "gnu"; }
+```
+
+Note the `abi`: the Windows target is mingw (`x86_64-w64-mingw32`). Do not
+derive the triple with `lib.systems.elaborate` — it reads the pseudo-system
+string alone and answers `msvc`.
+
+### platformOf
+
+The same triple, from a package set that is already in scope.
+
+```nix
+logos-module-builder.lib.parseMetadata.platformOf pkgs.stdenv.hostPlatform
 ```
 
 ---
@@ -383,6 +415,7 @@ List of supported systems.
 ```nix
 logos-module-builder.lib.common.systems
 # [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ]
+# plus "x86_64-windows" when the logos-nix input is threaded into the builder
 ```
 
 ### getLibExtension

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -91,6 +91,48 @@ nix build
 }
 ```
 
+### Platform-specific values
+
+`include` and everything under `nix` may be overridden per target by an ordered
+list of overlays. Every matching entry applies, in declaration order; **lists
+concatenate**, **scalars overwrite**, and **objects recurse** (merged key by
+key, base-only keys survive).
+
+```json
+"include": [],
+"platforms": [
+  { "when": { "os": "linux" },   "include": ["libcore.so"] },
+  { "when": { "os": "darwin" },  "include": ["libcore.dylib"] },
+  { "when": { "os": "windows" }, "include": ["libcore.dll"] }
+],
+
+"nix": {
+  "packages": { "runtime": ["nlohmann_json"] },
+  "platforms": [
+    { "when": { "os": "linux" }, "packages": { "runtime": ["krb5"] } }
+  ]
+}
+```
+
+The **empty base** for `include` is the pattern to copy, not a stylistic choice.
+Lists concatenate, so leaving `libcore.so` in the base would resolve darwin to
+`["libcore.so","libcore.dylib"]` — a cross-platform superset, which is exactly
+what the overlays exist to eliminate. The `.so` is the Linux value; it goes in
+the Linux overlay. `nix.packages.runtime` above shows the other case:
+`nlohmann_json` is genuinely correct everywhere, so it stays in the base.
+
+`main` and `dependencies` may **not** be platform-keyed. Not on principle — the
+shipped `metadata.json` is the source file copied verbatim, so a per-target
+value would be resolved for the build and not for the artifact. A `platforms`
+key anywhere but the top level or `nix` (e.g. `nix.packages.platforms`) is a
+hard error, not a silently skipped overlay.
+
+`os` ∈ `linux | darwin | windows`, `architecture` ∈ `x86_64 | aarch64`,
+`abi` ∈ `gnu | unknown` — each independently optional, an empty `when` is an
+error, and an unrecognised value is an error rather than a non-match. Note the
+Windows target is mingw, so its `abi` is `gnu` (and `{"abi":"gnu"}` on its own
+therefore also matches Linux). See `docs/configuration.md` for the full rules.
+
 ## CMakeLists.txt Quick Reference
 
 ```cmake

--- a/flake.nix
+++ b/flake.nix
@@ -233,7 +233,9 @@
         };
       };
 
-      # Tests — pure Nix evaluation tests (no compilation)
+      # Tests — mostly pure Nix evaluation, but NOT entirely: test-platform-triples
+      # instantiates five package sets (including the mingw cross) to assert the
+      # os/architecture/abi table against reality rather than against itself.
       checks = forAllSystems ({ pkgs, system, ... }: {
         default = import ./tests {
           inherit pkgs;

--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -17,9 +17,25 @@
 }:
 
 let
-  # Parse the module configuration
-  rawConfig = parseMetadata.parseModuleConfig (builtins.readFile configFile);
+  metadataJson = builtins.readFile configFile;
+
+  # `config` is parsed with NO platform: it answers only for the fields no
+  # `platforms` overlay may vary (name / version / type / interface), which are
+  # the fields read here above forAllSystems — `selectedBackend` below, and the
+  # system-agnostic `config` flake output. A platform-keyed field read off it
+  # THROWS rather than handing back the base value; `configFor system` is the
+  # resolved answer, and every per-system closure rebinds `config` to it.
+  # See lib/resolvePlatforms.nix for the reasoning behind that split.
+  rawConfig = parseMetadata.parseModuleConfig { json = metadataJson; platform = null; };
   config = common.recursiveMerge [ rawConfig configOverrides ];
+
+  configFor = system: common.recursiveMerge [
+    (parseMetadata.parseModuleConfig {
+      json = metadataJson;
+      platform = parseMetadata.platformForSystem system;
+    })
+    configOverrides
+  ];
 
   # Select backend based on module type: core modules are swappable, UI stays Qt
   selectedBackend =
@@ -62,6 +78,7 @@ let
   perSystem = forAllSystems (system:
     let
       pkgs = common.mkPkgs system;
+      config = configFor system;
 
       # ── Concrete dependency classification (mirrors mkLogosModule.nix) ──────
       # LIDL-based deps → bindings generated from the dep's published `lidl`
@@ -342,6 +359,7 @@ let
   devShells = forAllSystems (system:
     let
       pkgs = common.mkPkgs system;
+      config = configFor system;
       logosSdk = logos-cpp-sdk.packages.${system}.default;
       # Build-platform half of the SDK. logos-cpp-generator is invoked by BARE
       # NAME from a build phase (logos-plugin-qt/lib/buildPlugin.nix:145), so it
@@ -444,4 +462,6 @@ let
 
 in {
   inherit config perSystem devShells lgxPackages;
+  # The RESOLVED config per target — see the `configFor` comment above.
+  configFor = forAllSystems configFor;
 }

--- a/lib/common.nix
+++ b/lib/common.nix
@@ -63,7 +63,17 @@ let
       transitive = builtins.foldl' (acc: name:
         let
           input = depInputs.${name};
-          tdeps = (input.config or {}).dependencies or [];
+          # `configFor.<system>` is the dependency's PLATFORM-RESOLVED config;
+          # `config` is its system-agnostic one, which cannot answer for a
+          # platform-keyed `dependencies` and throws when asked. Prefer the
+          # resolved output when the dependency publishes one, and fall back to
+          # `config` for a dependency pinned to a builder that predates it —
+          # that fallback is exactly right, because a module built by an older
+          # builder cannot have had platform overlays applied either.
+          tdeps =
+            if input ? configFor && input.configFor ? ${system}
+            then input.configFor.${system}.dependencies or []
+            else (input.config or {}).dependencies or [];
           tinputs = input.inputs or {};
         in
           if tdeps == [] then acc

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -58,9 +58,37 @@
 }:
 
 let
-  # Parse the module configuration
-  rawConfig = parseMetadata.parseModuleConfig (builtins.readFile configFile);
+  metadataJson = builtins.readFile configFile;
+
+  # ── Two configs, and why ──────────────────────────────────────────────────
+  #
+  # `config` is parsed with NO platform. It is the answer for the handful of
+  # fields no `platforms` overlay may vary — name, version, type, interface —
+  # and those are exactly the fields read here, above forAllSystems, where no
+  # target exists yet: `selectedBackend` below, and the system-agnostic `config`
+  # flake output that collectAllModuleDeps reads from a FOREIGN flake.
+  #
+  # It is NOT a fallback. A field some overlay declares comes back as a throw
+  # (resolvePlatforms.poisonField), so reading one of those up here is a loud
+  # error rather than the base value — which is the whole point: a superset
+  # nobody meant to use on its own is how the .so/.dylib/.dll spelling lists
+  # drifted in the first place.
+  #
+  # `configFor system` is the resolved answer, and every per-system closure
+  # below rebinds `config` to it as its first `let` binding. That rebinding is
+  # deliberate rather than a rename: it keeps ~40 existing `config.*` reads
+  # correct by construction, and there is no reading inside a per-system
+  # closure that should see the unresolved tree.
+  rawConfig = parseMetadata.parseModuleConfig { json = metadataJson; platform = null; };
   config = common.recursiveMerge [ rawConfig configOverrides ];
+
+  configFor = system: common.recursiveMerge [
+    (parseMetadata.parseModuleConfig {
+      json = metadataJson;
+      platform = parseMetadata.platformForSystem system;
+    })
+    configOverrides
+  ];
 
   # Select backend based on module type: core modules are swappable, UI stays Qt
   selectedBackend =
@@ -95,6 +123,7 @@ let
   packages = forAllSystems (system:
     let
       pkgs = common.mkPkgs system;
+      config = configFor system;
 
       # Rust target triple when `system` is a cross pseudo-system; null natively.
       # Every cross branch below keys off this being non-null, so a native build
@@ -301,6 +330,15 @@ let
       # A name that matches nothing is NORMAL, not an error: the list is a
       # deliberate cross-platform superset (modules name the .so, .dylib and
       # .dll spellings side by side), so at most one spelling can ever match.
+      #
+      # `config.include` here is the PLATFORM-RESOLVED list (this closure
+      # rebinds `config` to `configFor system`), so a module can now name one
+      # spelling per target with a `platforms` overlay instead of a superset.
+      # The tolerance above stays for the modules that still write the superset
+      # — and because the superset is unvalidated, which is how
+      # logos-package-downloader-module ended up naming .so and .dylib but not
+      # .dll. An overlay whose selector is misspelled throws at parse time
+      # instead.
       #
       # Runs BEFORE the module's own postInstall, so author hooks can react to
       # what was staged, and before the Windows postFixup, so linkDLLsInfolder
@@ -867,6 +905,7 @@ let
   devShells = forAllSystems (system:
     let
       pkgs = common.mkPkgs system;
+      config = configFor system;
       logosSdk = logos-cpp-sdk.packages.${system}.default;
       # Build-platform half of the SDK. logos-cpp-generator is invoked by BARE
       # NAME from a build phase (logos-plugin-qt/lib/buildPlugin.nix:145), so it
@@ -1001,6 +1040,7 @@ let
       apps = forAllSystems (system:
         let
           pkgs = common.mkPkgs system;
+          config = configFor system;
           # Collect all module dependencies (direct + transitive) for bundling
           allDeps = common.collectAllModuleDeps system flakeInputs config.dependencies;
         in {
@@ -1066,5 +1106,10 @@ let
 in {
   packages = finalPackages;
   inherit devShells config;
-  metadataJson = builtins.readFile configFile;
+  # The RESOLVED config, per target. `config` above cannot answer for a
+  # platform-keyed field and says so when asked; a consumer that needs
+  # `dependencies` / `include` / `main` for a specific system reads this.
+  # collectAllModuleDeps already prefers it when a dependency publishes one.
+  configFor = forAllSystems configFor;
+  inherit metadataJson;
 } // optionalApps // optionalTests

--- a/lib/mkLogosModuleTests.nix
+++ b/lib/mkLogosModuleTests.nix
@@ -51,14 +51,25 @@ in
 let
   forAllSystems = f: lib.genAttrs common.systems (system: f system);
 
-  # Parse config if available (defaults must satisfy parseModuleConfig shape consumers)
-  config = if configFile != null
-    then parseMetadata.parseModuleConfig (builtins.readFile configFile)
-    else parseMetadata.parseModuleConfig ''{"name":"unknown","version":"0.0.0"}'';
+  # Parse config if available (defaults must satisfy parseModuleConfig shape consumers).
+  #
+  # Per-system, because everything this file reads off it — nix_packages.runtime,
+  # dependencies, go_static_lib_names — is platform-keyable, and all of it is
+  # read inside `checks` below where the target IS known. The literal fallback
+  # takes a platform too: it can never contain a `platforms` block, but leaving
+  # one call site on the old shape would leave a permanently-unmigrated example
+  # in the tree for the next person to copy.
+  configFor = system: parseMetadata.parseModuleConfig {
+    platform = parseMetadata.platformForSystem system;
+    json = if configFile != null
+      then builtins.readFile configFile
+      else ''{"name":"unknown","version":"0.0.0"}'';
+  };
 
   checks = forAllSystems (system:
     let
       pkgs = common.mkPkgs system;
+      config = configFor system;
       logosSdk = logos-cpp-sdk.packages.${system}.default;
       # Build-platform half of the SDK. logos-cpp-generator is invoked by BARE
       # NAME from a build phase (logos-plugin-qt/lib/buildPlugin.nix:145), so it

--- a/lib/mkLogosQmlModule.nix
+++ b/lib/mkLogosQmlModule.nix
@@ -36,9 +36,44 @@
 }:
 
 let
+  metadataJson = builtins.readFile configFile;
+
   # Parse metadata first so we can decide whether to build a C++ backend at all.
-  rawConfig = parseMetadata.parseModuleConfig (builtins.readFile configFile);
+  #
+  # NO platform here, and this file is the one that most needs saying why. Three
+  # of the reads below — `config.type`, `config.view`, `config.main` — happen
+  # above forAllSystems and decide the flake's output SHAPE, not just its
+  # contents: `hasBackend` gates whether `packages.<sys>` even has a `-lib`
+  # attribute. A per-system answer for `main` would make the ATTRIBUTE NAMES
+  # differ between systems, which is not something a flake can express.
+  #
+  # A module cannot platform-key `main` at all — resolvePlatforms refuses it in
+  # `topDeferred`, on every target and with no target, so the throw arrives at
+  # the overlay rather than here. That refusal replaced an earlier arrangement
+  # in which `main` WAS overlay-able and this read was supposed to be the thing
+  # that caught it, via resolvePlatforms.poisonField. It was not: mkLogosModule's
+  # only read of `config.main` is modulePreConfigure.nix:200's legacy-interface
+  # guard, which only ever throws — so a CORE module keying it sailed through
+  # with no diagnostic anywhere and shipped a manifest naming a plugin that does
+  # exist on the non-base targets. A guard that fires for one module type and
+  # silently does not for the other is not a guard.
+  #
+  # The reasoning for parsing with no platform here is unaffected: `type` and
+  # `view` still decide output shape, and the plugin's file EXTENSION is already
+  # handled centrally by common.getPluginFilename, so there is no case a
+  # per-platform `main` serves that is not better served there.
+  rawConfig = parseMetadata.parseModuleConfig { json = metadataJson; platform = null; };
   config = common.recursiveMerge [ rawConfig configOverrides ];
+
+  # The resolved config per target, rebound as `config` inside every per-system
+  # closure below.
+  configFor = system: common.recursiveMerge [
+    (parseMetadata.parseModuleConfig {
+      json = metadataJson;
+      platform = parseMetadata.platformForSystem system;
+    })
+    configOverrides
+  ];
 
   # Validate: view modules must be type "ui_qml" with a "view" field.
   # The "main" backend library is OPTIONAL — if absent, the module is QML-only and
@@ -147,6 +182,7 @@ let
   # Package outputs
   packages = forAllSystems (system:
     let
+      config = configFor system;
       moduleLib =
         if hasBackend then built.perSystem.${system}.moduleLib else null;
       moduleLibPortable =
@@ -232,6 +268,7 @@ let
   apps = forAllSystems (system:
     let
       pkgs = common.mkPkgs system;
+      config = configFor system;
       # Collect all module dependencies (direct + transitive) for bundling
       allDeps = common.collectAllModuleDeps system flakeInputs config.dependencies;
     in {
@@ -264,6 +301,7 @@ let
     let
       mkPluginTest = resolvedStandalone.lib.${system}.mkPluginTest;
       pkgs = pkgsFor system;
+      config = configFor system;
       allDeps = common.collectAllModuleDeps system flakeInputs config.dependencies;
     in {
       integration-test = mkPluginTest {
@@ -295,5 +333,7 @@ in {
     else lib.genAttrs common.systems (system:
       { default = (pkgsFor system).mkShell {}; });
   inherit apps config;
-  metadataJson = builtins.readFile configFile;
+  # The RESOLVED config per target — see the `configFor` comment above.
+  configFor = lib.genAttrs common.systems configFor;
+  inherit metadataJson;
 }

--- a/lib/parseMetadata.nix
+++ b/lib/parseMetadata.nix
@@ -2,12 +2,89 @@
 # Runtime fields (name, type, dependencies, icon, main…) live at the top level
 # and are read by Qt, logos-standalone-app, the nix bundler and the Nix build system.
 # Nix/build-only fields live under the "nix" key and are ignored at runtime.
+#
+# Fields may be platform-keyed via `platforms` overlays (top level, and inside
+# "nix"). Resolution happens FIRST, in lib/resolvePlatforms.nix, over the raw
+# JSON tree — so the ~300 lines below run once over the resolved answer, every
+# existing validation applies to that answer, and `config.*` keeps exactly the
+# flat shape every consumer already reads.
 { lib }:
 
+let
+  platforms = import ./resolvePlatforms.nix { inherit lib; };
+
+  # ── Why the signature is an attrset with a REQUIRED `platform` ─────────────
+  #
+  # `parseModuleConfig` used to take the JSON text alone, and the tempting
+  # migration was to keep that and add a second entry point that throws only
+  # when the JSON declares `platforms`. That guarantee is conditional on module
+  # CONTENT: a call site that forgot the platform works perfectly for every
+  # module written so far and detonates months later when someone else, in
+  # another repo, adds a `platforms` block. The defect is authored in one place
+  # and discovered in another.
+  #
+  # A required argument makes it a property of the SIGNATURE instead — a caller
+  # that supplies no platform gets an error at the call, before any module
+  # content is read, on day one. `platform = null` is still spellable and
+  # means "no target known"; see resolvePlatforms.poisonField for what that
+  # buys and what it costs.
+  #
+  # The old positional form is intercepted rather than left to Nix's "expected
+  # a set but found a string", because docs/nix-api.md publishes it and the
+  # two forms are distinguishable by type.
+  requireArgs = arg:
+    if builtins.isString arg then
+      throw ''
+        parseMetadata.parseModuleConfig now takes an attrset, not the JSON string alone:
+
+          parseModuleConfig {
+            json     = builtins.readFile ./metadata.json;
+            platform = parseMetadata.platformForSystem system;   # or null
+          }
+
+        The platform is required because metadata.json fields can now be platform-keyed
+        (`platforms` overlays). A caller that cannot name a target passes
+        `platform = null` explicitly and gets a config whose platform-keyed fields
+        THROW when read, rather than one that quietly answers with the base value.
+      ''
+    else if !(builtins.isAttrs arg) then
+      throw ("parseMetadata.parseModuleConfig expects { json, platform }, got "
+             + "${builtins.typeOf arg}.")
+    else if !(arg ? json) then
+      throw "parseMetadata.parseModuleConfig: missing required argument `json`."
+    else if !(arg ? platform) then
+      throw ("parseMetadata.parseModuleConfig: missing required argument `platform`. "
+             + "Pass parseMetadata.platformForSystem <system> (inside forAllSystems, where "
+             + "the target is known), parseMetadata.platformOf pkgs.stdenv.hostPlatform, or "
+             + "an explicit `null` to mean \"no target known\" — null is not a default "
+             + "because a forgotten platform would then read as a deliberate one.")
+    else
+      let extra = lib.subtractLists [ "json" "platform" ] (builtins.attrNames arg); in
+      if extra != [ ] then
+        throw ("parseMetadata.parseModuleConfig: unexpected argument(s) "
+               + builtins.concatStringsSep ", " extra + ". Expected { json, platform }.")
+      else arg;
+in
+
 {
-  parseModuleConfig = jsonContent:
+  # The platform-triple constructors and the reachable-target table, re-exported
+  # so a caller reaches them through the same attrset it already has.
+  inherit (platforms) platformForSystem platformOf validatePlatform platformTriples;
+
+  # What a `platforms` overlay may vary, and — for the two top-level fields that
+  # are refused only until the resolved tree reaches the shipped manifest — the
+  # reason and the precondition, as text. Re-exported because a throw message is
+  # not something a pure-Nix test can read, so this is the only way to assert
+  # that the refusal still EXPLAINS itself rather than merely refusing.
+  inherit (platforms) overlayAllowed overlayDeferredTop overlayDeferredPrecondition;
+
+  parseModuleConfig = arg:
     let
-      raw = builtins.fromJSON jsonContent;
+      args = requireArgs arg;
+      raw = platforms.resolvePlatforms {
+        platform = args.platform;
+        raw = builtins.fromJSON args.json;
+      };
       nix = raw.nix or {};
       safeList = val: if builtins.isList val then val else [];
 
@@ -313,6 +390,15 @@
       go_static_lib_names = map (x: x.name) (lib.filter (x: x ? go_build && x.go_build == true)
         (safeList (nix.external_libraries or [])));
 
+      # The RESOLVED raw tree, with both `platforms` keys removed. Not the
+      # pre-resolution JSON: a consumer reading `_raw.include` off that would
+      # get the unresolved superset, which is the same silent wrong answer one
+      # layer down from the one this feature exists to remove.
       _raw = raw;
+
+      # The triple this config was resolved for (null when parsed without a
+      # target). Exposed so a builder can assert which answer it is holding
+      # rather than inferring it from where the value came from.
+      _platform = platforms.validatePlatform args.platform;
     };
 }

--- a/lib/resolvePlatforms.nix
+++ b/lib/resolvePlatforms.nix
@@ -1,0 +1,719 @@
+# Platform-keyed metadata.json — the selector, the merge, and the several ways
+# this could have gone silently wrong.
+#
+# A module may declare an ORDERED list of selector-keyed overlays. The selector
+# is a structured triple; each of its three components is independently
+# optional:
+#
+#   "nix": {
+#     "packages": { "runtime": ["nlohmann_json"] },
+#     "platforms": [
+#       { "when": { "os": "linux" },
+#         "packages": { "runtime": ["krb5"] } },
+#       { "when": { "architecture": "arm64" },
+#         "cmake": { "extra_link_libraries": ["atomic"] } },
+#       { "when": { "os": "windows", "architecture": "x86_64", "abi": "gnu" },
+#         "cmake": { "extra_link_libraries": ["ws2_32","bcrypt","ntdll"] } }
+#     ]
+#   }
+#
+# EVERY matching entry applies, in DECLARATION ORDER. Lists concatenate (base
+# first, then each matching overlay in turn), scalars overwrite, and OBJECTS
+# RECURSE — merged key by key, with the keys only the base has surviving.
+# There is no removal operator in v1 — restructure the base instead.
+#
+# WHY OBJECTS RECURSE INSTEAD OF OVERWRITING. The first sketch of this feature
+# said "scalars and attrsets overwrite", and that is wrong in a way that is
+# worth writing down rather than quietly fixing. Every overlay-able key under
+# `nix` is an OBJECT: `packages` is `{build, runtime}`, `cmake` is four lists,
+# `rust` is `{packages, env, toolchain}`. Under whole-object overwrite, the
+# headline case of the whole feature —
+#
+#   "packages": { "build": ["pkg-config"], "runtime": ["nlohmann_json"] },
+#   "platforms": [ { "when": {"os":"linux"}, "packages": {"runtime":["krb5"]} } ]
+#
+# — would silently DROP `packages.build` and `packages.runtime`'s base entry on
+# Linux, because the overlay's `packages` object would replace the base's
+# wholesale. Worse, "lists concatenate" would become unreachable for anything
+# under `nix`: no list is ever a direct child of `packages`/`cmake`/`rust`, so
+# the merge would never descend far enough to find one, and the single rule
+# authors are most likely to rely on would be dead text. Recursion is what
+# makes the two rules compose — descend through the objects, and apply the
+# list/scalar rule at the leaf where the author actually wrote a value.
+#
+# WHY AN ORDERED LIST AND NOT A MAP KEYED BY SELECTOR. A map has no order, so
+# it cannot express "general first, specific last": `{"os":"windows"}` and
+# `{"os":"windows","architecture":"x86_64"}` would both match an x86_64 mingw
+# build with nothing to say which one wins. The list makes that expressible —
+# but note it does NOT make it automatic. Ordering is DECLARATION order, never
+# specificity: put the general entry first yourself, because reversing the two
+# entries above genuinely reverses the answer, and no rule here will catch it.
+#
+# WHY THIS EXISTS AT ALL. Nothing in metadata.json was platform-keyed before,
+# so a module that needed a platform-specific anything declared a
+# cross-platform SUPERSET by hand and let the build ignore the parts that did
+# not apply. `include` names the .so, .dylib AND .dll spellings side by side
+# (mkLogosModule.nix documents a name matching nothing as NORMAL), and
+# `nix.packages.runtime` cannot express a superset at all: krb5 is an
+# EVALUATION-time hard failure for a mingw host (its closure pulls in bash,
+# whose meta.badPlatforms excludes a windows/pe host), so eight UI modules
+# carry a hand-applied "drop unused krb5" commit and seven of them still have
+# it. A superset nobody validates drifts — logos-package-downloader-module
+# already forgot its .dll — which is why every rule below prefers a loud throw
+# to a silently-skipped overlay.
+{ lib }:
+
+let
+  # ── The reachable targets, as a TABLE rather than a derivation ────────────
+  #
+  # The triple is `pkgs.stdenv.hostPlatform.parsed.{kernel,cpu,abi}.name`, and
+  # these five rows are that expression's measured output for the five entries
+  # of common.systems. tests/test-platform-triples.nix asserts every row
+  # against the real package set, because the whole point of the table is that
+  # the cheap way to get these values is WRONG:
+  #
+  #   lib.systems.elaborate "x86_64-windows"           -> abi = "msvc"
+  #   (common.mkPkgs "x86_64-windows").stdenv
+  #     .hostPlatform.parsed.abi.name                  -> abi = "gnu"
+  #
+  # The mingw-ness of the Windows target lives in logos-nix's mkWindowsPkgs
+  # crossSystem (x86_64-w64-mingw32), not in the pseudo-system string, so
+  # elaborating the string alone yields msvc and the headline selector
+  # {"os":"windows","architecture":"x86_64","abi":"gnu"} would never match on
+  # the one platform this workspace cross-builds for. A table that a test pins
+  # to reality is the cheapest way to make that failure impossible; deriving it
+  # from a package set here would instead force nixpkgs to be instantiated
+  # before a single line of metadata could be parsed.
+  #
+  # Deliberately NOT filtered by common.systems: whether logos-nix is threaded
+  # into this builder decides what can be BUILT, and must not silently change
+  # whether {"os":"windows"} is an accepted selector or a typo.
+  platformTriples = {
+    "x86_64-linux"   = { os = "linux";   architecture = "x86_64";  abi = "gnu"; };
+    "aarch64-linux"  = { os = "linux";   architecture = "aarch64"; abi = "gnu"; };
+    "x86_64-darwin"  = { os = "darwin";  architecture = "x86_64";  abi = "unknown"; };
+    "aarch64-darwin" = { os = "darwin";  architecture = "aarch64"; abi = "unknown"; };
+    # PSEUDO-system: a cross derivation's `system` is its BUILD platform, so
+    # this row describes x86_64-w64-mingw32, not a native Windows builder.
+    "x86_64-windows" = { os = "windows"; architecture = "x86_64";  abi = "gnu"; };
+  };
+
+  triples = builtins.attrValues platformTriples;
+  reachableValues = field: lib.sort (a: b: a < b) (lib.unique (map (t: t.${field}) triples));
+  reachableList = field: builtins.concatStringsSep ", " (reachableValues field);
+
+  # ── Canonical vocabulary ──────────────────────────────────────────────────
+  #
+  # Both sides of every comparison are canonicalised through the SAME nixpkgs
+  # tables that produced the observed values above, so "the author's spelling
+  # and the build's spelling drifted apart" is not a state this code can reach.
+  # That matters because three vocabularies are already live in this tree —
+  # nix system strings (mkExternalLib's vendor_path/<system>/ subdirs), LGX
+  # variant names (linux-amd64, darwin-arm64, the Go spelling), and now this —
+  # and mkStandaloneApp.nix probes for three spellings of the same variant at
+  # once precisely because nobody could say which was authoritative.
+  #
+  # Going through the tables means the aliases nixpkgs already carries work:
+  # "arm64" resolves to "aarch64", "macos" and "win32" to "darwin" and
+  # "windows". An author who writes the wrong-but-obvious thing gets the right
+  # answer rather than an overlay that silently never fires.
+  canonTables = {
+    os           = lib.systems.parse.kernels;
+    architecture = lib.systems.parse.cpuTypes;
+    abi          = lib.systems.parse.abis;
+  };
+
+  # Consulted ONLY to improve an error message — never to accept a value. Every
+  # entry here is a spelling that is absent from the nixpkgs table above, so
+  # without the hint the author gets "not recognised" and a list of 47 cpu
+  # names to guess from.
+  aliasHints = {
+    os = {
+      win = "windows"; win64 = "windows"; mingw = "windows"; "mingw32" = "windows";
+      osx = "darwin"; mac = "darwin"; macosx = "darwin"; apple = "darwin";
+    };
+    architecture = {
+      amd64 = "x86_64"; x64 = "x86_64"; "x86-64" = "x86_64"; x86 = "x86_64";
+      arm64e = "aarch64";
+    };
+    abi = {
+      glibc = "gnu"; ucrt = "gnu"; msvcrt = "gnu"; mingw = "gnu"; none = "unknown";
+    };
+  };
+
+  # Two-stage validation, and BOTH stages are load-bearing.
+  #
+  # Stage 1 (spelling) rejects a value the nixpkgs table has never heard of.
+  # Stage 2 (reachability) rejects a value that canonicalises perfectly well but
+  # that no Logos target has — {"os":"freebsd"} or {"abi":"musl"}. Without
+  # stage 2 those are accepted and simply never fire, which is exactly the
+  # failure mode this whole feature exists to remove: an overlay that looks
+  # right, evaluates green everywhere, and quietly contributes nothing.
+  canon = field: value:
+    let
+      table = canonTables.${field};
+      hint = aliasHints.${field}.${value} or null;
+    in
+      if !(builtins.isString value) then
+        throw ("metadata.json: platform selector `${field}` must be a string, got "
+               + "${builtins.toJSON value}.")
+      else if !(table ? ${value}) then
+        throw ("metadata.json: platform selector `${field}: \"${value}\"` is not a "
+               + "recognised ${field}."
+               + (if hint != null then " Did you mean \"${hint}\"?" else "")
+               + " Reachable values: ${reachableList field}.")
+      else
+        let c = table.${value}.name; in
+        if !(builtins.elem c (reachableValues field)) then
+          throw ("metadata.json: platform selector `${field}: \"${value}\"` canonicalises "
+                 + "to \"${c}\", which no Logos target has, so this overlay could never "
+                 + "apply. Reachable values: ${reachableList field}.")
+        else c;
+
+  selectorKeys = [ "os" "architecture" "abi" ];
+
+  # ── The selector ──────────────────────────────────────────────────────────
+  #
+  # Canonicalises every PRESENT component and forces all of them before
+  # comparing anything. The obvious `&&` chain is wrong here and the bug is
+  # invisible: `{"os":"darwin","architecture":"amd64"}` validated CLEAN on
+  # Linux, because the os mismatch short-circuited before "amd64" was ever
+  # forced. That ships a typo which only throws on macOS — a green Linux CI run
+  # proving nothing at all, which is how most Windows defects in this workspace
+  # reached a release.
+  canonWhen = { path, index, when }:
+    let
+      keys = builtins.attrNames when;
+      unknown = lib.subtractLists selectorKeys keys;
+      out = lib.genAttrs (lib.intersectLists selectorKeys keys) (k: canon k when.${k});
+    in
+      if !(builtins.isAttrs when) then
+        throw ("metadata.json: ${path}[${toString index}].when must be an object like "
+               + "{ \"os\": \"linux\" }, got ${builtins.toJSON when}.")
+      else if keys == [ ] then
+        throw ("metadata.json: ${path}[${toString index}] has an empty `when`. An overlay "
+               + "that matches every platform IS the base config — move those values into "
+               + "the base instead. `when: {}` is refused because it is indistinguishable "
+               + "from a half-written entry, and it would let a module carry a non-empty "
+               + "`platforms` list that varies nothing.")
+      else if unknown != [ ] then
+        throw ("metadata.json: ${path}[${toString index}].when has unknown key(s) "
+               + builtins.concatStringsSep ", " (map (k: "`${k}`") unknown)
+               + ". A selector may only use: " + builtins.concatStringsSep ", " selectorKeys
+               + ". Each is independently optional; all three together name one variant.")
+      # deepSeq, not the implicit forcing of `==`: every component must throw
+      # its own spelling error even on a platform where an earlier component
+      # already decided the answer.
+      else builtins.deepSeq out out;
+
+  matches = when: platform:
+    (!(when ? os)           || when.os           == platform.os)
+    && (!(when ? architecture) || when.architecture == platform.architecture)
+    && (!(when ? abi)          || when.abi          == platform.abi);
+
+  # ── What may vary by platform ─────────────────────────────────────────────
+  #
+  # Everything under `nix` is build-only and safe. Top-level fields cross the
+  # build→run boundary, and that boundary is the whole reason this list is one
+  # key long: the shipped metadata.json is the RAW SOURCE FILE. mkLogosQmlModule
+  # copies ${configFile} into $out/lib/metadata.json verbatim, and the core path
+  # embeds the same source file via configure_file + Q_PLUGIN_METADATA. Nothing
+  # between the parse and the artifact ever writes the RESOLVED tree back out.
+  #
+  # So a top-level overlay is resolved for the BUILD and ships UNRESOLVED. That
+  # is harmless for `include`, which is purely a build-time staging list read
+  # once by mkLogosModule's stageIncludedRuntimeFiles and by nobody at runtime.
+  # It is not harmless for anything a reader downstream of the build takes off
+  # the installed manifest — see `topDeferred` below, which names the two such
+  # fields and what has to land before they can be re-admitted.
+  #
+  # The refusals are the interesting half of this list:
+  #   name / version / type / interface — module IDENTITY and the backend
+  #     selection. `type` in particular is read OUTSIDE forAllSystems by both
+  #     builders; a per-platform value has no single answer to give them.
+  #   codegen / interface_dependencies / dependency_overrides — these decide
+  #     the generated contract, hence the interface hash. A Linux consumer
+  #     calling a Windows provider whose contract was generated from different
+  #     inputs is a mismatch at introspect time, not a build error.
+  #   host_services — a SECURITY declaration validated against a hardcoded
+  #     allowlist. parseMetadata already argues that "a build-time allowlist a
+  #     module could extend from its own metadata would not be an allowlist";
+  #     a platform overlay is exactly such an extension vector, and it would
+  #     mean auditing the Linux build tells you nothing about the Windows one.
+  #   concurrency — the author owns thread-safety for "multi". Code whose
+  #     correctness depends on which host built it is not code anyone can review.
+  #   icon / view / category / description — pure manifest, resolved on the
+  #     install machine, with no motivating case.
+  topAllowed = [ "include" ];
+  nixAllowed = [ "packages" "external_libraries" "cmake" "rust" ];
+
+  # ── Refused FOR NOW, with the precondition written down ────────────────────
+  #
+  # These two are not refused on principle the way `type` or `host_services`
+  # are — a per-target `main` or `dependencies` is a coherent thing to want.
+  # They are refused because resolving them today changes the BUILD and not the
+  # ARTIFACT, and the resulting module is wrong in a way that raises nothing
+  # anywhere: no throw, no warning, a green evaluation on every platform, and a
+  # manifest that names a file that does not exist on the targets the overlay
+  # was written for.
+  #
+  # Kept as DATA rather than as a comment on the allowlist, so the refusal can
+  # print the precondition to the author who tripped over it, and so that
+  # re-admitting a key is a deliberate edit here rather than a word added to a
+  # list. tests/test-parse-metadata.nix pins both the refusal and this map.
+  topDeferred = {
+    main = ''
+      `main` names the plugin file the loader opens, and the manifest that names
+      it is the SOURCE metadata.json, copied verbatim — so a per-target `main`
+      would build one plugin and ship a manifest naming another on every target
+      the overlay matched.
+
+      It is worse than that here, and this is the part that decides the answer:
+      mkLogosModule reads `config.main` in exactly ONE place — the
+      legacy-interface guard at modulePreConfigure.nix:200, which only ever
+      throws — so no BUILDING core module's `main` is read for anything; the
+      file name comes from common.getPluginFilename. A core module that
+      platform-keys it therefore evaluates green with no diagnostic anywhere. The platform-null poison that
+      is supposed to catch this only ever fires on the ui_qml path, where
+      mkLogosQmlModule reads `config.main` for `hasBackend`. A guarantee that
+      holds for one module type and silently does not for the other is not a
+      guarantee.'';
+    dependencies = ''
+      `dependencies` is resolved for the build and not for the artifact TWICE
+      over. lgpm and the liblogos loader read the dependency list off the
+      installed manifest, which is the verbatim source file; and the LogosModules
+      umbrella is generated at build time by logos-plugin-qt/lib/buildPlugin.nix
+      from that same raw array — the generator reads `deps` out of metadata.json
+      itself, not out of this config — so the umbrella would carry the BASE list
+      while the flake inputs carried the resolved one. A dependency added by an
+      overlay would be built and linked, and then have no member on
+      `modules()`.'';
+  };
+
+  # The one thing that has to be true before either key above can go back into
+  # `topAllowed`. Named once, quoted by both refusals.
+  deferredPrecondition = ''
+    Both are re-admissible once the resolved tree reaches the artifact rather
+    than the source file reaching it:
+
+      1. lib/modulePreConfigure.nix's jq stamp (the one that already splices
+         `logos_protocol_version` into the build-tree ./metadata.json) also
+         splices the RESOLVED values in and does `del(.platforms)`, so the
+         embedded and generator-visible copy is the resolved one; and
+      2. lib/mkLogosQmlModule.nix copies that stamped build-tree file into
+         $out/lib/metadata.json instead of ''${configFile}.
+
+    Until both land, put the value in the base and let the platform-specific
+    part be handled where it already is: a plugin's file EXTENSION comes from
+    common.getPluginFilename, which is the case a per-target `main` would
+    otherwise serve.'';
+
+  # ── One overlay entry ─────────────────────────────────────────────────────
+  validateOverlay = { path, allowed, deferred ? { }, index, overlay }:
+    let
+      body = removeAttrs overlay [ "when" ];
+      bodyKeys = builtins.attrNames body;
+      offenders = lib.subtractLists allowed bodyKeys;
+      # Two kinds of refusal, and they deserve different words. A `type` or a
+      # `host_services` overlay is refused because the field must not vary, ever.
+      # A `main` or `dependencies` overlay is refused because the plumbing that
+      # would make it honest does not exist yet — telling an author "not allowed"
+      # when the real answer is "not yet, and here is what is missing" is how a
+      # temporary restriction becomes folklore.
+      deferredOffenders = lib.filter (k: deferred ? ${k}) offenders;
+      hardOffenders = lib.subtractLists (builtins.attrNames deferred) offenders;
+      hardText = lib.optionalString (hardOffenders != [ ])
+        ("metadata.json: ${path}[${toString index}] may not override "
+         + builtins.concatStringsSep ", " (map (k: "`${k}`") hardOffenders)
+         + ". Only " + builtins.concatStringsSep ", " allowed
+         + " may vary by platform at this level — see lib/resolvePlatforms.nix for "
+         + "why each of the others is refused.\n");
+      deferredText = lib.optionalString (deferredOffenders != [ ])
+        ("metadata.json: ${path}[${toString index}] may not override "
+         + builtins.concatStringsSep ", " (map (k: "`${k}`") deferredOffenders)
+         + " — not on principle, but because resolving it today would change the BUILD "
+         + "and not the SHIPPED MODULE, and nothing anywhere would say so.\n\n"
+         + builtins.concatStringsSep "\n\n" (map (k: deferred.${k}) deferredOffenders)
+         + "\n\n" + deferredPrecondition);
+    in
+      if !(builtins.isAttrs overlay) then
+        throw ("metadata.json: ${path}[${toString index}] must be an object with a `when` "
+               + "selector, got ${builtins.toJSON overlay}.")
+      else if !(overlay ? when) then
+        throw ("metadata.json: ${path}[${toString index}] has no `when` selector. It is not "
+               + "defaulted to match-everything: an overlay that applies unconditionally is "
+               + "the base config, so a missing selector is far more likely to be an "
+               + "unfinished entry than an intentional one.")
+      else if offenders != [ ] then throw (hardText + deferredText)
+      else {
+        inherit index body;
+        when = canonWhen { inherit path index; when = overlay.when; };
+      };
+
+  asOverlayList = path: v:
+    if builtins.isList v then v
+    else throw ("metadata.json: `${path}` must be a LIST of overlays, got "
+                + "${builtins.typeOf v}. It is ordered rather than an object keyed by "
+                + "selector precisely so a general entry can be written before a specific "
+                + "one; an object could not express that.");
+
+  # ── The node merge ────────────────────────────────────────────────────────
+  #
+  # Deliberately NOT common.recursiveMerge, which is close but wrong twice for
+  # this job: it runs the merged lists through lib.unique (dedup that can
+  # REORDER a link line, where order is load-bearing), and on a type mismatch it
+  # silently takes lib.last instead of refusing. Both would turn an authoring
+  # mistake into a build that succeeds and links the wrong thing.
+  mergeNode = { path, a, b }:
+    builtins.foldl' (acc: k:
+      let
+        pk = path ++ [ k ];
+        here = builtins.concatStringsSep "." pk;
+        av = acc.${k} or null;
+        bv = b.${k};
+      in
+        if bv == null then
+          throw ("metadata.json: platform overlay sets `${here}` to null. There is no "
+                 + "removal operator in v1 — null over a scalar is a blanking operator and "
+                 + "null over a list is removal, and both need a semantics that says what "
+                 + "happens when two overlays disagree. Restructure the base so the value "
+                 + "only appears in the overlays that want it.")
+        else if !(acc ? ${k}) then acc // { ${k} = bv; }
+        # An explicit null in the BASE means "unset" — `"nix": {"rust":
+        # {"toolchain": null}}` is how a module says "the pinned nixpkgs rustc"
+        # — so an overlay may fill it. Null is asymmetric on purpose:
+        # unset-then-set is a thing an author means, set-then-unset (null in an
+        # overlay, above) is the removal operator v1 does not have.
+        else if av == null then acc // { ${k} = bv; }
+        else if builtins.isList av && builtins.isList bv then acc // { ${k} = av ++ bv; }
+        else if builtins.isAttrs av && builtins.isAttrs bv then
+          acc // { ${k} = mergeNode { path = pk; a = av; b = bv; }; }
+        else if builtins.typeOf av == builtins.typeOf bv then acc // { ${k} = bv; }
+        else
+          throw ("metadata.json: type mismatch at `${here}`: the base is a "
+                 + "${builtins.typeOf av} and a platform overlay supplies a "
+                 + "${builtins.typeOf bv}. Lists concatenate and scalars overwrite, but "
+                 + "there is no rule that turns one into the other.")
+    ) a (builtins.attrNames b);
+
+  applyOverlays = { path, basePath, allowed, deferred ? { }, base, overlays, platform }:
+    let
+      checked = lib.imap0 (index: overlay:
+        validateOverlay { inherit path allowed deferred index overlay; }
+      ) (asOverlayList path overlays);
+      matching = lib.filter (c: matches c.when platform) checked;
+    in {
+      # Forced by the caller whether or not anything matched — a typo in an
+      # overlay for another platform must fail HERE, not on the machine that
+      # happens to build for it.
+      validated = map (c: c.when) checked;
+      touchedKeys = lib.unique (lib.concatMap (c: builtins.attrNames c.body) checked);
+      matchedKeys = lib.unique (lib.concatMap (c: builtins.attrNames c.body) matching);
+      merged = builtins.foldl' (acc: c: mergeNode { path = basePath; a = acc; b = c.body; })
+                 base matching;
+    };
+
+  # ── external_libraries: concatenation alone is silently WRONG here ─────────
+  #
+  # It is a list of OBJECTS that mkExternalLib folds with lib.listToAttrs keyed
+  # on `.name` — and listToAttrs keeps the FIRST entry on a duplicate key
+  # (verified: listToAttrs [{name="a";value=1;} {name="a";value=2;}] == {a=1;}).
+  # So under base-first concatenation, an overlay refining a library the base
+  # already declares is discarded and the BASE wins: the exact inverse of
+  # "specific last", with nothing raised. Refuse the ambiguous shape instead of
+  # inventing a by-name merge whose precedence would be a second thing to learn.
+  #
+  # Checked only when a matching overlay actually supplied external_libraries,
+  # so a module that already ships a duplicate (a pre-existing bug, but not one
+  # this change introduced) keeps building exactly as it did.
+  checkExternalLibs = { merged, matchedKeys }:
+    let
+      libs = merged.external_libraries or [ ];
+      names = map (l: l.name or null) (if builtins.isList libs then libs else [ ]);
+      dupes = lib.unique (lib.filter (n: n != null
+                && builtins.length (lib.filter (m: m == n) names) > 1) names);
+    in
+      if !(builtins.elem "external_libraries" matchedKeys) || dupes == [ ] then merged
+      else throw ("metadata.json: platform overlays leave `nix.external_libraries` with "
+                  + "duplicate name(s) " + builtins.concatStringsSep ", " (map (n: "`${n}`") dupes)
+                  + ". Entries concatenate, and mkExternalLib folds them by name keeping the "
+                  + "FIRST — so the base entry would silently win over the overlay that was "
+                  + "meant to refine it. Move the whole entry into the platform overlays "
+                  + "that want it rather than declaring it twice.");
+
+  # ── No platform available ─────────────────────────────────────────────────
+  #
+  # Parsing with `platform = null` is legitimate: both builders need a
+  # system-agnostic config for the handful of fields no overlay may vary
+  # (`name`, `type`, `version`), and those are read OUTSIDE forAllSystems where
+  # no package set and no target exist yet. What must never happen is that such
+  # a parse answers a platform-keyed question with the BASE value — a superset
+  # that was never meant to be used on its own is how the .so/.dylib/.dll
+  # spelling lists drifted in the first place.
+  #
+  # So instead of failing the whole parse (which would take `config.name` and
+  # `config.type` down with it, and with them the backend selection and every
+  # cross-flake reader of the module's `config` output), poison exactly the
+  # fields an overlay declares. Nix's laziness makes that precise: attrNames,
+  # name, type, version all keep working; the fields that no longer have a
+  # single answer refuse to produce one, and say where to get the real one.
+  poisonField = { path, field }:
+    throw ("metadata.json: `${path}${field}` is platform-keyed (some `platforms` overlay "
+           + "sets it) but this config was parsed with `platform = null`, so there is no "
+           + "single answer to give. Reading it would hand back the BASE value, which is "
+           + "the one thing a platform-keyed field must never silently do.\n\n"
+           + "Parse with a platform: parseMetadata.parseModuleConfig { json = ...; "
+           + "platform = parseMetadata.platformForSystem system; } — inside forAllSystems, "
+           + "where the target is known. A builder that reads this field above "
+           + "forAllSystems has to move that read down; a flake consumer should read "
+           + "`configFor.<system>` instead of the system-agnostic `config`.");
+
+  # ── A `platforms` key that is not in a place overlays are read from ───────
+  #
+  # `nix.packages.platforms`, `nix.rust.platforms`, `codegen.platforms` — every
+  # one of these is a natural thing to write, because the author is thinking
+  # "this block varies by platform" and puts the list next to the block. And
+  # every one of them is read by NOTHING: resolution looks at exactly two paths,
+  # so the overlay is dropped on the floor, the base ships to every target, and
+  # the module builds green everywhere while doing none of what it says.
+  #
+  # That is precisely the failure this whole file is written to make impossible
+  # — a superset nobody validates, an overlay that quietly never fires — so the
+  # tree gets swept for the key and a misplaced one is a hard error that names
+  # the path. The sweep is cheap (metadata.json is a few KB of plain JSON) and
+  # it runs on EVERY parse, including the early return for a module that
+  # declares no overlays at all: a module with `nix.rust.platforms` and nothing
+  # else HAS no legal overlay block, so the early return is exactly the path
+  # such a module takes, and leaving the sweep off it would mean the check
+  # never fires for the modules that need it most.
+  #
+  # It descends into lists as well as objects, because `nix.external_libraries`
+  # is a list of objects and "put the platforms list inside the library entry it
+  # varies" is the same mistake one level down.
+  legalPlatformsPaths = [ "platforms" "nix.platforms" ];
+
+  # Spellings that are obviously meant to be `platforms` and would otherwise be
+  # ignored in silence.
+  platformsNearMisses = [ "platform" "Platforms" "platform_overrides" "platform_overlays" ];
+
+  sweepMisplacedPlatforms = raw:
+    let
+      walk = path: v:
+        if builtins.isAttrs v then
+          lib.concatMap (k:
+            let here = if path == "" then k else "${path}.${k}"; in
+            # Near-misses are swept too. A sweep keyed on the exact spelling
+            # leaves `platform` (singular) — ONE character from the mistake this
+            # exists to make impossible — silently dropped, which is the original
+            # defect wearing a typo. No metadata.json in the tree carries any
+            # `platform*` key, so refusing them costs nothing today.
+            if (k == "platforms" && !(builtins.elem here legalPlatformsPaths))
+               || builtins.elem k platformsNearMisses
+            then [ here ]
+            else walk here v.${k}
+          ) (builtins.attrNames v)
+        else if builtins.isList v then
+          lib.concatLists (lib.imap0 (i: e: walk "${path}[${toString i}]" e) v)
+        else [ ];
+      offenders = if builtins.isAttrs raw then walk "" raw else [ ];
+      # A MISSPELLING and a MISPLACEMENT need different advice: one is renamed
+      # where it stands, the other is moved. Telling an author to "move the list
+      # up" when they wrote `platform` sends them off to rewrite a structure
+      # that was already correct.
+      misspelled = lib.filter (o: builtins.elem (lib.last (lib.splitString "." o))
+                                                platformsNearMisses) offenders;
+      fixHint =
+        if misspelled != [ ] && misspelled == offenders then
+          "Rename it to `platforms` (plural) where it stands."
+        else
+          "Move the list up to whichever of those owns the key you meant to vary, "
+          + "and name the key inside the overlay body: "
+          + "`\"nix\": { \"platforms\": [ { \"when\": {...}, \"packages\": {...} } ] }`, "
+          + "not `\"nix\": { \"packages\": { \"platforms\": [...] } }`.";
+    in
+      if offenders == [ ] then null
+      else throw ("metadata.json: `" + builtins.concatStringsSep "`, `" offenders
+                  + "` is not a place platform overlays are read from, so it would have "
+                  + "been SILENTLY IGNORED — the base would ship to every target and "
+                  + "nothing would have said so. Overlays are declared in exactly two "
+                  + "places: `platforms` at the TOP LEVEL (which may vary "
+                  + builtins.concatStringsSep ", " topAllowed
+                  + ") and `nix.platforms` (which may vary "
+                  + builtins.concatStringsSep ", " nixAllowed
+                  + "). " + fixHint);
+
+in
+rec {
+  inherit platformTriples;
+
+  # The one sanctioned way to turn a nix system string into a selector triple.
+  platformForSystem = system:
+    platformTriples.${system} or (throw
+      ("logos-module-builder: no platform triple for system '${system}'. Known: "
+       + builtins.concatStringsSep ", " (builtins.attrNames platformTriples)
+       + ". Add a row to platformTriples in lib/resolvePlatforms.nix (and to the "
+       + "reality assertion in tests/test-platform-triples.nix) when a target is added."));
+
+  # ...and from a package set, for callers that already have one. Kept as the
+  # SAME triple the table produces so there is one comparison vocabulary, not
+  # two that can disagree.
+  platformOf = hostPlatform:
+    if !(builtins.isAttrs hostPlatform) || !(hostPlatform ? parsed) then
+      throw ("logos-module-builder: platformOf expects pkgs.stdenv.hostPlatform (it reads "
+             + "`.parsed.{kernel,cpu,abi}.name`). A hand-rolled stub with only "
+             + "isLinux/isDarwin/isWindows will not do: those three booleans cannot express "
+             + "`architecture` or `abi`.")
+    else validatePlatform {
+      os           = hostPlatform.parsed.kernel.name;
+      architecture = hostPlatform.parsed.cpu.name;
+      abi          = hostPlatform.parsed.abi.name;
+    };
+
+  # A platform triple is validated through the SAME canonicalise + reachability
+  # check as a `when` value. Symmetric validation on both sides is what makes
+  # "a well-spelled selector always matches its own platform" a property of the
+  # code rather than a hope — and it stops a test from hand-rolling
+  # { os = "win"; } and quietly asserting nothing.
+  validatePlatform = platform:
+    if platform == null then null
+    else if !(builtins.isAttrs platform) then
+      throw ("logos-module-builder: `platform` must be null or a triple "
+             + "{ os, architecture, abi }, got ${builtins.typeOf platform}. Build one with "
+             + "parseMetadata.platformForSystem <system> or parseMetadata.platformOf "
+             + "pkgs.stdenv.hostPlatform.")
+    else
+      let
+        keys = builtins.attrNames platform;
+        missing = lib.subtractLists keys selectorKeys;
+        extra = lib.subtractLists selectorKeys keys;
+        out = lib.genAttrs selectorKeys (k: canon k platform.${k});
+      in
+        if missing != [ ] || extra != [ ] then
+          throw ("logos-module-builder: `platform` must have exactly "
+                 + builtins.concatStringsSep ", " selectorKeys
+                 + (if missing != [ ] then "; missing " + builtins.concatStringsSep ", " missing else "")
+                 + (if extra != [ ] then "; unexpected " + builtins.concatStringsSep ", " extra else "")
+                 + ". Unlike a `when` selector, a platform is a full triple — a partial one "
+                 + "would make `abi`-only selectors match by accident.")
+        else builtins.deepSeq out (
+          # Every component can be individually reachable while the COMBINATION
+          # exists on no target: {os="darwin"; architecture="aarch64"; abi="gnu"}
+          # passes a component-wise check, but darwin's abi is "unknown", so every
+          # `abi`-bearing selector would silently never fire. That is the same
+          # silence the platform guard above exists to prevent, one level down —
+          # so it is refused here rather than discovered as a missing library on
+          # one target six months later.
+          if !(builtins.elem out (builtins.attrValues platformTriples)) then
+            throw ("logos-module-builder: `platform` " + builtins.toJSON out
+                   + " is not a Logos target. Each component is reachable on its "
+                   + "own, but no row of platformTriples carries this combination, "
+                   + "so every `abi`-bearing selector would silently never match. "
+                   + "Known targets: "
+                   + builtins.concatStringsSep ", " (builtins.attrNames platformTriples)
+                   + ".")
+          else out);
+
+  # Resolve `platforms` overlays into the raw JSON tree, returning a tree of the
+  # same shape with both `platforms` keys removed. Everything downstream — the
+  # whole 300-line body of parseMetadata.nix, every existing validation, every
+  # `config.*` field — then runs unchanged over the RESOLVED answer.
+  resolvePlatforms = { platform, raw }:
+    let
+      plat = validatePlatform platform;
+      # See the bottom of this function for why this is a binding and not an
+      # inline call: it has to be forced on the early-return path too.
+      sweep = sweepMisplacedPlatforms raw;
+      # A non-object `nix` is a metadata bug, but it is parseMetadata's to
+      # report — it already fails on `(nix.packages or {})`, and substituting an
+      # empty set here would turn that error into a config that silently parses
+      # with no build inputs at all. `nixIsObject` gates every rewrite below so
+      # the malformed value is passed through untouched.
+      nixIsObject = raw ? nix && builtins.isAttrs raw.nix;
+      nix0 = if nixIsObject then raw.nix else { };
+      hasTop = raw ? platforms;
+      hasNix = nix0 ? platforms;
+
+      nixRes = applyOverlays {
+        path = "nix.platforms";
+        basePath = [ "nix" ];
+        allowed = nixAllowed;
+        base = removeAttrs nix0 [ "platforms" ];
+        overlays = nix0.platforms or [ ];
+        platform = plat;
+      };
+      nixMerged = checkExternalLibs {
+        merged = nixRes.merged;
+        matchedKeys = nixRes.matchedKeys;
+      };
+
+      topBase = (removeAttrs raw [ "platforms" ])
+                // lib.optionalAttrs nixIsObject { nix = nixMerged; };
+      topRes = applyOverlays {
+        path = "platforms";
+        basePath = [ ];
+        allowed = topAllowed;
+        deferred = topDeferred;
+        base = topBase;
+        overlays = raw.platforms or [ ];
+        platform = plat;
+      };
+
+      # Forced regardless of which branch we take below: a malformed selector is
+      # a metadata bug, and metadata is a few KB of plain JSON, so checking it
+      # whole costs nothing and turns every rule above into a PARSE-time failure
+      # on EVERY platform. Left lazy, a bad selector under `nix.platforms` stays
+      # silent on any build that never happens to read `nix.packages`.
+      validation = builtins.deepSeq [ nixRes.validated topRes.validated ] null;
+
+      poisoned =
+        (removeAttrs raw [ "platforms" ])
+        // lib.optionalAttrs nixIsObject {
+             nix = (removeAttrs nix0 [ "platforms" ])
+                   // lib.genAttrs nixRes.touchedKeys
+                        (field: poisonField { path = "nix."; inherit field; });
+           }
+        // lib.genAttrs topRes.touchedKeys (field: poisonField { path = ""; inherit field; });
+
+      resolved = builtins.deepSeq topRes.merged topRes.merged;
+    in
+      # ── Both guards are forced on EVERY path, including the early return ────
+      #
+      # The early return below exists because a module with no `platforms` block
+      # anywhere must get back the identical tree it handed in — that is what
+      # keeps every module in the tree building byte-for-byte as it did. What it
+      # must NOT also do is skip the checks, and it did:
+      #
+      #   `plat` is only ever forced by the overlay machinery, so a module with
+      #   no overlays never forced it. An invalid `platform` argument — a bare
+      #   "x86_64-linux" string, `true`, a partial triple, an attrset with the
+      #   wrong keys — was therefore ACCEPTED IN SILENCE by every module in the
+      #   tree, since none of them declares an overlay yet. It would only start
+      #   throwing the day somebody, in a different repo, months later, added
+      #   one. That is a guarantee conditional on module CONTENT, and
+      #   parseMetadata.nix's own header spends fifteen lines arguing that such
+      #   a guarantee is worse than none: the defect is authored at one call
+      #   site and discovered at another.
+      #
+      #   `sweep` has the same shape and a sharper edge, because a module whose
+      #   only `platforms` key is a MISPLACED one (`nix.packages.platforms`)
+      #   takes exactly this early return — `hasTop` and `hasNix` are both
+      #   false for it — so the check that exists to catch that mistake would
+      #   never run for the only module that can make it.
+      #
+      # Forcing both here costs one seq on a path that then returns `raw`
+      # unchanged, and makes both guarantees properties of the CALL rather than
+      # of what the module happens to contain.
+      builtins.seq plat (builtins.seq sweep (
+        if !hasTop && !hasNix then raw
+        else builtins.seq validation (if plat == null then poisoned else resolved)));
+
+  # The overlay allowlists and the deferred-with-a-reason map, exposed so a test
+  # can pin them and so an error message elsewhere can quote them. `deferredTop`
+  # in particular is the written-down precondition for re-admitting `main` and
+  # `dependencies`; a test asserts it still names both halves of that
+  # precondition, so deleting the plumbing note and quietly widening the
+  # allowlist is not a one-word edit.
+  overlayAllowed = { top = topAllowed; nix = nixAllowed; };
+  overlayDeferredTop = topDeferred;
+  overlayDeferredPrecondition = deferredPrecondition;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,5 +1,13 @@
 # Test runner for logos-module-builder
-# All tests are pure Nix evaluation — no compilation needed.
+#
+# Nothing here COMPILES anything — the derivation below is an echo — but "pure
+# Nix evaluation" is no longer the whole truth either: test-platform-triples.nix
+# instantiates all five package sets in common.systems, the x86_64-windows mingw
+# cross among them, because the platform table it checks is only worth having if
+# something pins it to what a real package set reports. So this check evaluates
+# nixpkgs five times and is correspondingly slower than the rest; the other test
+# files are still pure evaluation over metadata.
+#
 # Usage: nix build .#checks.<system>.default
 { pkgs, lib, parseMetadata, common, mkExternalLib, fixturesRoot ? ./fixtures }:
 
@@ -25,7 +33,7 @@ let
       else builtins.throw "FAIL ${name}: expected expression to throw, but it succeeded with ${builtins.toJSON result.value}";
 
   # Import test modules
-  parseMetadataTests = import ./test-parse-metadata.nix { inherit assertEq assertBool assertHasAttr assertThrows parseMetadata; };
+  parseMetadataTests = import ./test-parse-metadata.nix { inherit lib assertEq assertBool assertHasAttr assertThrows parseMetadata; };
   commonTests = import ./test-common.nix { inherit pkgs lib assertEq assertBool assertHasAttr common; };
   externalLibTests = import ./test-external-lib.nix { inherit assertEq assertBool mkExternalLib; };
   templateTests = import ./test-templates.nix { inherit assertEq assertBool assertHasAttr parseMetadata; builderRoot = ./..; };
@@ -36,13 +44,64 @@ let
   # safety boundary (which images may hold a LogosAPI-free consumer wrapper),
   # not a parsing default, and the reasoning belongs next to the cases.
   consumerApiStyleTests = import ./test-consumer-api-style.nix { inherit assertEq assertBool assertThrows parseMetadata; };
+  # The hand-written system -> platform-triple table, asserted against the real
+  # package sets. Its own file because it is the only eval test that
+  # instantiates nixpkgs five times, and because what it pins is a fact about
+  # the CROSS target rather than anything about parsing. See its header for the
+  # elaborate()-says-msvc trap it exists to catch.
+  platformTripleTests = import ./test-platform-triples.nix {
+    inherit assertEq common parseMetadata;
+  };
   modulePreConfigureTests = import ./test-module-pre-configure.nix {
     inherit lib assertBool assertThrows;
     modulePreConfigure = import ../lib/modulePreConfigure.nix { inherit lib; };
   };
 
-  # Collect all test results into a list of bools (all must be true)
-  allTests = parseMetadataTests ++ commonTests ++ externalLibTests ++ templateTests ++ collectDepsTests ++ fixtureTests ++ modulePreConfigureTests ++ consumerApiStyleTests;
+  # Every suite, LABELLED. The label is not decoration: the elements of these
+  # lists are bare bools, so a failure report that could only say "element 274"
+  # would send the reader counting through nine files.
+  suites = [
+    { name = "test-parse-metadata";       tests = parseMetadataTests; }
+    { name = "test-common";               tests = commonTests; }
+    { name = "test-external-lib";         tests = externalLibTests; }
+    { name = "test-templates";            tests = templateTests; }
+    { name = "test-collectAllModuleDeps"; tests = collectDepsTests; }
+    { name = "test-fixtures";             tests = fixtureTests; }
+    { name = "test-module-pre-configure"; tests = modulePreConfigureTests; }
+    { name = "test-consumer-api-style";   tests = consumerApiStyleTests; }
+    { name = "test-platform-triples";     tests = platformTripleTests; }
+  ];
+
+  # ── Why every element is type-checked and not merely deepSeq'd ─────────────
+  #
+  # `builtins.deepSeq` does not force a LAMBDA — it forces to WHNF and a lambda
+  # is already there — so a partially applied assertion is a perfectly good list
+  # element that asserts nothing and still counts toward the total printed
+  # below. That is not hypothetical: `assertBool "interface universal" (...)`
+  # sat in test-parse-metadata.nix missing its third argument, evaluating to a
+  # lambda, reported as a passing test, for as long as the file has existed. A
+  # test suite whose failure mode is "silently shrinks" is worse than a smaller
+  # suite, because the number at the end is what everyone reads.
+  #
+  # So each element must be a bool AND must be true. assertEq/assertBool/
+  # assertThrows already throw on failure and return `true`, so a `false` here
+  # means someone put a raw comparison in the list — also worth catching.
+  checkSuite = suite: lib.imap0 (i: t:
+    if !(builtins.isBool t) then
+      throw ("FAIL ${suite.name}[${toString i}]: this list element is a "
+             + "${builtins.typeOf t}, not a bool. A ${builtins.typeOf t} is most "
+             + "likely an assertion missing an argument — assertEq and assertBool "
+             + "take THREE (name, actual, expected), assertThrows takes two. "
+             + "builtins.deepSeq does not force a lambda, so such an element would "
+             + "otherwise be counted as a passing test forever.")
+    else if !t then
+      throw ("FAIL ${suite.name}[${toString i}]: assertion evaluated to false. The "
+             + "assert* helpers throw on failure and return true, so a bare false "
+             + "means a raw comparison was put in the list instead of an assertion.")
+    else t
+  ) suite.tests;
+
+  allTests = lib.concatMap checkSuite suites;
 
   # Force evaluation of all tests
   allPassed = builtins.deepSeq allTests (builtins.length allTests);

--- a/tests/fixtures/platform-overlay-module/metadata.json
+++ b/tests/fixtures/platform-overlay-module/metadata.json
@@ -1,0 +1,32 @@
+{
+  "name": "platform_overlay_module",
+  "version": "1.4.0",
+  "type": "core",
+  "interface": "universal",
+  "category": "network",
+  "description": "Fixture exercising platform-keyed metadata from disk",
+  "main": "platform_overlay_module_plugin",
+  "dependencies": [],
+
+  "include": [],
+
+  "platforms": [
+    { "when": { "os": "linux" },   "include": ["libcore.so"] },
+    { "when": { "os": "darwin" },  "include": ["libcore.dylib"] },
+    { "when": { "os": "windows" }, "include": ["libcore.dll"] }
+  ],
+
+  "nix": {
+    "packages": {
+      "build": ["pkg-config"],
+      "runtime": ["nlohmann_json"]
+    },
+    "external_libraries": [],
+    "platforms": [
+      { "when": { "os": "linux" },
+        "packages": { "runtime": ["krb5"] } },
+      { "when": { "architecture": "arm64" },
+        "cmake": { "extra_link_libraries": ["atomic"] } }
+    ]
+  }
+}

--- a/tests/test-consumer-api-style.nix
+++ b/tests/test-consumer-api-style.nix
@@ -22,7 +22,11 @@
 { assertEq, assertBool, assertThrows, parseMetadata }:
 
 let
-  parse = parseMetadata.parseModuleConfig;
+  # A fixed platform: nothing in this file is platform-keyed, so pinning one
+  # keeps every assertion below reading exactly as it did when
+  # parseModuleConfig took the JSON alone.
+  linuxX86 = { os = "linux"; architecture = "x86_64"; abi = "gnu"; };
+  parse = json: parseMetadata.parseModuleConfig { inherit json; platform = linuxX86; };
 
   mk = attrs: parse (builtins.toJSON ({ name = "m"; } // attrs));
 

--- a/tests/test-fixtures.nix
+++ b/tests/test-fixtures.nix
@@ -4,7 +4,15 @@
 { assertEq, assertBool, assertHasAttr, parseMetadata, fixturesRoot }:
 
 let
-  parse = parseMetadata.parseModuleConfig;
+  # A fixed platform for the fixtures that are not platform-keyed, so those
+  # assertions read exactly as they did when parseModuleConfig took the JSON
+  # alone. The overlay fixture below parses for several targets instead.
+  linuxX86 = { os = "linux"; architecture = "x86_64"; abi = "gnu"; };
+  parse = json: parseMetadata.parseModuleConfig { inherit json; platform = linuxX86; };
+  parseAt = system: json: parseMetadata.parseModuleConfig {
+    inherit json;
+    platform = parseMetadata.platformForSystem system;
+  };
 
   # Parse each fixture's metadata.json from disk
   coreMeta     = parse (builtins.readFile (fixturesRoot + "/core-module/metadata.json"));
@@ -14,6 +22,15 @@ let
   backendMeta  = parse (builtins.readFile (fixturesRoot + "/ui-qml-backend-module/metadata.json"));
   extlibMeta   = parse (builtins.readFile (fixturesRoot + "/extlib-module/metadata.json"));
   depsMeta     = parse (builtins.readFile (fixturesRoot + "/module-with-deps/metadata.json"));
+
+  # Platform-keyed fixture, parsed once per target. On disk rather than inline
+  # because that is this file's whole purpose: an overlay list survives a round
+  # trip through real JSON — nested objects, key ordering, trailing whitespace —
+  # only if it is read from a file the way a module's actually is.
+  overlayJson = builtins.readFile (fixturesRoot + "/platform-overlay-module/metadata.json");
+  overlayLinux   = parseAt "x86_64-linux"   overlayJson;
+  overlayDarwin  = parseAt "aarch64-darwin" overlayJson;
+  overlayWindows = parseAt "x86_64-windows" overlayJson;
 
 in [
   # ---------------------------------------------------------------------------
@@ -175,4 +192,70 @@ in [
   # deps module (QML-only with deps)
   (assertBool "deps: view is set" (depsMeta.view != null) true)
   (assertEq "deps: main is null" depsMeta.main null)
+
+  # ---------------------------------------------------------------------------
+  # Platform-keyed fixture, read from disk
+  # ---------------------------------------------------------------------------
+  # ONE `include` spelling per target — which is the entire point of the
+  # feature, and which the shape of this fixture has to demonstrate rather than
+  # merely permit. It used to be written the obvious way:
+  #
+  #   "include": ["libcore.so"],
+  #   "platforms": [ {"when":{"os":"darwin"},  "include":["libcore.dylib"]},
+  #                  {"when":{"os":"windows"}, "include":["libcore.dll"]} ]
+  #
+  # and that is WRONG in the exact way the feature exists to remove. Lists
+  # CONCATENATE, so darwin resolved to ["libcore.so","libcore.dylib"] and
+  # windows to ["libcore.so","libcore.dll"]: still a cross-platform superset,
+  # still relying on mkLogosModule tolerating a name that matches nothing, still
+  # a list that drifts unvalidated — which is how logos-package-downloader-module
+  # ended up naming .so and .dylib but not .dll. The .so is not a base value, it
+  # is the LINUX value, so it belongs in the Linux overlay with the others.
+  #
+  # The correct shape, and the one an author should copy: an EMPTY base plus one
+  # overlay per OS. It is also what makes the assertions below meaningful — each
+  # target gets exactly one name, so a resolver that leaked a non-matching entry
+  # would fail here instead of producing a longer list nobody reads.
+  #
+  # The point of doing this from a file at all: the inline cases in
+  # test-parse-metadata.nix are built with builtins.toJSON, which can never
+  # produce the shapes a hand-written metadata.json does.
+  (assertEq "fixture overlay: include on linux"   overlayLinux.include   [ "libcore.so" ])
+  (assertEq "fixture overlay: include on darwin"  overlayDarwin.include  [ "libcore.dylib" ])
+  (assertEq "fixture overlay: include on windows" overlayWindows.include [ "libcore.dll" ])
+
+  # Stated directly, because "one spelling per target" is the property, not the
+  # particular strings: no target may resolve to a superset.
+  (assertBool "fixture overlay: every target gets exactly ONE include entry"
+    (builtins.length overlayLinux.include   == 1
+     && builtins.length overlayDarwin.include  == 1
+     && builtins.length overlayWindows.include == 1)
+    true)
+
+  # The krb5 case: a runtime package that CANNOT be declared as a superset,
+  # because resolving it against a mingw package set is an evaluation-time
+  # failure long before anything is compiled.
+  (assertEq "fixture overlay: linux gets krb5"
+    overlayLinux.nix_packages.runtime [ "nlohmann_json" "krb5" ])
+  (assertEq "fixture overlay: windows does not"
+    overlayWindows.nix_packages.runtime [ "nlohmann_json" ])
+
+  # An architecture-only selector spelled `arm64`, canonicalised to aarch64 —
+  # it must reach aarch64-darwin and skip x86_64-linux.
+  #
+  # `cmake.extra_link_libraries` is used here only because it is the one
+  # overlay-able key with a distinct shape; note that NOTHING in the workspace
+  # currently consumes `config.cmake.*` (parsed at parseMetadata.nix:188-192,
+  # zero readers anywhere), so this asserts resolution, not configuration. Do
+  # not copy this fixture as an example of how to add a link library.
+  (assertEq "fixture overlay: arm64 selector reaches aarch64-darwin"
+    overlayDarwin.cmake.extra_link_libraries [ "atomic" ])
+  (assertEq "fixture overlay: arm64 selector skips x86_64"
+    overlayLinux.cmake.extra_link_libraries [ ])
+
+  # Fields no overlay touches are identical across targets — a resolver that
+  # leaked overlay residue into the base would show up here first.
+  (assertEq "fixture overlay: untouched fields are target-independent"
+    { inherit (overlayLinux) name version type main; build = overlayLinux.nix_packages.build; }
+    { inherit (overlayWindows) name version type main; build = overlayWindows.nix_packages.build; })
 ]

--- a/tests/test-parse-metadata.nix
+++ b/tests/test-parse-metadata.nix
@@ -1,8 +1,32 @@
 # Tests for parseMetadata.nix
-{ assertEq, assertBool, assertHasAttr, assertThrows, parseMetadata }:
+{ lib, assertEq, assertBool, assertHasAttr, assertThrows, parseMetadata }:
 
 let
-  parse = parseMetadata.parseModuleConfig;
+  # A fixed platform, so every existing assertion below reads exactly as it did
+  # when parseModuleConfig took the JSON alone. Overlay-specific cases build
+  # their own platforms; see the `platforms` section (and tests/test-platform-
+  # triples.nix, which pins these three values to the real package set).
+  linuxX86 = { os = "linux"; architecture = "x86_64"; abi = "gnu"; };
+  parse = json: parseMetadata.parseModuleConfig { inherit json; platform = linuxX86; };
+
+  # ---------------------------------------------------------------------------
+  # Platform-overlay helpers
+  # ---------------------------------------------------------------------------
+  # `at` parses a module for one nix system, going through platformForSystem so
+  # the tests use the SAME triple constructor the builders do — a hand-rolled
+  # { os = "win"; } would validate against nothing and quietly assert nothing.
+  pf = parseMetadata.platformForSystem;
+  at = system: attrs:
+    parseMetadata.parseModuleConfig {
+      platform = pf system;
+      json = builtins.toJSON ({ name = "m"; } // attrs);
+    };
+  # Same, with no target at all — the shape a builder uses above forAllSystems.
+  atNone = attrs:
+    parseMetadata.parseModuleConfig {
+      platform = null;
+      json = builtins.toJSON ({ name = "m"; } // attrs);
+    };
 
   # ---------------------------------------------------------------------------
   # Minimal valid config (only required field: name)
@@ -249,7 +273,7 @@ in [
   (let
     iface = parse ''{ "name": "m", "interface": "universal", "codegen": { "impl_class": "X" } }'';
   in assertBool "interface universal"
-    (iface.interface == "universal" && iface.codegen.impl_class == "X"))
+    (iface.interface == "universal" && iface.codegen.impl_class == "X") true)
 
   (let
     goNames = parse (builtins.toJSON {
@@ -304,4 +328,642 @@ in [
       name = "x";
       dependency_overrides = { d = { input = "z"; }; };
     })))
+
+  # ---------------------------------------------------------------------------
+  # Platform-keyed metadata: `platforms` overlays
+  # ---------------------------------------------------------------------------
+  # The selector is a triple whose three components are independently optional,
+  # and the list is ORDERED because a map could not express "general first,
+  # specific last". Every rule here is written to make an authoring mistake a
+  # throw rather than an overlay that quietly never fires: a superset nobody
+  # validates is how the .so/.dylib/.dll `include` lists drifted, and how
+  # logos-package-downloader-module ended up without its .dll.
+
+  # --- no platforms at all: byte-identical answer on every target ---
+  # The regression that matters most. Roughly every module in the tree has no
+  # `platforms` block, so if resolution changed ANY of them the change is wrong.
+  # (`_platform` is the one attr that must differ — it records WHICH answer this
+  # config is, so a caller can assert what it is holding.)
+  (assertEq "no platforms: same config on linux and the mingw cross"
+    (removeAttrs (at "x86_64-linux"  { include = [ "a.so" ]; nix.packages.runtime = [ "zstd" ]; }) [ "_platform" ])
+    (removeAttrs (at "x86_64-windows" { include = [ "a.so" ]; nix.packages.runtime = [ "zstd" ]; }) [ "_platform" ]))
+
+  # --- os-only selector: matches every arch on that OS ---
+  (assertEq "os-only overlay applies on the matching OS"
+    (at "x86_64-linux" {
+      include = [ "libcore.so" ];
+      platforms = [ { when.os = "linux"; include = [ "extra.so" ]; } ];
+    }).include
+    [ "libcore.so" "extra.so" ])
+
+  (assertEq "os-only overlay applies on the other arch of the same OS"
+    (at "aarch64-linux" {
+      include = [ "libcore.so" ];
+      platforms = [ { when.os = "linux"; include = [ "extra.so" ]; } ];
+    }).include
+    [ "libcore.so" "extra.so" ])
+
+  # --- os-only selector: non-match leaves the base untouched ---
+  (assertEq "os-only overlay does not apply on another OS"
+    (at "aarch64-darwin" {
+      include = [ "libcore.so" ];
+      platforms = [ { when.os = "linux"; include = [ "extra.so" ]; } ];
+    }).include
+    [ "libcore.so" ])
+
+  # --- architecture-only selector, written with the alias an author reaches for ---
+  # nixpkgs spells it `aarch64`; every LGX variant name and every Apple document
+  # spells it `arm64`. Both are canonicalised through lib.systems.parse.cpuTypes,
+  # so "arm64" matches rather than silently never firing.
+  (assertEq "architecture-only overlay: arm64 canonicalises to aarch64 (darwin)"
+    (at "aarch64-darwin" {
+      include = [ ];
+      platforms = [ { when.architecture = "arm64"; include = [ "atomic-shim" ]; } ];
+    }).include
+    [ "atomic-shim" ])
+
+  (assertEq "architecture-only overlay crosses OS boundaries (linux aarch64 too)"
+    (at "aarch64-linux" {
+      include = [ ];
+      platforms = [ { when.architecture = "arm64"; include = [ "atomic-shim" ]; } ];
+    }).include
+    [ "atomic-shim" ])
+
+  (assertEq "architecture-only overlay skips the other arch"
+    (at "x86_64-linux" {
+      include = [ ];
+      platforms = [ { when.architecture = "aarch64"; include = [ "atomic-shim" ]; } ];
+    }).include
+    [ ])
+
+  # --- full triple ---
+  # This is the headline selector, and it is only correct because the Windows
+  # target's abi really is `gnu` (x86_64-w64-mingw32). `lib.systems.elaborate
+  # "x86_64-windows"` says `msvc`, so a resolver that took the shortcut of
+  # elaborating the system string would make this exact entry match nothing on
+  # the one platform the workspace cross-builds for.
+  (assertEq "full triple matches the mingw cross"
+    (at "x86_64-windows" {
+      platforms = [ { when = { os = "windows"; architecture = "x86_64"; abi = "gnu"; };
+                      include = [ "extra.dll" ]; } ];
+    }).include
+    [ "extra.dll" ])
+
+  (assertEq "full triple does not match a different OS"
+    (at "x86_64-linux" {
+      platforms = [ { when = { os = "windows"; architecture = "x86_64"; abi = "gnu"; };
+                      include = [ "extra.dll" ]; } ];
+    }).include
+    [ ])
+
+  # --- abi alone is legal, and matches MORE than it looks like it does ---
+  # Pinned rather than left to folklore: `gnu` is the abi of x86_64-linux,
+  # aarch64-linux AND the mingw cross, so a lone {"abi":"gnu"} spans two
+  # operating systems. It is not a mingw discriminator and will not become one
+  # until a musl or msvc target exists.
+  (assertEq "abi-only overlay applies on linux"
+    (at "x86_64-linux" { platforms = [ { when.abi = "gnu"; include = [ "g" ]; } ]; }).include
+    [ "g" ])
+  (assertEq "abi-only overlay ALSO applies on the windows cross"
+    (at "x86_64-windows" { platforms = [ { when.abi = "gnu"; include = [ "g" ]; } ]; }).include
+    [ "g" ])
+  (assertEq "abi-only overlay skips darwin, whose abi is \"unknown\""
+    (at "aarch64-darwin" { platforms = [ { when.abi = "gnu"; include = [ "g" ]; } ]; }).include
+    [ ])
+
+  # --- several matching overlays apply, in DECLARATION order ---
+  (assertEq "every matching overlay applies, concatenating in order"
+    (at "x86_64-windows" {
+      include = [ "base" ];
+      platforms = [
+        { when.abi = "gnu"; include = [ "from-abi" ]; }
+        { when.os = "windows"; include = [ "from-os" ]; }
+        { when = { os = "windows"; architecture = "x86_64"; abi = "gnu"; };
+          include = [ "from-triple" ]; }
+      ];
+    }).include
+    [ "base" "from-abi" "from-os" "from-triple" ])
+
+  # --- scalars: LAST matching overlay wins ---
+  # Written on `nix.rust.toolchain` rather than on `main`, and that is not an
+  # arbitrary choice of example: `main` is REFUSED at the top level (see the
+  # `topDeferred` cases below), so `nix.rust.toolchain` is the overlay-able
+  # scalar. It is also a realistic one — a crate whose deps out-pace the pinned
+  # rustc on one target only.
+  (assertEq "scalar overwrite: specific entry declared last wins"
+    (at "x86_64-windows" {
+      nix = {
+        rust.toolchain = "1.90.0";
+        platforms = [
+          { when.os = "windows"; rust.toolchain = "1.95.0"; }
+          { when = { os = "windows"; architecture = "x86_64"; abi = "gnu"; };
+            rust.toolchain = "1.96.0"; }
+        ];
+      };
+    }).nix_rust.toolchain
+    "1.96.0")
+
+  # ...and the same two entries REVERSED give the other answer. Ordering is
+  # declaration order, never specificity — the ordered list makes "general
+  # first, specific last" expressible, not automatic. Anyone reading only the
+  # case above would assume the resolver ranks selectors; it does not.
+  (assertEq "scalar overwrite: reversing the declaration reverses the answer"
+    (at "x86_64-windows" {
+      nix = {
+        rust.toolchain = "1.90.0";
+        platforms = [
+          { when = { os = "windows"; architecture = "x86_64"; abi = "gnu"; };
+            rust.toolchain = "1.96.0"; }
+          { when.os = "windows"; rust.toolchain = "1.95.0"; }
+        ];
+      };
+    }).nix_rust.toolchain
+    "1.95.0")
+
+  # --- nested attrset: recursed key by key, siblings survive ---
+  # The krb5 case, which is the reason this feature exists: krb5 is an
+  # EVALUATION-time hard failure for a mingw host (its closure reaches bash,
+  # whose meta.badPlatforms excludes a windows/pe host), so it cannot be
+  # declared as part of a cross-platform superset the way `include` can.
+  (assertEq "nix.packages.runtime concatenates and leaves .build alone"
+    (at "x86_64-linux" {
+      nix = {
+        packages = { build = [ "pkg-config" ]; runtime = [ "nlohmann_json" ]; };
+        platforms = [ { when.os = "linux"; packages.runtime = [ "krb5" ]; } ];
+      };
+    }).nix_packages
+    { build = [ "pkg-config" ]; runtime = [ "nlohmann_json" "krb5" ]; })
+
+  (assertEq "nix.packages.runtime is left alone on the non-matching target"
+    (at "x86_64-windows" {
+      nix = {
+        packages = { build = [ "pkg-config" ]; runtime = [ "nlohmann_json" ]; };
+        platforms = [ { when.os = "linux"; packages.runtime = [ "krb5" ]; } ];
+      };
+    }).nix_packages
+    { build = [ "pkg-config" ]; runtime = [ "nlohmann_json" ]; })
+
+  # A base-only key inside an overlaid attrset must survive: an overlay is a
+  # MERGE, not a replacement. `nix.rust.env` is the realistic case (per-target
+  # CFLAGS_* alongside a shared var).
+  (assertEq "nested attrset merge keeps base-only keys"
+    (at "x86_64-windows" {
+      nix = {
+        rust.env = { SHARED = "1"; };
+        platforms = [ { when.os = "windows"; rust.env = { WINDOWS_ONLY = "2"; }; } ];
+      };
+    }).nix_rust.env
+    { SHARED = "1"; WINDOWS_ONLY = "2"; })
+
+  # ...and the recursion is not one level deep, which is the rule the spec sketch
+  # got wrong. "Scalars and attrsets OVERWRITE" is the simpler rule and it is
+  # the wrong one: every overlay-able key under `nix` IS an attrset, so
+  # whole-object overwrite would replace `rust` wholesale here and take
+  # `packages.build`, `env` and `toolchain` down with it — and "lists
+  # concatenate" would become unreachable for the entire `nix` block, since no
+  # list is ever a direct child of packages/cmake/rust. Recursion is what lets
+  # the two rules compose: descend through the objects, apply the list/scalar
+  # rule at the leaf where the author actually wrote a value.
+  (assertEq "attrset merge recurses all the way down; siblings survive at every level"
+    (at "x86_64-windows" {
+      nix = {
+        rust = {
+          packages = { build = [ "pkg-config" ]; runtime = [ "openssl" ]; };
+          env = { SHARED = "1"; };
+          toolchain = "1.90.0";
+        };
+        platforms = [ { when.os = "windows"; rust.packages.runtime = [ "windows-sys" ]; } ];
+      };
+    }).nix_rust
+    { packages = { build = [ "pkg-config" ]; runtime = [ "openssl" "windows-sys" ]; };
+      env = { SHARED = "1"; };
+      toolchain = "1.90.0"; })
+
+  # --- an overlay under `nix` AND one at the top level, same module ---
+  # The two lists have disjoint key sets (nothing may appear in both), so they
+  # can never interact and need no ordering rule between them. Pinned so that
+  # stays true.
+  (assertEq "top-level and nix overlays both apply, independently"
+    (let c = at "x86_64-windows" {
+      include = [ "libcore.so" ];
+      platforms = [ { when.os = "windows"; include = [ "libcore.dll" ]; } ];
+      nix = {
+        packages.runtime = [ "zstd" ];
+        platforms = [ { when.os = "windows"; packages.runtime = [ "windows-only" ]; } ];
+      };
+    }; in { inherit (c) include; runtime = c.nix_packages.runtime; })
+    { include = [ "libcore.so" "libcore.dll" ];
+      runtime = [ "zstd" "windows-only" ]; })
+
+  # --- an empty `when` is refused ---
+  # An overlay that matches every platform IS the base config, so writing one
+  # states the opposite of what it means. Every other way to get an accidental
+  # match-everything (a misspelled key, a missing `when`) already throws;
+  # allowing this one would be the single silent hole.
+  (assertThrows "empty `when` is refused"
+    (at "x86_64-linux" { platforms = [ { when = { }; include = [ "x" ]; } ]; }))
+
+  (assertThrows "a missing `when` is refused rather than defaulting to match-all"
+    (at "x86_64-linux" { platforms = [ { include = [ "x" ]; } ]; }))
+
+  (assertThrows "an unknown key in `when` is refused"
+    (at "x86_64-linux" { platforms = [ { when.platform = "linux"; include = [ "x" ]; } ]; }))
+
+  # --- deny-listed fields ---
+  # `host_services` is the sharp one: it is a SECURITY declaration checked
+  # against a hardcoded allowlist, and a platform-varying privilege set would
+  # mean auditing the Linux build tells you nothing about the Windows one.
+  (assertThrows "a platform overlay may not set host_services"
+    (at "x86_64-linux" {
+      platforms = [ { when.os = "linux"; host_services = [ "token_registry" ]; } ];
+    }))
+
+  # `type` selects the BACKEND, and both builders read it above forAllSystems
+  # where no target exists — there is no per-platform answer to give them.
+  (assertThrows "a platform overlay may not set type"
+    (at "x86_64-linux" { platforms = [ { when.os = "linux"; type = "ui"; } ]; }))
+
+  # `interface` / `codegen` decide the generated contract, hence the interface
+  # hash: a Linux consumer calling a Windows provider built from a different
+  # contract is a mismatch at introspect time, not a build error.
+  (assertThrows "a platform overlay may not set interface"
+    (at "x86_64-linux" { platforms = [ { when.os = "linux"; interface = "cdylib"; } ]; }))
+
+  # The two levels have DISJOINT allowlists, so a top-level key under `nix` is
+  # refused too — that is what removes any ordering question between the lists.
+  (assertThrows "a nix-level overlay may not set a top-level field"
+    (at "x86_64-linux" { nix.platforms = [ { when.os = "linux"; include = [ "x" ]; } ]; }))
+
+  (assertThrows "a top-level overlay may not set a nix-level field"
+    (at "x86_64-linux" { platforms = [ { when.os = "linux"; packages.runtime = [ "x" ]; } ]; }))
+
+  # --- `main` and `dependencies`: refused, and refused for a different reason ---
+  #
+  # Both used to be in `topAllowed`, and both were resolved for the BUILD and
+  # not for the ARTIFACT. The shipped metadata.json is the SOURCE file copied
+  # verbatim (mkLogosQmlModule.nix's `cp ${configFile} $out/lib/metadata.json`,
+  # and the core path embeds the same file via configure_file), and the
+  # LogosModules umbrella is generated at build time by logos-plugin-qt's
+  # buildPlugin.nix out of that same raw `dependencies` array. So a core module
+  # that platform-keyed `main` evaluated GREEN with no diagnostic anywhere —
+  # mkLogosModule never reads `config.main`, so the platform-null poison that is
+  # supposed to catch this only ever fired on the ui_qml path — and shipped a
+  # manifest naming a plugin that does not exist on the non-base targets.
+  (assertThrows "a platform overlay may not set `main` (yet)"
+    (at "x86_64-linux" { platforms = [ { when.os = "linux"; main = "linux_plugin"; } ]; }))
+
+  (assertThrows "a platform overlay may not set `dependencies` (yet)"
+    (at "x86_64-linux" {
+      platforms = [ { when.os = "linux"; dependencies = [ "waku_module" ]; } ];
+    }))
+
+  # ...and on every target, not only the one the selector names. A refusal that
+  # depended on which machine ran the parse would be the same content-conditional
+  # guarantee the whole design is written against.
+  (assertThrows "a platform-keyed `main` is refused on targets it does not match either"
+    (at "aarch64-darwin" { platforms = [ { when.os = "windows"; main = "win_plugin"; } ]; }))
+
+  (assertThrows "a platform-keyed `main` is refused with no target at all"
+    (atNone { platforms = [ { when.os = "windows"; main = "win_plugin"; } ]; }).name)
+
+  # The allowlist itself, pinned. Widening it back is then a deliberate edit in
+  # two files rather than one word added to a list.
+  (assertEq "only `include` may vary at the top level"
+    parseMetadata.overlayAllowed.top [ "include" ])
+
+  (assertEq "the nix-level allowlist is unchanged"
+    parseMetadata.overlayAllowed.nix [ "packages" "external_libraries" "cmake" "rust" ])
+
+  # A throw message is not something a pure-Nix test can read, so the refusal
+  # texts are exported as data and asserted here. The point is not that the two
+  # keys are refused — the cases above cover that — but that the refusal still
+  # EXPLAINS itself: an author who hits it needs to know it is "not yet" rather
+  # than "never", and the next person to re-admit the key needs to know exactly
+  # what has to land first.
+  (assertEq "the deferred top-level fields are exactly `main` and `dependencies`"
+    (builtins.attrNames parseMetadata.overlayDeferredTop) [ "dependencies" "main" ])
+
+  (assertBool "the `main` refusal names the read that is missing"
+    (lib.hasInfix "config.main" parseMetadata.overlayDeferredTop.main
+     && lib.hasInfix "verbatim" parseMetadata.overlayDeferredTop.main)
+    true)
+
+  (assertBool "the `dependencies` refusal names the umbrella generator"
+    (lib.hasInfix "buildPlugin.nix" parseMetadata.overlayDeferredTop.dependencies)
+    true)
+
+  (assertBool "the precondition names both halves of the plumbing that must land"
+    (lib.hasInfix "modulePreConfigure.nix" parseMetadata.overlayDeferredPrecondition
+     && lib.hasInfix "del(.platforms)" parseMetadata.overlayDeferredPrecondition
+     && lib.hasInfix "mkLogosQmlModule.nix" parseMetadata.overlayDeferredPrecondition)
+    true)
+
+  # --- a `platforms` key somewhere overlays are never read from ---
+  #
+  # Resolution looks at exactly two paths, so `nix.packages.platforms` — which
+  # is the shape an author reaches for, because they are thinking "this block
+  # varies by platform" and put the list next to the block — was read by
+  # nothing. The base shipped to every target and the module evaluated green.
+  #
+  # Note what each of these modules has in common: NO legal `platforms` key. So
+  # every one of them takes resolvePlatforms' early return, which is why the
+  # sweep has to run on that path — the modules that can make this mistake are
+  # exactly the modules that never reach the overlay machinery. Each case reads
+  # `.name`, a field that is never platform-keyed, so nothing but the sweep
+  # itself can be doing the throwing.
+  (assertThrows "a `platforms` list under nix.packages is refused, not ignored"
+    (at "x86_64-linux" {
+      nix.packages.platforms = [ { when.os = "linux"; runtime = [ "krb5" ]; } ];
+    }).name)
+
+  (assertThrows "a `platforms` list under nix.rust is refused, not ignored"
+    (at "x86_64-linux" {
+      nix.rust.platforms = [ { when.os = "windows"; env = { WIN = "1"; }; } ];
+    }).name)
+
+  (assertThrows "a `platforms` list under nix.cmake is refused, not ignored"
+    (at "x86_64-linux" {
+      nix.cmake.platforms = [ { when.os = "linux"; extra_link_libraries = [ "dl" ]; } ];
+    }).name)
+
+  # The sweep descends into LISTS as well as objects: `nix.external_libraries`
+  # is a list of objects, and "put the platforms list inside the library entry
+  # it varies" is the same mistake one level down.
+  (assertThrows "a `platforms` key inside an external_libraries entry is refused"
+    (at "x86_64-linux" {
+      nix.external_libraries = [
+        { name = "foo"; platforms = [ { when.os = "linux"; vendor_path = "v"; } ]; }
+      ];
+    }).name)
+
+  (assertThrows "a `platforms` key under codegen is refused"
+    (at "x86_64-linux" { codegen.platforms = [ { when.os = "linux"; impl_class = "X"; } ]; }).name)
+
+  # ...and it is refused when a LEGAL overlay list is present too, so a module
+  # that got one of the two right does not get the other silently dropped.
+  (assertThrows "a misplaced `platforms` is refused even beside a legal one"
+    (at "x86_64-linux" {
+      nix = {
+        packages = { runtime = [ "zstd" ]; platforms = [ { when.os = "linux"; } ]; };
+        platforms = [ { when.os = "linux"; packages.runtime = [ "krb5" ]; } ];
+      };
+    }).nix_packages)
+
+  # A `platforms` nested inside an overlay BODY is refused too — that one was
+  # already caught by the body allowlist, and this pins that it stays caught.
+  (assertThrows "a `platforms` key inside an overlay body is refused"
+    (at "x86_64-linux" { platforms = [ { when.os = "linux"; platforms = [ ]; } ]; }))
+
+  # The negative: the two legal paths must NOT be swept up by the check that
+  # exists to protect them. (Every overlay case above this line is really the
+  # same assertion; this one states it directly.)
+  (assertEq "the two legal `platforms` paths still resolve"
+    (let c = at "x86_64-linux" {
+      include = [ ];
+      platforms = [ { when.os = "linux"; include = [ "a.so" ]; } ];
+      nix = {
+        packages.runtime = [ ];
+        platforms = [ { when.os = "linux"; packages.runtime = [ "krb5" ]; } ];
+      };
+    }; in { inherit (c) include; runtime = c.nix_packages.runtime; })
+    { include = [ "a.so" ]; runtime = [ "krb5" ]; })
+
+  # --- R2: a platform-keyed field parsed with NO platform must not answer ---
+  # This is the failure mode the whole design turns on. Returning the base value
+  # here would be indistinguishable from a correct answer at every call site,
+  # and would reintroduce exactly the hand-written superset the feature removes.
+  (assertThrows "reading a platform-keyed field with platform = null throws"
+    (atNone {
+      include = [ "libcore.so" ];
+      platforms = [ { when.os = "linux"; include = [ "extra.so" ]; } ];
+    }).include)
+
+  (assertThrows "reading a platform-keyed nix field with platform = null throws"
+    (atNone {
+      nix = {
+        packages.runtime = [ "zstd" ];
+        platforms = [ { when.os = "linux"; packages.runtime = [ "krb5" ]; } ];
+      };
+    }).nix_packages)
+
+  # ...but the refusal is FIELD-SCOPED, and that is deliberate. Both builders
+  # need `name` and `type` above forAllSystems to pick a backend and to publish
+  # a system-agnostic `config` output; failing the whole parse would take those
+  # down with it and make the feature unusable for the module that adopts it.
+  (assertEq "a platform-null parse still answers for fields no overlay may vary"
+    (atNone {
+      type = "ui";
+      include = [ "libcore.so" ];
+      platforms = [ { when.os = "linux"; include = [ "extra.so" ]; } ];
+    }).type
+    "ui")
+
+  # A module with no overlays is unaffected by a platform-null parse — this is
+  # what keeps every existing call site working.
+  (assertEq "a platform-null parse is unchanged for a module with no overlays"
+    (atNone { include = [ "libcore.so" ]; }).include
+    [ "libcore.so" ])
+
+  # --- R3: an unrecognised selector value must throw, not never-match ---
+  # A silently-skipped overlay is indistinguishable from a correct one at eval
+  # time and shows up as a missing file at load time on the machine with the
+  # least tooling. Both validation stages are exercised: "amd64" is absent from
+  # the nixpkgs table entirely, while "freebsd" and "musl" canonicalise fine and
+  # are caught only by the reachability check.
+  (assertThrows "an unrecognised architecture spelling throws"
+    (at "x86_64-linux" { platforms = [ { when.architecture = "amd64"; include = [ "x" ]; } ]; }))
+
+  (assertThrows "an unrecognised os spelling throws"
+    (at "x86_64-linux" { platforms = [ { when.os = "win"; include = [ "x" ]; } ]; }))
+
+  (assertThrows "a valid-but-unreachable os throws (no Logos target has it)"
+    (at "x86_64-linux" { platforms = [ { when.os = "freebsd"; include = [ "x" ]; } ]; }))
+
+  (assertThrows "a valid-but-unreachable abi throws"
+    (at "x86_64-linux" { platforms = [ { when.abi = "musl"; include = [ "x" ]; } ]; }))
+
+  # The non-short-circuit rule. With an `&&` chain this case validates CLEAN on
+  # Linux: the os mismatch decides the answer before "amd64" is ever forced, so
+  # the typo ships and only throws on macOS — a green Linux CI run proving
+  # nothing, which is how most Windows defects in this workspace reached a tag.
+  (assertThrows "a typo in a NON-matching overlay still throws"
+    (at "x86_64-linux" {
+      platforms = [ { when = { os = "darwin"; architecture = "amd64"; }; include = [ "x" ]; } ];
+    }))
+
+  # ...and it throws even when nothing ever reads the field the overlay sets.
+  # Resolution is forced eagerly: metadata.json is a few KB of plain JSON, so
+  # checking it whole is free, and left lazy a bad selector under `nix.platforms`
+  # stays silent on every build that happens not to read `nix.packages`.
+  (assertThrows "a bad selector throws even if only `name` is read"
+    (at "x86_64-linux" {
+      nix.platforms = [ { when.os = "freebsd"; packages.runtime = [ "x" ]; } ];
+    }).name)
+
+  # --- shape errors in the overlay body ---
+  (assertThrows "a type mismatch between base and overlay throws"
+    (at "x86_64-linux" {
+      include = [ "a" ];
+      platforms = [ { when.os = "linux"; include = "b"; } ];
+    }))
+
+  # There is no removal operator in v1: null over a scalar is a blanking
+  # operator and null over a list is removal, and both need a rule for what
+  # happens when two overlays disagree. Refused rather than guessed.
+  (assertThrows "null in an overlay is refused (no removal operator in v1)"
+    (at "x86_64-linux" {
+      include = [ "a" ];
+      platforms = [ { when.os = "linux"; include = null; } ];
+    }))
+
+  # An explicit null in the BASE is "unset", not a type — `"toolchain": null`
+  # means "the pinned nixpkgs rustc" — so an overlay must be able to fill it.
+  # Null is asymmetric on purpose (unset-then-set yes, set-then-unset no).
+  (assertEq "an overlay may fill a base field that is explicitly null"
+    (at "x86_64-windows" {
+      nix = {
+        rust.toolchain = null;
+        platforms = [ { when.os = "windows"; rust.toolchain = "1.96.0"; } ];
+      };
+    }).nix_rust.toolchain
+    "1.96.0")
+
+  # `platforms` is a LIST, not an object keyed by selector — the ordering above
+  # is exactly what an object could not express.
+  (assertThrows "an object-shaped `platforms` is refused"
+    (at "x86_64-linux" { platforms = { linux.include = [ "x" ]; }; }))
+
+  # --- external_libraries is a list of OBJECTS folded by name ---
+  # lib.listToAttrs keeps the FIRST entry on a duplicate key, so a naive
+  # concatenation would let the BASE entry win over the overlay meant to refine
+  # it — the exact inverse of "specific last", with nothing raised. Refused.
+  (assertThrows "overlays leaving a duplicate external_libraries name are refused"
+    (at "x86_64-linux" {
+      nix = {
+        external_libraries = [ { name = "foo"; vendor_path = "vendor/foo"; } ];
+        platforms = [ { when.os = "linux";
+                        external_libraries = [ { name = "foo"; vendor_path = "vendor/foo-linux"; } ]; } ];
+      };
+    }))
+
+  # A distinct name is fine, and go_static_lib_names must be derived from the
+  # RESOLVED list — otherwise a platform-only Go archive silently loses its
+  # whole-archive link flags.
+  (assertEq "go_static_lib_names is derived from the resolved external_libraries"
+    (at "x86_64-linux" {
+      nix = {
+        external_libraries = [ { name = "base_lib"; go_build = true; } ];
+        platforms = [ { when.os = "linux";
+                        external_libraries = [ { name = "linux_lib"; go_build = true; } ]; } ];
+      };
+    }).go_static_lib_names
+    [ "base_lib" "linux_lib" ])
+
+  # --- _raw is the RESOLVED tree, with `platforms` gone ---
+  # A consumer reading `_raw.include` off the pre-resolution tree would get the
+  # unresolved superset: the same silent wrong answer, one layer down. And
+  # nothing should be able to re-read the unresolved overlay list.
+  (assertEq "_raw carries the resolved value"
+    (at "x86_64-linux" {
+      include = [ "libcore.so" ];
+      platforms = [ { when.os = "linux"; include = [ "extra.so" ]; } ];
+    })._raw.include
+    [ "libcore.so" "extra.so" ])
+
+  (assertBool "_raw no longer carries the `platforms` key"
+    ((at "x86_64-linux" {
+      include = [ ];
+      platforms = [ { when.os = "linux"; include = [ "extra.so" ]; } ];
+    })._raw ? platforms)
+    false)
+
+  # --- the platform argument is validated the SAME way a selector is ---
+  # Symmetric validation is what makes "a well-spelled selector always matches
+  # its own platform" a property of the code rather than a hope, and it stops a
+  # test from hand-rolling { os = "win"; } and quietly asserting nothing.
+  (assertThrows "a misspelled platform triple is refused"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}'';
+      platform = { os = "win"; architecture = "x86_64"; abi = "gnu"; };
+    }))
+
+  (assertThrows "a partial platform triple is refused"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}'';
+      platform = { os = "linux"; };
+    }))
+
+  # ...and it is refused for a module with NO `platforms` block, which is every
+  # module in the tree today. This is the one that matters, and the two cases
+  # above do not cover it: they force the WHOLE config, so `_platform` (which
+  # re-validates the argument) is what throws. Read one ordinary field instead
+  # — `name`, which no overlay may vary — and the platform argument was only
+  # ever forced by the overlay machinery, which a module with no overlays never
+  # reaches. So an invalid `platform` was ACCEPTED IN SILENCE by every module in
+  # the tree, and would have started throwing the day someone in a different
+  # repo added an overlay months later: a guarantee conditional on module
+  # CONTENT, which is exactly what parseMetadata.nix's header argues must not
+  # exist. Each spelling below is its own case because each fails a different
+  # branch of validatePlatform.
+  (assertThrows "a bare system STRING as `platform` is refused (module has no overlays)"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}''; platform = "x86_64-linux";
+    }).name)
+
+  (assertThrows "a non-attrset `platform` is refused (module has no overlays)"
+    (parseMetadata.parseModuleConfig { json = ''{"name":"m"}''; platform = true; }).name)
+
+  (assertThrows "a PARTIAL platform triple is refused (module has no overlays)"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}''; platform = { os = "linux"; };
+    }).name)
+
+  (assertThrows "a platform triple with the WRONG KEYS is refused (module has no overlays)"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}''; platform = { os = "linux"; arch = "x86_64"; abi = "gnu"; };
+    }).name)
+
+  (assertThrows "a MISSPELLED platform triple is refused (module has no overlays)"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}''; platform = { os = "win"; architecture = "x86_64"; abi = "gnu"; };
+    }).name)
+
+  (assertThrows "an UNREACHABLE platform triple is refused (module has no overlays)"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}''; platform = { os = "freebsd"; architecture = "x86_64"; abi = "gnu"; };
+    }).name)
+
+  # The other half of the same rule: `platform = null` is the ONE non-triple
+  # that is legal, and it must still return the tree untouched for a module with
+  # no overlays. Forcing the argument on every path must not turn "no target
+  # known" into an error.
+  (assertEq "`platform = null` still parses a module with no overlays"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m","include":["a.so"]}''; platform = null;
+    }).include
+    [ "a.so" ])
+
+  (assertThrows "an unknown system has no platform triple"
+    (parseMetadata.platformForSystem "riscv64-linux"))
+
+  # --- the signature itself ---
+  # A caller that omits the platform must fail at the CALL, before any module
+  # content is read. Anything conditional on module content — "throw only if
+  # the JSON declares platforms" — is a guarantee that holds until someone in
+  # another repo adds an overlay months later.
+  (assertThrows "omitting `platform` is an error even for a module with no overlays"
+    (parseMetadata.parseModuleConfig { json = ''{"name":"m"}''; }))
+
+  (assertThrows "the old positional (JSON-string) form is refused with a migration message"
+    (parseMetadata.parseModuleConfig ''{"name":"m"}''))
+
+  (assertThrows "an unexpected argument is refused"
+    (parseMetadata.parseModuleConfig {
+      json = ''{"name":"m"}''; platform = null; jsonContent = "oops";
+    }))
+
+  # --- _platform records which answer this config is ---
+  (assertEq "_platform is the resolved triple"
+    (at "x86_64-windows" { })._platform
+    { os = "windows"; architecture = "x86_64"; abi = "gnu"; })
 ]

--- a/tests/test-platform-triples.nix
+++ b/tests/test-platform-triples.nix
@@ -1,0 +1,34 @@
+# The platform table in lib/resolvePlatforms.nix, checked against reality.
+#
+# `platformTriples` is a hand-written table mapping each entry of
+# common.systems to the { os, architecture, abi } triple that
+# `pkgs.stdenv.hostPlatform.parsed.{kernel,cpu,abi}.name` actually produces for
+# it. It is a table rather than a derivation so that parsing metadata.json does
+# not force a package set — but a hand-written table drifts, and drift here is
+# invisible: a wrong row does not break the build, it makes every selector for
+# that target quietly match nothing.
+#
+# This file is the only thing standing between that table and the following
+# real trap, which is why it instantiates package sets that no other eval test
+# needs:
+#
+#   lib.systems.elaborate "x86_64-windows"  ->  abi = "msvc"
+#   (common.mkPkgs "x86_64-windows")…       ->  abi = "gnu"
+#
+# The mingw-ness of the Windows target lives in logos-nix's mkWindowsPkgs
+# crossSystem (x86_64-w64-mingw32), not in the pseudo-system string. Elaborating
+# the string — the obvious way to avoid instantiating anything — yields msvc, so
+# the headline selector {"os":"windows","architecture":"x86_64","abi":"gnu"}
+# would match nothing on the one platform this workspace cross-builds for, and
+# every Windows overlay in the tree would be silently inert.
+{ assertEq, common, parseMetadata }:
+
+let
+  actualFor = system:
+    parseMetadata.platformOf (common.mkPkgs system).stdenv.hostPlatform;
+in
+map (system:
+  assertEq "platformTriples row for ${system} matches the real package set"
+    (parseMetadata.platformForSystem system)
+    (actualFor system)
+) common.systems

--- a/tests/test-templates.nix
+++ b/tests/test-templates.nix
@@ -3,7 +3,11 @@
 { assertEq, assertBool, assertHasAttr, parseMetadata, builderRoot }:
 
 let
-  parse = parseMetadata.parseModuleConfig;
+  # A fixed platform: nothing in this file is platform-keyed, so pinning one
+  # keeps every assertion below reading exactly as it did when
+  # parseModuleConfig took the JSON alone.
+  linuxX86 = { os = "linux"; architecture = "x86_64"; abi = "gnu"; };
+  parse = json: parseMetadata.parseModuleConfig { inherit json; platform = linuxX86; };
 
   # Read and parse each template's metadata.json
   minimalMeta = parse (builtins.readFile (builderRoot + "/templates/minimal-module/metadata.json"));


### PR DESCRIPTION
Item 2 of the platform-gaps plan. Stage 1: the overlay mechanism. Wiring the (still dead) `nix.cmake.*` fields and the canonical `darwin-amd64`/`darwin-x86_64` variant fix are separate follow-ups.

## The gap

Nothing in `metadata.json` is platform-keyed, so every platform decision lives in nix or CMake and modules declare cross-platform supersets by hand — `include` lists the `.so`, `.dylib` **and** `.dll` spellings side by side, and `logos-package-downloader-module` already forgot its `.dll`.

```jsonc
"nix": {
  "packages": { "runtime": ["nlohmann_json"] },
  "platforms": [
    { "when": { "os": "linux" }, "packages": { "runtime": ["krb5"] } },
    { "when": { "os": "windows", "architecture": "x86_64", "abi": "gnu" },
      "cmake": { "extra_link_libraries": ["ws2_32","bcrypt","ntdll"] } }
  ]
}
```

Each of `os` / `architecture` / `abi` is independently optional, so one selector spells a full variant, a whole OS, or an architecture everywhere. Every matching entry applies in declaration order; lists concatenate, attrsets recurse.

Resolution happens over the raw JSON **before** the existing parse, so the 300-line body of `parseMetadata.nix` runs unchanged over the resolved answer and `config.*` keeps its exact flat shape. Nothing below the parse changed.

## The design rule: a selector must never fail silently

A selector that never fires looks exactly like a platform that needs nothing. Everything below follows from that.

- **`parseModuleConfig` takes `{ json, platform }`, both required, and validates on *every* path** — including the early return for a module with no overlays. Guarding only the overlay path would make the guarantee conditional on file content: authored in one repo, discovered months later in another. (This was the most serious audit finding.)
- An unrecognised `os`/`architecture`/`abi` throws with an alias hint, and so does a component-wise-valid combination that exists on no target — `{darwin, aarch64, gnu}`, since darwin's abi is `unknown`.
- A `platforms` key anywhere it isn't read throws naming the path, and the sweep covers near-misses like `platform` (singular) — one character from the mistake it exists to prevent. Misspelling and misplacement get different advice, because "move the list up" is wrong for a typo.
- **Only `include` is overlay-able at the top level.** `main` and `dependencies` resolve for the *build*, but the shipped manifest is the verbatim source file and the `LogosModules` umbrella is generated from the raw `dependencies` array — so a core module keying them would build one plugin and ship a manifest naming another, evaluating green throughout. The precondition for re-admitting each is recorded as **data**, not prose.

Attrset **recursion** rather than overwrite is deliberate and argued at `resolvePlatforms.nix:20`: every overlay-able key under `nix` is an object, so literal overwrite would drop `packages.build` in the krb5 case above and make "lists concatenate" unreachable for the whole block.

## Verification

All 8 checks pass, including the `module-impl-abi-nm` check that landed on master while this was in flight.

**396 assertions**, up from 369 reported — one of which asserted nothing: an `assertBool` missing its third argument left a **lambda** in the list, and `deepSeq` doesn't force lambdas, so it counted as a pass while checking nothing. Pre-existing at HEAD. `tests/default.nix` now refuses any element that isn't a bool.

**Proven inert for the existing tree**, not asserted: field-by-field against master's parser across 24 config keys × 102 modules × 5 targets — **0 differing**. And through the real `mkLogosModule`, a non-matching overlay yields a byte-identical derivation to no overlay at all, while a matching one is byte-identical to writing the same value in the base.

Two independent adversarial audits returned BROKEN on the first draft and found six defects, each now closed with a test verified to go red before the fix and green after; a third audit reverted each fix individually to confirm the test actually catches it.

## Known caveat, documented

A platform-keyed `include` is correct for the build, but the shipped manifest is still the raw source file. `include` is not read at runtime so this is inert today — the fix has a proven hook (extend `modulePreConfigure`'s jq stamp to splice resolved values and `del(.platforms)`), which is also the precondition for re-admitting `main`/`dependencies`.

**Ordering:** an older builder ignores `platforms` as an unknown key and silently emits the base config, so this must land before any module declares an overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)