### PR TITLE
chore(deps): relock onto the SDKs carrying the lossless Qt mapping

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787270089,
-        "narHash": "sha256-GYaGET2WTGChyl3bJVXE4ioapC3aLILK4tQI/C29FSY=",
+        "lastModified": 1787433464,
+        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "667990f28c1736ac902ac1d2cb46a0aeaf42467a",
+        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
         "type": "github"
       },
       "original": {
@@ -4261,11 +4261,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268585,
-        "narHash": "sha256-yDh1GpHNWAo7JlGvR83paJhFTCNLjDnLtxRxNl/1RzE=",
+        "lastModified": 1787433990,
+        "narHash": "sha256-nUZ2qLB6sRfhHzlGkX8Trgr4tQcYVsbhbr0HR80jthc=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4a1104cabb5647ef8524809c7021104e050cb529",
+        "rev": "133042bffe9a9e904e2a60cba9b710f6d4582514",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`logos-cpp-sdk 667990f → acea0d2`, `logos-qt-sdk 4a1104c → 133042b`. Lock only.

This is where the widened Qt consumer surface actually reaches modules, so it was **measured against the fleet**, not assumed.

## Fleet result

**26 pass, 5 fail, 1 not built — and every failure reproduces identically against module-builder master `352df67`.** Zero relock-caused breaks. The five are three pre-existing debts: chat's records-as-structs sweep, `lez_core`'s `uint32_t`, and `storage_module`'s reserved `version()`.

Four of 21 contracts change their Qt signature; only two of those have a consumer, and neither regresses. `logos-test-modules`' `test_fullapi_qtproxy`, `test_fullapi_ui` and `test_fullapi_proxy` all pass — #47's sweep holds at this lock.

## What actually moves

Four functional commits ride along, not one. They were separated with an intermediate *isolate* lock (cpp-sdk `b505ee9` / qt-sdk `618c467`) so each effect is attributable:

| contract | effect |
|---|---|
| no widened shapes | the lossless pair contributes **byte-for-byte zero** — `headers-qt` and `headers-lp` output NARs identical between isolate and relock |
| any contract | the **detector widening** changes one hunk in every generated consumer `.cpp`. Signatures do not move (`.h` byte-identical on both surfaces) but every module rebuilds |
| uses `?T` / `[T]` / `{tstr:V}` | nine declarations move — `QVariant`→`std::optional<QString>`, `QVariantList`→`QList<qulonglong>`, `QVariantMap`→`QMap<QString,qlonglong>`; `[tstr]` correctly does not; `#include <optional>` added |

`headers-lp` is byte-identical even for the widened contract — the std surface already kept these types, so this is a Qt-consumer-only change.

Note drv-hash identity is not an available inertness metric for *any* relock (the generator's store path moves); output-NAR identity is, and that is what was used.

## A premise that turned out false, in both halves

The plan carried a warning that a Rust cdylib does not install a `.lidl` sidecar, and that aligning Rust to the LIDL vocabulary would therefore hard-fail an lp header build at exit 7. Probed directly:

- **Rust cdylibs do install the sidecar.** `mkLogosModule`'s `lidlStaging` copies the trait-derived `.lidl` into `generated_code/`, and `buildPlugin.nix` installs it to `$out/share/logos/`. Verified on disk (`eth_rpc_module.lidl`, 1813 bytes). It is absent from the `combined` output, which is why it looked missing — `buildHeaders` reads the **lib** output.
- **The exposure is on the C++ side, not Rust.** With `--events-from` withheld by hand: Rust cdylib → exit 0 (Qt names, legacy path); C++ universal → **exit 7**.
- No fleet module takes that path anyway — all six Rust modules publish `packages.<sys>.lidl`, so `depIsLidl` holds everywhere and consumers go through `--dep`. Confirmed end to end: `wallet_backend_module` (5 Rust deps), `uniswap_module`, `railgun_module` all pass.

**Residual worth recording:** the guard is `--events-from`, not the sidecar's existence. A hand-run generator invocation, or any caller that drops the flag, now hard-fails at exit 7 on every C++ universal module where it previously emitted a silently untyped wrapper. Intended, but new outside `buildHeaders.nix`.

## Checks

8/8 on **x86_64-linux** and 8/8 on **aarch64-darwin**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)