### PR TITLE
chore(deps): bump logos-qt-sdk for the record-codec qualification

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4288,11 +4288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787442773,
-        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
+        "lastModified": 1787527335,
+        "narHash": "sha256-QYFh0gAYGkIaGwFk9XAmjic1DuhMWqiW+G7Qo2LDEo0=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
+        "rev": "3ab74215669c10cf2619ac0ae95294d177c5da5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`logos-qt-sdk 4ab78a1 → 3ab7421`, picking up [qt-sdk#43](https://github.com/logos-co/logos-qt-sdk/pull/43). Lock only.

Without it, **a record-bearing contract cannot be consumed by a proxy at all**. The generated record codecs were file-scope statics named after the record alone (`recToWire_Blob`), and logos-cpp-sdk's umbrella amalgamates every `<name>_api.cpp` into one TU — so a proxy holding the bound wrapper plus one per declared dependency collides on every record:

```
error: no match for 'operator=' (operand types are 'FullApiExt::Opt' and 'TestFullapiExtCpp::Opt')
error: conversion from 'TestFullapiExtCpp::Opt' to non-scalar type 'FullApiExt::Opt' requested
```

#43 qualifies the codec names by wrapper class.

Needed by logos-test-modules' ext qtproxy fixture — the first record-bearing contract to be consumed through a proxy, which is how the defect surfaced after shipping unnoticed.

`checks.<sys>.{default, qml-integration, rust-native-dep, module-impl-abi-nm}` all pass on the bumped lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)