### PR TITLE
feat: build ui_qml glue with logos-view-generator, not logos-qt-generator

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -542,10 +542,38 @@ function(logos_module)
             ${LOGOS_QT_HOST_ROOT}/include/core
         )
     endif()
+    # logos_ui_plugin_context.h, from logos-view-module — and FIRST, ahead of
+    # the logos-qt-sdk root below, which may still ship a copy of the same
+    # header name.
+    #
+    # Ordering is load-bearing here, which is exactly why this is not left to
+    # chance. This header and the view glue emitter are one MATCHED PAIR: the
+    # emitted `<name>_ui_glue.cpp` calls
+    # `_logos_codegen_::maybeUiPluginAboutToUnload(...)`, which only this header
+    # declares. Both now ship from logos-view-module under ONE pin, so they
+    # cannot disagree. logos-qt-sdk's copy is pinned SEPARATELY by this repo's
+    # flake.lock and drifts independently — resolving to it is how a build gets
+    # an emitter from one revision and a context header from another, and the
+    # symptom is a compile error inside generated code, far from the pin that
+    # caused it.
+    #
+    # Passed as a cache variable by every nix build (LOGOS_VIEW_INCLUDE_DIR) and
+    # as an env var for a hand-run cmake in a dev shell, the same two channels
+    # LOGOS_VIEW_TEMPLATE_DIR uses.
+    if(NOT LOGOS_VIEW_INCLUDE_DIR AND DEFINED ENV{LOGOS_VIEW_INCLUDE_DIR})
+        set(LOGOS_VIEW_INCLUDE_DIR "$ENV{LOGOS_VIEW_INCLUDE_DIR}")
+    endif()
+    if(LOGOS_VIEW_INCLUDE_DIR)
+        # BEFORE, not the default append: a stale logos_ui_plugin_context.h on
+        # the qt-sdk root must lose, not win by accident of ordering.
+        target_include_directories(${MODULE_NAME}_module_plugin BEFORE PRIVATE
+            ${LOGOS_VIEW_INCLUDE_DIR}/include
+        )
+    endif()
     # The Qt-typed headers logos-qt-sdk owns — logos_qt_lp_bridge.h /
-    # logos_qt_wire.h (emitted by name into generated Qt consumer wrappers) and
-    # logos_ui_plugin_context.h. The two roots no longer share a header name, so
-    # the ordering against the host runtime's dirs is no longer load-bearing.
+    # logos_qt_wire.h (emitted by name into generated Qt consumer wrappers).
+    # It may still ship logos_ui_plugin_context.h too; the block above is
+    # ordered ahead of this one so logos-view-module's copy is the one found.
     if(NOT "${LOGOS_QT_SDK_ROOT}" STREQUAL "${LOGOS_QT_HOST_ROOT}")
         if(LOGOS_QT_SDK_IS_SOURCE)
             target_include_directories(${MODULE_NAME}_module_plugin PRIVATE

--- a/docs/cmake-reference.md
+++ b/docs/cmake-reference.md
@@ -231,8 +231,15 @@ the legacy `PluginInterface` — lives in **logos-plugin-qt** and ships as the
 logos-qt-sdk still forwards the same code, so a build that supplies only
 `LOGOS_QT_SDK_ROOT` keeps working, with a message saying it took the legacy
 package; a build that supplies neither is a `FATAL_ERROR`. `LOGOS_QT_SDK_ROOT`
-stays required regardless — it is where `logos_qt_lp_bridge.h`,
-`logos_qt_wire.h` and `logos_ui_plugin_context.h` come from.
+stays required regardless — it is where `logos_qt_lp_bridge.h` and
+`logos_qt_wire.h` come from.
+
+`logos_ui_plugin_context.h` comes from `LOGOS_VIEW_INCLUDE_DIR`
+(logos-view-module), which is placed on the include path AHEAD of
+`LOGOS_QT_SDK_ROOT`. That header and the view glue emitter are one matched pair
+— the emitted glue calls `maybeUiPluginAboutToUnload()`, which only that header
+declares — so both ship from one pin. logos-qt-sdk may still install an older
+copy of the same header name; the ordering is what keeps it from being found.
 
 ### logos_find_qt()
 

--- a/lib/buildCppPlugin.nix
+++ b/lib/buildCppPlugin.nix
@@ -214,6 +214,33 @@ let
       # systems, so `packages.x86_64-windows` would EVAL-fail on the Windows leg.
       viewTemplates =
         logos-view-module.packages.${common.buildSystemFor system}.logos-view-templates;
+      # The VIEW plugin glue generator (`--backend ui`). It lives in
+      # logos-view-module, beside the LogosView*.in templates the glue it emits
+      # is compiled against and beside logos_ui_plugin_context.h, which that
+      # glue calls into -- the three are one authoring surface and used to be
+      # split across two repos. logos-qt-sdk shipped the same emitter and
+      # rotted: it gained the teardown hook, the copy here did not, and nothing
+      # detected it because a missing hook is silent at every layer.
+      #
+      # buildSystemFor: a code generator RUNS on the build machine, and
+      # logos-view-module publishes only the four NATIVE systems, so plain
+      # ${system} would EVAL-fail on the Windows leg.
+      logosViewGenerator =
+        logos-view-module.packages.${common.buildSystemFor system}.logos-view-generator;
+      # logos_ui_plugin_context.h -- the context a view's *Backend derives, and
+      # the header the emitted glue calls maybeUiPluginAboutToUnload() in.
+      #
+      # It comes from logos-view-module, the SAME pin as the generator above,
+      # and that is the whole point. The emitter and this header are one
+      # MATCHED PAIR: the emitter writes a call, the header declares what it
+      # calls. While both lived in logos-qt-sdk they moved together under one
+      # pin and could not disagree. Sourcing the generator from one repo and
+      # this header from another would make every ui_qml build depend on two
+      # pins agreeing, with nothing enforcing it -- and the failure is a
+      # compile error deep inside GENERATED code, far from the pin that caused
+      # it. One pin, one pair.
+      logosViewInclude =
+        logos-view-module.packages.${common.buildSystemFor system}.include;
       logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
 
@@ -278,7 +305,7 @@ let
           inherit externalLibs;
           # pkgs.jq is target-typed too and jq runs in preConfigure
           # (modulePreConfigure.nix:203). buildPackages == pkgs natively.
-          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdkBuild logosQtGenerator logosQtHostGenerator pkgs.buildPackages.jq ];
+          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdkBuild logosQtGenerator logosQtHostGenerator logosViewGenerator pkgs.buildPackages.jq ];
           extraBuildInputs = extraBuildInputs ++ runtimePkgs ++ [ logosQtSdk logosQtHost logosProtocolPkg ];
           # Qt splits each module's TOOLS (repc, moc, qmltyperegistrar) into a
           # SEPARATE package that must run on the BUILD machine. Without these
@@ -294,6 +321,7 @@ let
             "-DLOGOS_QT_HOST_ROOT=${logosQtHost}"
             "-DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg}"
             "-DLOGOS_VIEW_TEMPLATE_DIR=${viewTemplates}"
+            "-DLOGOS_VIEW_INCLUDE_DIR=${logosViewInclude}"
           ] ++ goCmakeFlags;
           extraEnv = {
             LOGOS_CPP_SDK_ROOT = "${logosSdk}";
@@ -306,6 +334,7 @@ let
             # different consumers — the flag a nix cmakeConfigurePhase, the env
             # var a hand-run `cmake` where no cmakeFlags exist.
             LOGOS_VIEW_TEMPLATE_DIR = "${viewTemplates}";
+            LOGOS_VIEW_INCLUDE_DIR = "${logosViewInclude}";
           };
         }
         # Only pass interfaceDeps when the module declares any — keeps existing
@@ -397,6 +426,33 @@ let
       # systems, so `packages.x86_64-windows` would EVAL-fail on the Windows leg.
       viewTemplates =
         logos-view-module.packages.${common.buildSystemFor system}.logos-view-templates;
+      # The VIEW plugin glue generator (`--backend ui`). It lives in
+      # logos-view-module, beside the LogosView*.in templates the glue it emits
+      # is compiled against and beside logos_ui_plugin_context.h, which that
+      # glue calls into -- the three are one authoring surface and used to be
+      # split across two repos. logos-qt-sdk shipped the same emitter and
+      # rotted: it gained the teardown hook, the copy here did not, and nothing
+      # detected it because a missing hook is silent at every layer.
+      #
+      # buildSystemFor: a code generator RUNS on the build machine, and
+      # logos-view-module publishes only the four NATIVE systems, so plain
+      # ${system} would EVAL-fail on the Windows leg.
+      logosViewGenerator =
+        logos-view-module.packages.${common.buildSystemFor system}.logos-view-generator;
+      # logos_ui_plugin_context.h -- the context a view's *Backend derives, and
+      # the header the emitted glue calls maybeUiPluginAboutToUnload() in.
+      #
+      # It comes from logos-view-module, the SAME pin as the generator above,
+      # and that is the whole point. The emitter and this header are one
+      # MATCHED PAIR: the emitter writes a call, the header declares what it
+      # calls. While both lived in logos-qt-sdk they moved together under one
+      # pin and could not disagree. Sourcing the generator from one repo and
+      # this header from another would make every ui_qml build depend on two
+      # pins agreeing, with nothing enforcing it -- and the failure is a
+      # compile error deep inside GENERATED code, far from the pin that caused
+      # it. One pin, one pair.
+      logosViewInclude =
+        logos-view-module.packages.${common.buildSystemFor system}.include;
       logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
 
@@ -418,7 +474,9 @@ let
       runtimePkgs = map (getPkg pkgs) config.nix_packages.runtime;
     in {
       default = pkgs.mkShell {
-        nativeBuildInputs = backendShell.nativeBuildInputs ++ buildPkgs;
+        # logosViewGenerator: this is the ui_qml dev shell, so it is exactly
+        # the shell where someone hand-runs the view glue codegen.
+        nativeBuildInputs = backendShell.nativeBuildInputs ++ buildPkgs ++ [ logosViewGenerator ];
         buildInputs = backendShell.buildInputs ++ runtimePkgs;
         shellHook = ''
           ${backendShell.shellHook}
@@ -430,6 +488,7 @@ let
           # templates moved to logos-view-module. This is the ui_qml dev shell,
           # so it is exactly the shell where a hand-run cmake needs it.
           export LOGOS_VIEW_TEMPLATE_DIR="${viewTemplates}"
+          export LOGOS_VIEW_INCLUDE_DIR="${logosViewInclude}"
           echo "Logos ${config.name} module development environment"
           echo "LOGOS_CPP_SDK_ROOT: $LOGOS_CPP_SDK_ROOT"
           echo "LOGOS_MODULE_ROOT: $LOGOS_MODULE_ROOT"

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -47,6 +47,9 @@ let
   mkLogosModuleTests = import ./mkLogosModuleTests.nix {
     inherit nixpkgs lib common parseMetadata;
     inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-plugin-qt logos-test-framework;
+    # Source of logos-view-generator: a ui_qml module's unit tests run the same
+    # autoCodegen the plugin build does.
+    inherit logos-view-module;
   };
 
 in {

--- a/lib/mkLogosModule.nix
+++ b/lib/mkLogosModule.nix
@@ -411,6 +411,33 @@ let
       # Windows leg — a failure that is invisible until someone crosses.
       viewTemplates =
         logos-view-module.packages.${common.buildSystemFor system}.logos-view-templates;
+      # The VIEW plugin glue generator (`--backend ui`). It lives in
+      # logos-view-module, beside the LogosView*.in templates the glue it emits
+      # is compiled against and beside logos_ui_plugin_context.h, which that
+      # glue calls into -- the three are one authoring surface and used to be
+      # split across two repos. logos-qt-sdk shipped the same emitter and
+      # rotted: it gained the teardown hook, the copy here did not, and nothing
+      # detected it because a missing hook is silent at every layer.
+      #
+      # buildSystemFor: a code generator RUNS on the build machine, and
+      # logos-view-module publishes only the four NATIVE systems, so plain
+      # ${system} would EVAL-fail on the Windows leg.
+      logosViewGenerator =
+        logos-view-module.packages.${common.buildSystemFor system}.logos-view-generator;
+      # logos_ui_plugin_context.h -- the context a view's *Backend derives, and
+      # the header the emitted glue calls maybeUiPluginAboutToUnload() in.
+      #
+      # It comes from logos-view-module, the SAME pin as the generator above,
+      # and that is the whole point. The emitter and this header are one
+      # MATCHED PAIR: the emitter writes a call, the header declares what it
+      # calls. While both lived in logos-qt-sdk they moved together under one
+      # pin and could not disagree. Sourcing the generator from one repo and
+      # this header from another would make every ui_qml build depend on two
+      # pins agreeing, with nothing enforcing it -- and the failure is a
+      # compile error deep inside GENERATED code, far from the pin that caused
+      # it. One pin, one pair.
+      logosViewInclude =
+        logos-view-module.packages.${common.buildSystemFor system}.include;
       logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
 
@@ -714,7 +741,7 @@ let
           inherit externalLibs;
           # pkgs.jq is target-typed too and jq runs in preConfigure
           # (modulePreConfigure.nix:203). buildPackages == pkgs natively.
-          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdkBuild logosQtGenerator logosQtHostGenerator pkgs.buildPackages.jq ];
+          extraNativeBuildInputs = extraNativeBuildInputs ++ buildPkgs ++ [ logosSdkBuild logosQtGenerator logosQtHostGenerator logosViewGenerator pkgs.buildPackages.jq ];
           extraBuildInputs = extraBuildInputs ++ runtimePkgs ++ [ logosQtSdk logosQtHost logosProtocolPkg ]
             # A Rust staticlib's vendored C may want winpthreads: with <sched.h>
             # reachable, aws-lc-sys compiles aws-lc's thread_pthread.c and the
@@ -743,6 +770,7 @@ let
             "-DLOGOS_QT_HOST_ROOT=${logosQtHost}"
             "-DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg}"
             "-DLOGOS_VIEW_TEMPLATE_DIR=${viewTemplates}"
+            "-DLOGOS_VIEW_INCLUDE_DIR=${logosViewInclude}"
           ] ++ goCmakeFlags ++ apiStyleCmakeFlags
             ++ lib.optionals isRustModule [ "-DLOGOS_MODULE_RUST_STATIC_LIBS=${rustStaticName}" ];
           extraEnv = {
@@ -757,6 +785,7 @@ let
             # buildPlugin's cmakeConfigurePhase sees; the env var is what a
             # hand-run `cmake` in a dev shell sees, where no cmakeFlags exist.
             LOGOS_VIEW_TEMPLATE_DIR = "${viewTemplates}";
+            LOGOS_VIEW_INCLUDE_DIR = "${logosViewInclude}";
           };
         }
         # Only pass interfaceDeps when the module declares any — keeps existing
@@ -980,6 +1009,33 @@ let
       # Windows leg — a failure that is invisible until someone crosses.
       viewTemplates =
         logos-view-module.packages.${common.buildSystemFor system}.logos-view-templates;
+      # The VIEW plugin glue generator (`--backend ui`). It lives in
+      # logos-view-module, beside the LogosView*.in templates the glue it emits
+      # is compiled against and beside logos_ui_plugin_context.h, which that
+      # glue calls into -- the three are one authoring surface and used to be
+      # split across two repos. logos-qt-sdk shipped the same emitter and
+      # rotted: it gained the teardown hook, the copy here did not, and nothing
+      # detected it because a missing hook is silent at every layer.
+      #
+      # buildSystemFor: a code generator RUNS on the build machine, and
+      # logos-view-module publishes only the four NATIVE systems, so plain
+      # ${system} would EVAL-fail on the Windows leg.
+      logosViewGenerator =
+        logos-view-module.packages.${common.buildSystemFor system}.logos-view-generator;
+      # logos_ui_plugin_context.h -- the context a view's *Backend derives, and
+      # the header the emitted glue calls maybeUiPluginAboutToUnload() in.
+      #
+      # It comes from logos-view-module, the SAME pin as the generator above,
+      # and that is the whole point. The emitter and this header are one
+      # MATCHED PAIR: the emitter writes a call, the header declares what it
+      # calls. While both lived in logos-qt-sdk they moved together under one
+      # pin and could not disagree. Sourcing the generator from one repo and
+      # this header from another would make every ui_qml build depend on two
+      # pins agreeing, with nothing enforcing it -- and the failure is a
+      # compile error deep inside GENERATED code, far from the pin that caused
+      # it. One pin, one pair.
+      logosViewInclude =
+        logos-view-module.packages.${common.buildSystemFor system}.include;
       logosProtocolPkg = logos-protocol.packages.${system}.default;
       logosModule = logos-module.packages.${system}.default;
 
@@ -999,7 +1055,7 @@ let
         (lib.mapAttrs resolveExtInputDev externalLibInputs);
     in {
       default = pkgs.mkShell {
-        nativeBuildInputs = backendShell.nativeBuildInputs ++ buildPkgs ++ [ logosSdkBuild ];
+        nativeBuildInputs = backendShell.nativeBuildInputs ++ buildPkgs ++ [ logosSdkBuild logosViewGenerator ];
         buildInputs = backendShell.buildInputs ++ runtimePkgs ++ lib.attrValues devExternalLibs;
         shellHook = ''
           ${backendShell.shellHook}
@@ -1013,6 +1069,7 @@ let
           # and nothing in that repo can catch the regression — a missing value
           # here surfaces only when someone hand-runs cmake on a REP_FILE module.
           export LOGOS_VIEW_TEMPLATE_DIR="${viewTemplates}"
+          export LOGOS_VIEW_INCLUDE_DIR="${logosViewInclude}"
           ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: drv: ''
             export LOGOS_EXT_ROOT_${lib.toUpper name}="${drv}"
           '') devExternalLibs)}
@@ -1087,6 +1144,9 @@ let
   mkTests = import ./mkLogosModuleTests.nix {
     inherit nixpkgs lib common parseMetadata;
     inherit logos-cpp-sdk logos-protocol logos-qt-sdk logos-plugin-qt;
+    # Source of logos-view-generator: a ui_qml module's unit tests run the same
+    # autoCodegen the plugin build does.
+    inherit logos-view-module;
     logos-test-framework = logos-test-framework;
   };
 

--- a/lib/mkLogosModuleTests.nix
+++ b/lib/mkLogosModuleTests.nix
@@ -13,7 +13,7 @@
 #     flakeInputs = inputs;
 #     mockCLibs = ["gowalletsdk"];  # optional
 #   };
-{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-plugin-qt ? null, logos-test-framework }:
+{ nixpkgs, lib, common, parseMetadata, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-plugin-qt ? null, logos-view-module, logos-test-framework }:
 
 let
   modulePreConfigure = import ./modulePreConfigure.nix { inherit lib; };
@@ -102,6 +102,16 @@ let
       # host-services grant went undelivered while every build stayed green.
       logosQtHostGenerator =
         logos-plugin-qt.packages.${common.buildSystemFor system}.logos-qt-host-generator;
+      # The VIEW plugin glue generator (`--backend ui`), from logos-view-module.
+      # Needed HERE too, not just in the plugin build: compose below runs
+      # autoCodegen, which for a `type: ui_qml` module is the ui backend. Before
+      # the emitter moved, this path got it for free from logos-qt-generator.
+      logosViewGenerator =
+        logos-view-module.packages.${common.buildSystemFor system}.logos-view-generator;
+      # Same pin as the generator: the emitted glue calls into this header, so
+      # the two must never come from different revisions. See buildCppPlugin.nix.
+      logosViewInclude =
+        logos-view-module.packages.${common.buildSystemFor system}.include;
       logosProtocolPkg = logos-protocol.packages.${system}.default;
       testFramework = logos-test-framework.packages.${system}.default;
 
@@ -194,6 +204,7 @@ let
           logosSdkBuild
           logosQtGenerator
           logosQtHostGenerator
+          logosViewGenerator
         ] ++ extraBuildInputs;
 
         buildInputs = with pkgs; [
@@ -235,6 +246,7 @@ let
             -DLOGOS_QT_SDK_ROOT=${logosQtSdk} \
             -DLOGOS_QT_HOST_ROOT=${logosQtHost} \
             -DLOGOS_PROTOCOL_ROOT=${logosProtocolPkg} \
+            -DLOGOS_VIEW_INCLUDE_DIR=${logosViewInclude} \
             -DLOGOS_TEST_FRAMEWORK_ROOT=${testFramework} \
             -DCMAKE_MODULE_PATH=${testFramework}/cmake \
             ${lib.optionalString (externalLibRpath != "") "-DCMAKE_INSTALL_RPATH=${externalLibRpath} -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"} \

--- a/lib/modulePreConfigure.nix
+++ b/lib/modulePreConfigure.nix
@@ -153,9 +153,34 @@ let
 
   # UI plugin backends (type=ui_qml + interface=universal): the USER
   # writes the .rep (the view contract) and the *Backend class (deriving
-  # <RepClass>SimpleSource + LogosUiPluginContext); the qt generator emits
+  # <RepClass>SimpleSource + LogosUiPluginContext); the view generator emits
   # only the *Interface.h and the *Plugin glue that wires the (Qt-typed)
   # LogosModules aggregate into the backend on initLogos.
+  #
+  # The binary is logos-VIEW-generator (logos-view-module), not
+  # logos-qt-generator (logos-qt-sdk). Both shipped the same emitter for a
+  # while and they rotted apart: logos-qt-sdk#38 added the module teardown
+  # hook to the copy this line used to call, and the other copy never got it.
+  #
+  # That divergence was invisible, and would have become permanent the moment
+  # this line was repointed without reconciling first: ui-host reaches
+  # aboutToUnload() BY NAME through the meta-object, so a generated plugin
+  # class that does not declare it simply has no such meta-method --
+  # QMetaObject::invokeMethod returns false and the host moves on, which is
+  # indistinguishable from a view answering "Synchronous, nothing to wait for".
+  # No build, load or call fails; every view just silently loses its chance to
+  # finish. logos-view-module's `ui-plugin-metaobject` check now compiles the
+  # emitted plugin and drives that handshake through QPluginLoader, so the
+  # regression cannot recur silently in the new home.
+  #
+  # The generator lives with the LogosView*.in templates its output is compiled
+  # against and with logos_ui_plugin_context.h, which its output calls into --
+  # one authoring surface, one repo, matching how logos-plugin-qt owns the
+  # cdylib Qt-plugin glue.
+  #
+  # `--backend ui` is spelled explicitly even though it is that binary's
+  # default: it keeps the call site self-describing, and logos-view-generator
+  # REFUSES an unrecognised --backend rather than silently defaulting.
   uiCodegen = config:
     let
       cg = config.codegen or {};
@@ -166,7 +191,7 @@ let
     in
       ''
         echo "logos-module-builder: generating ui plugin glue (${config.name})..."
-        logos-qt-generator --backend ui \
+        logos-view-generator --backend ui \
           --metadata metadata.json \
           --rep "${repFile}"${backendFlags} \
           --output-dir ./generated_code

--- a/skills/create-ui-module.md
+++ b/skills/create-ui-module.md
@@ -200,7 +200,8 @@ The backend is the only C++ class you write. It derives:
 
 - `{RepClass}SimpleSource` — generated from your `.rep` by repc, pulled in via
   `"rep_{module_name}_source.h"`. Implement its SLOTs and feed its PROPs.
-- `LogosUiPluginContext` — from `"logos_ui_plugin_context.h"` (logos-qt-sdk).
+- `LogosUiPluginContext` — from `"logos_ui_plugin_context.h"` (logos-view-module,
+  the same repo as the view glue generator that emits calls into it).
   Gives the backend `modules()` (Qt-typed callers for `dependencies`), typed
   event subscriptions (`modules().dep.on<Event>(...)`), and `onContextReady()`.
   A UI plugin is a view, not a module — it has no host identity

--- a/tests/test-module-pre-configure.nix
+++ b/tests/test-module-pre-configure.nix
@@ -33,6 +33,12 @@ let
     type = "core";
   };
 
+  ui = auto {
+    name = "ticker_panel";
+    interface = "universal";
+    type = "ui_qml";
+  };
+
 in [
   # The retired interface must THROW, not silently emit an empty snippet.
   (assertThrows "autoCodegen rejects the removed interface \"provider\""
@@ -56,11 +62,30 @@ in [
   (assertBool "cdylib glue uses the maintained generator"
     (contains "logos-qt-host-generator" cdylib) true)
   # `logos-qt-generator ` with the trailing space so it cannot match
-  # `logos-qt-host-generator`; the ui backend still legitimately uses qt-sdk's.
+  # `logos-qt-host-generator`.
   (assertBool "universal glue does NOT fall back to qt-sdk's copy"
     (contains "logos-qt-generator " universal) false)
   (assertBool "cdylib glue does NOT fall back to qt-sdk's copy"
     (contains "logos-qt-generator " cdylib) false)
+
+  # The ui backend, same rule and for the same reason. It used to call
+  # logos-qt-sdk's logos-qt-generator; the emitter now lives in
+  # logos-view-module, beside the LogosView*.in templates its output compiles
+  # against and beside logos_ui_plugin_context.h its output calls into.
+  #
+  # This pins the CHOICE OF BINARY because the two copies had already rotted
+  # apart once -- logos-qt-sdk#38 gave the live one a teardown hook and the
+  # other never got it -- and picking the wrong one is not a build error. It
+  # emits a plugin whose meta-object simply lacks aboutToUnload(), which
+  # ui-host cannot distinguish from a view with nothing to wait for. What the
+  # emitted glue actually contains is logos-view-module's `ui-plugin-metaobject`
+  # check; this only pins which binary gets asked.
+  (assertBool "ui glue uses the view generator"
+    (contains "logos-view-generator " ui) true)
+  (assertBool "ui glue does NOT fall back to qt-sdk's copy"
+    (contains "logos-qt-generator " ui) false)
+  (assertBool "ui glue still selects the ui backend explicitly"
+    (contains "--backend ui" ui) true)
 
   # And nothing anywhere still reaches for the removed generator flag.
   (assertBool "universal codegen does not use --provider-header"


### PR DESCRIPTION
Second of three — with [logos-view-module#3](https://github.com/logos-co/logos-view-module/pull/3) (owns the emitter) and logos-qt-sdk (retires the old copy). **They must land and relock together.**

`modulePreConfigure.nix` switches the `--backend ui` invocation to `logos-view-generator`.

## This is not cosmetic — it delivers a feature that has never shipped

This builder pins `logos-qt-sdk` at `4a1104c`, which **predates `b7b82e5`** — the commit that added the module teardown hook to the ui emitter. At `4a1104c` *both* halves lack it, so every build has been green and self-consistent, and **the hook has never reached a single shipped `ui_qml` module.**

Measured on the same module, before and after, by loading the built plugin with `QPluginLoader` and dumping its `QMetaObject`:

```
BASELINE                        MIGRATED
  initLogos(LogosAPI*)            unloadFinished()       [signal]
                                  initLogos(LogosAPI*)
                                  int aboutToUnload()    [invokable]
```

So this delivers the hook for the first time rather than preserving it.

## One pin for the pair

`LOGOS_VIEW_INCLUDE_DIR` is added **`BEFORE`** the qt-sdk root in `LogosModule.cmake`, so the emitter and its `logos_ui_plugin_context.h` resolve from one pin.

**That ordering is load-bearing** until logos-qt-sdk stops installing its copy of the header. Anything going through `logos_module()` is safe; a hand-run cmake putting `LOGOS_QT_SDK_ROOT` first would silently get the wrong header. Called out in the code rather than left implicit — removing the duplicate needs its own survey of ui builds that bypass this builder.

## Blast radius: 7 modules, not one

`package_manager_ui`, `chat_ui`, `wallet_ui`, `test_uiqml_probe`, `test_fullapi_ui`, `calc_ui_cpp` and `templates/ui-qml-backend` all match `ui_qml` + `interface: universal`. **None override `aboutToUnload()`**, and the base default is `Synchronous`, so every one answers 0 and no host waits — the change is additive.

Only `package_manager_ui` was built end to end.

## Verification

Three assertions in `tests/test-module-pre-configure.nix` pin the binary choice; repointing at `logos-qt-generator` fails them. Also corrects a comment there that claimed "the ui backend still legitimately uses qt-sdk's".

7/7 checks green, 399 unit tests. aarch64-darwin only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)