### PR TITLE
fix(deps): restore the view teardown hook, and pick up the deduplicated qt-sdk

### DIFF
--- a/cmake/LogosModule.cmake
+++ b/cmake/LogosModule.cmake
@@ -543,11 +543,14 @@ function(logos_module)
         )
     endif()
     # logos_ui_plugin_context.h, from logos-view-module — and FIRST, ahead of
-    # the logos-qt-sdk root below, which may still ship a copy of the same
-    # header name.
+    # the logos-qt-sdk root below.
     #
-    # Ordering is load-bearing here, which is exactly why this is not left to
-    # chance. This header and the view glue emitter are one MATCHED PAIR: the
+    # As of the qt-sdk pin above, logos-view-module is the ONLY repo that ships
+    # this header, so ordering is no longer what decides which copy wins. It
+    # stays BEFORE anyway: this repo pins the two independently, and an older
+    # qt-sdk pin — a rollback, a branch, a consumer overriding the input — brings
+    # the duplicate straight back. Belt-and-braces now, load-bearing again the
+    # moment those pins disagree. This header and the view glue emitter are one MATCHED PAIR: the
     # emitted `<name>_ui_glue.cpp` calls
     # `_logos_codegen_::maybeUiPluginAboutToUnload(...)`, which only this header
     # declares. Both now ship from logos-view-module under ONE pin, so they
@@ -572,8 +575,9 @@ function(logos_module)
     endif()
     # The Qt-typed headers logos-qt-sdk owns — logos_qt_lp_bridge.h /
     # logos_qt_wire.h (emitted by name into generated Qt consumer wrappers).
-    # It may still ship logos_ui_plugin_context.h too; the block above is
-    # ordered ahead of this one so logos-view-module's copy is the one found.
+    # It no longer ships logos_ui_plugin_context.h; logos-view-module is its sole
+    # owner, and the block above stays ordered ahead of this one so an older
+    # qt-sdk pin that still carries a copy cannot win.
     if(NOT "${LOGOS_QT_SDK_ROOT}" STREQUAL "${LOGOS_QT_HOST_ROOT}")
         if(LOGOS_QT_SDK_IS_SOURCE)
             target_include_directories(${MODULE_NAME}_module_plugin PRIVATE

--- a/flake.lock
+++ b/flake.lock
@@ -4730,11 +4730,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787164758,
-        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
+        "lastModified": 1787441236,
+        "narHash": "sha256-dDbws6OlaOw5YTCHQfVLXqF+ssD6Fs3vCrLqOthEYOI=",
         "owner": "logos-co",
         "repo": "logos-view-module",
-        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
+        "rev": "d6c8885494524504cc5ea9dcfdad54a98ed26ea4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -4261,11 +4261,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787433990,
-        "narHash": "sha256-nUZ2qLB6sRfhHzlGkX8Trgr4tQcYVsbhbr0HR80jthc=",
+        "lastModified": 1787442773,
+        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "133042bffe9a9e904e2a60cba9b710f6d4582514",
+        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Two lock bumps. The first is a **live regression fix**; the second is the deduplication follow-up.

## 1. The view teardown hook (the regression)

#211 switched ui_qml glue generation from `logos-qt-generator` to `logos-view-generator`. The `logos-view-module` pin it landed with — `1f95a75` — **predates the reconciliation that gave that emitter the module teardown hook.**

| | emitted `aboutToUnload` | header declares `maybeUiPluginAboutToUnload` |
|---|---|---|
| `1f95a75` (pinned until now) | **0** | **0** |
| `d6c8885` (this bump) | 4 lines | 2 |

So since #211 landed, **every view plugin built through this repo has silently lost `aboutToUnload()`.**

It is silent by construction: a generated plugin missing the hook builds, links, loads and runs — it is simply never asked to finish. No build diagnostic, no load error, no failing test. That is the exact failure that motivated putting the emitter and its context header in one repo under one pin: they are a matched pair, the emitted glue calls `_logos_codegen_::maybeUiPluginAboutToUnload(...)`, and only that header declares it. Here the *pin* reintroduced the split — same defect, one level up.

The bump also brings `--backend` validation: `logos-view-generator` now refuses an unrecognised value instead of ignoring the flag. `lib/modulePreConfigure.nix:177-183` already documents and relies on that guarantee; at `1f95a75` the binary never read `--backend` at all, so the flag this repo passes was silently discarded and the documented refusal did not exist.

## 2. The deduplicated qt-sdk

[logos-qt-sdk#42](https://github.com/logos-co/logos-qt-sdk/pull/42) deleted qt-sdk's copy of `logos_ui_plugin_context.h` (and the `logos_qt_provider` target that existed only for it), leaving logos-view-module the sole owner. Two `LogosModule.cmake` comments described the old world and are corrected.

**The `BEFORE`-ordering of `LOGOS_VIEW_INCLUDE_DIR` stays.** It is no longer what decides which copy wins — there is only one copy now — but this repo pins the two repos independently, and an older qt-sdk pin (a rollback, a branch, a consumer overriding the input) brings the duplicate straight back. Belt-and-braces now, load-bearing again the moment those pins disagree.

## Verification

```
nix build .#checks.aarch64-darwin.qml-integration   PASS
nix build .#checks.aarch64-darwin.qt-host-repoint   PASS
```

Both run with both bumps applied.