### PR TITLE
chore(deps): pick up ui-host's teardown grace period

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         "process-stats": "process-stats"
       },
       "locked": {
-        "lastModified": 1787280754,
-        "narHash": "sha256-WIl6zuC4tsYM0XkUiSdIUuxEIZ3xW7QyHPj73PusziA=",
+        "lastModified": 1787316686,
+        "narHash": "sha256-FRC6SYKwzoQLkSdiiiJ9Ov8Tn6k6hai33ey4PtjgdUY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "3893c833ecdd33d77478f0109e9163781029f4db",
+        "rev": "b2a9a0ba9dca51dc0d96651989fab21cd249c5fc",
         "type": "github"
       },
       "original": {
@@ -3833,11 +3833,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -3864,11 +3864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -4156,11 +4156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787275122,
+        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
         "type": "github"
       },
       "original": {
@@ -4181,11 +4181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
         "type": "github"
       },
       "original": {
@@ -4550,11 +4550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787280916,
-        "narHash": "sha256-P3rSVSCgqMLzlM9xEOmJpZEagzjCHGJHb4h0fQtUghY=",
+        "lastModified": 1787361051,
+        "narHash": "sha256-q3RlsjdM3wIgnZVQg17xC9/1AgW2Jla/QmN3RsIU8wY=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "5f6784f35b727a996d06fe42827feebe7b099262",
+        "rev": "9c0aabef5b68cf5ab88d1bab6b375e23a4f9d2a4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3589,11 +3589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787346530,
+        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
         "type": "github"
       },
       "original": {
@@ -3972,11 +3972,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
         "type": "github"
       },
       "original": {
@@ -4705,11 +4705,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787172850,
-        "narHash": "sha256-p5MReDNu3sSosuGYzEeD+wVP4dYUL2KKHA6dtCBsTN8=",
+        "lastModified": 1787356738,
+        "narHash": "sha256-icN5SY1+l3xcup/9cvWnden6JW7n/mdDYm3bYHkcAO4=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "b9a6778fff2f5714ddb556647ab961f4689a9937",
+        "rev": "7cbc5a6ed3ba5ccffd584c25b966dbf67868d841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
[logos-view-module-runtime#26](https://github.com/logos-co/logos-view-module-runtime/pull/26) (`7cbc5a6`) gives a view its chance to finish between "stop" and teardown: ui-host asks the plugin's `aboutToUnload()` before `delete pluginObject` and waits up to 2 s for `unloadFinished()`.

**This is the pin that decides whether any of that reaches a real app.** Every `ui_qml` view is hosted by ui-host, and this builder is what hands an author the shell that runs it — so until this moves, the grace period exists in the runtime and is unreachable from anything built here.

One bump covers both consumers: `logos-standalone-app` already carries `inputs.logos-view-module-runtime.follows` here, so there is a **single copy** in the closure and moving the direct input moves it for the app shell too. (The standalone-app repo has its own relock PR for anyone consuming it directly rather than through this builder.)

Also pulls `logos-plugin-qt` to `ef11c21` transitively — where the shared `runPluginAboutToUnload()` helper lives — and `logos-protocol` to `7989472`, which plugin-qt's `logos_qt_host_shared` requires (protocol#65).

All eight checks green: `default`, `qml-integration`, `test-framework-integration`, `static-extlib`, `qt-host-repoint`, `view-interface-abi`, `rust-native-dep`, `module-impl-abi-nm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)