### PR TITLE
chore(deps): bump onto the caller-identity wave — protocol 0.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -264,7 +264,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_6",
         "logos-nix": "logos-nix_12",
-        "logos-protocol": "logos-protocol_2",
+        "logos-protocol": "logos-protocol_3",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -332,7 +332,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_5",
+        "logos-protocol": "logos-protocol_6",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -396,7 +396,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_10",
+        "logos-protocol": "logos-protocol_11",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -486,7 +486,7 @@
         "logos-nix": "logos-nix_49",
         "logos-package-manager": "logos-package-manager_2",
         "logos-plugin-qt": "logos-plugin-qt_7",
-        "logos-protocol": "logos-protocol_7",
+        "logos-protocol": "logos-protocol_8",
         "logos-qt-sdk": "logos-qt-sdk_4",
         "nixpkgs": [
           "logos-standalone-app",
@@ -891,11 +891,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -1034,11 +1034,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -1266,7 +1266,7 @@
         "logos-nix": "logos-nix_21",
         "logos-plugin-core": "logos-plugin-core_2",
         "logos-plugin-qt": "logos-plugin-qt_3",
-        "logos-protocol": "logos-protocol_3",
+        "logos-protocol": "logos-protocol_4",
         "logos-qt-sdk": "logos-qt-sdk_2",
         "logos-rust-sdk": "logos-rust-sdk_2",
         "logos-standalone-app": [
@@ -3494,11 +3494,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -3558,11 +3558,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -3918,11 +3918,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787430480,
+        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
         "type": "github"
       },
       "original": {
@@ -3932,6 +3932,31 @@
       }
     },
     "logos-protocol_10": {
+      "inputs": {
+        "logos-nix": [
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_11": {
       "inputs": {
         "logos-nix": [
           "logos-view-module-runtime",
@@ -3960,7 +3985,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_11": {
+    "logos-protocol_12": {
       "inputs": {
         "logos-nix": [
           "logos-view-module-runtime",
@@ -3988,6 +4013,33 @@
     "logos-protocol_2": {
       "inputs": {
         "logos-nix": [
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_3": {
+      "inputs": {
+        "logos-nix": [
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
@@ -4014,7 +4066,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_3": {
+    "logos-protocol_4": {
       "inputs": {
         "logos-nix": "logos-nix_26",
         "nixpkgs": [
@@ -4041,7 +4093,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_4": {
+    "logos-protocol_5": {
       "inputs": {
         "logos-nix": [
           "logos-standalone-app",
@@ -4074,7 +4126,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_5": {
+    "logos-protocol_6": {
       "inputs": {
         "logos-nix": [
           "logos-standalone-app",
@@ -4111,7 +4163,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_6": {
+    "logos-protocol_7": {
       "inputs": {
         "logos-nix": [
           "logos-standalone-app",
@@ -4144,7 +4196,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_7": {
+    "logos-protocol_8": {
       "inputs": {
         "logos-nix": "logos-nix_56",
         "nixpkgs": [
@@ -4169,7 +4221,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_8": {
+    "logos-protocol_9": {
       "inputs": {
         "logos-nix": [
           "logos-standalone-app",
@@ -4186,31 +4238,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_9": {
-      "inputs": {
-        "logos-nix": [
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -4461,6 +4488,7 @@
         "logos-nix": [
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_2",
         "nixpkgs": [
           "logos-rust-sdk",
           "logos-nix",
@@ -4468,11 +4496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787312984,
-        "narHash": "sha256-5tUekequUlrzhG7C005bm20zALXpLPw2K2SYl2eZL1I=",
+        "lastModified": 1787432825,
+        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "49dbb0768a9a18cfaf264cc3ecfa55cca2630157",
+        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
         "type": "github"
       },
       "original": {
@@ -4538,7 +4566,7 @@
         "logos-liblogos": "logos-liblogos",
         "logos-nix": "logos-nix_59",
         "logos-plugin-qt": "logos-plugin-qt_8",
-        "logos-protocol": "logos-protocol_8",
+        "logos-protocol": "logos-protocol_9",
         "logos-qt-mcp": "logos-qt-mcp",
         "logos-view-module-runtime": [
           "logos-view-module-runtime"
@@ -4574,7 +4602,7 @@
         ],
         "logos-nix": "logos-nix_29",
         "logos-plugin-qt": "logos-plugin-qt_5",
-        "logos-protocol": "logos-protocol_4",
+        "logos-protocol": "logos-protocol_5",
         "logos-qt-sdk": "logos-qt-sdk_3",
         "nixpkgs": [
           "logos-standalone-app",
@@ -4607,7 +4635,7 @@
         ],
         "logos-nix": "logos-nix_62",
         "logos-plugin-qt": "logos-plugin-qt_9",
-        "logos-protocol": "logos-protocol_9",
+        "logos-protocol": "logos-protocol_10",
         "logos-qt-sdk": "logos-qt-sdk_5",
         "nixpkgs": [
           "logos-test-framework",
@@ -4667,7 +4695,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_4",
         "logos-nix": "logos-nix_31",
         "logos-plugin-qt": "logos-plugin-qt_6",
-        "logos-protocol": "logos-protocol_6",
+        "logos-protocol": "logos-protocol_7",
         "nixpkgs": [
           "logos-standalone-app",
           "logos-liblogos",
@@ -4697,7 +4725,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-nix": "logos-nix_64",
         "logos-plugin-qt": "logos-plugin-qt_10",
-        "logos-protocol": "logos-protocol_11",
+        "logos-protocol": "logos-protocol_12",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-nix",


### PR DESCRIPTION
Item 5 completion. Four root inputs, one commit — and the run that proves the whole wave works.

## Why both plugin-qt entries

`flake.nix:88` declares `logos-plugin-core` as a **second** input onto `logos-plugin-qt`, selected by module *type*. Moving only the first would leave core and ui modules linking two different `logos-qt-host` copies.

They must move together for a harder reason too: the glue emits a call guarded `>= 0.6` and both backends define it guarded `>= 0.6`, and **both guards resolve against the same protocol header in a module's closure**. Split across commits and there is a closure where the call exists without the definition — links clean, undefined symbol at `dlopen`, Linux only.

## Every input moves forward, and lands at master

| input | | direction |
|---|---|---|
| `logos-protocol` | `480f40f` → `6c24fcb` (0.6.0) | +4, at master |
| `logos-plugin-qt` | `55713b9` → `c459e47` | +4, at master |
| `logos-plugin-core` | `55713b9` → `c459e47` | +4, at master |
| `logos-rust-sdk` | `49dbb07` → `2b88750` | +4, at master |

Nothing else in the lock changes. Verified per-input against each repo's current `master` via the GitHub compare API — `ahead_by=N, behind_by=0` for all four, and each new rev is identical to that repo's master tip.

Closure consistency was also checked at the **artifact** level, not just the lock: walking every check's derivation closure finds exactly one protocol source (0.6.0) plus its byte-identical re-import, and no second protocol reaches anything the builder builds.

## `module-impl-abi-nm` now sees eleven exports in both built plugins

```
declared exports: 11 (from logos-protocol, never hardcoded here)
[logos-cpp-sdk  (C++ universal / Qt plugin)]  11 defined, defines all 11, no undefined
[logos-rust-sdk (Rust cdylib)]                12 defined, defines all 11, no undefined
   ... T logos_module_set_call_caller
```

(The Rust plugin's twelfth is `logos_module_install`, an `extern "Rust"` author hook, not part of this ABI.)

That check earns its keep here and nowhere else — it is the only one in the fleet that sees the glue, both backends, and this repo's own `protocolVersion` derivation together.

**Proven by breaking it, which took two experiments.** Mangling the version regex alone no longer reaches a build: `48cfdbe` already replaced the vanishing flag with a throw. So the belt came off too — with the pre-fix `lib.optionalString (protocolVersion != null)` carrier restored *and* the regex broken, nm went red **on the Rust module only**, 8 exports instead of 11, naming the four missing. That is the historical carrier bug reproduced and caught.

## The feature actually works — a handler printed its caller's name

Four modules built from this branch's own lock, run as four separate processes under a real `logoscore`:

```
$ logoscore call caller_driver askCpp     -> "module:caller_driver"
$ logoscore call caller_driver askRust    -> "module:caller_driver"
```

**The control that makes it meaningful.** `caller_driver_two` is byte-identical source with a different name, hitting the *same probe process in the same daemon session*:

```
$ logoscore call caller_driver_two askCpp -> "module:caller_driver_two"
$ logoscore call caller_driver_two askCppIsModule caller_driver -> false
```

One probe binary tells two callers two different things. The value is the caller's identity — not a constant, not "whoever loaded me", not a name baked in at build time.

Rule 5 holds on the wire: a host-initiated call answers `host` with **no name**. The documented sharp edge holds too — a worker thread spawned by a handler *while a dispatch is in flight*, and the context-ready hook, both read `unknown`, in both languages. All 22 calls answered identically against a C++ universal callee and a Rust cdylib callee.

## The negative control

The **same module store path**, not rebuilt, on a pre-wave host (protocol 0.5.0, whose `logos_host` has zero occurrences of `currentCallerJson`):

```
askCpp  -> "unknown"   (was "module:caller_driver")
```

Every answer collapses to `unknown` — **fail-closed, never a wrong name** — and the daemon log names the mechanism: `No such method LogosAPI::currentCallerJson()`. So it is the wave producing the identity, not the fixture. It also means wave-built modules **load and run fine on a 0.5 host**: the surface degrades, it does not break.

## All eight checks pass on x86_64-linux

`module-impl-abi-nm`, `default`, `rust-native-dep`, `qml-integration`, `test-framework-integration`, `static-extlib`, `qt-host-repoint`, `view-interface-abi`.

## Not reached

Only the QtRO local-socket transport (logoscore's default, and the one documented as carrying the identity) and only the single-dispatch glue branch at runtime — `multi` was covered by logos-plugin-qt#25's two-image harness. `qt_local`, plain `tcp`/`tcp_ssl`, the ui-host bridge and legacy plugins are all documented as `Unknown` and none were exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)