### PR TITLE
chore(deps): bump the three SDKs for the arity bound and the result decode

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787433464,
-        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
+        "lastModified": 1787539869,
+        "narHash": "sha256-08sFNagM6dJZXG1FUOlqjJJ/KatUv5Kgqj6hURtJfiM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
+        "rev": "692af756cc61786d69eb2b272b5dca8e097437a7",
         "type": "github"
       },
       "original": {
@@ -4288,11 +4288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787527335,
-        "narHash": "sha256-QYFh0gAYGkIaGwFk9XAmjic1DuhMWqiW+G7Qo2LDEo0=",
+        "lastModified": 1787538017,
+        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "3ab74215669c10cf2619ac0ae95294d177c5da5f",
+        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
         "type": "github"
       },
       "original": {
@@ -4496,11 +4496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787432825,
-        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
+        "lastModified": 1787539875,
+        "narHash": "sha256-a3FDak1jvMw3Dtt1ugr2WcjEAUFF3OwEpD1tPougqec=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
+        "rev": "d3fe4b434933a91ec1cebb0b581771daa3f3c85b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Carries three merged SDK fixes to every module the builder builds.

| Input | Rev | What |
|---|---|---|
| logos-cpp-sdk | `692af75` ([#150](https://github.com/logos-co/logos-cpp-sdk/pull/150)) | arity upper bound in the cdylib dispatch; `jsonToStdResult` on the lp surface |
| logos-rust-sdk | `d3fe4b4` ([#50](https://github.com/logos-co/logos-rust-sdk/pull/50)) | the same upper bound, plus its own gate on the identity arm |
| logos-qt-sdk | `6a570b3` ([#44](https://github.com/logos-co/logos-qt-sdk/pull/44)) | `logosResultFromReply` on all three Qt consumer surfaces |

## Why these three move together

Two independent defects, and one of them is **split across two repos by construction**.

**The arity bound.** An extra argument was silently dropped and the call succeeded — both backends, every arity including zero, and the derived identity dispatch on top of that (`version("junk")` answered `"1.0.0"` with status ok). Arity is the one part of a contract a caller cannot check for itself, so a parameter added or removed upstream produced a plausible answer instead of a refusal.

**The result decode.** `jsonToLogosResult` and `jsonToStdResult` both open with `if (!is_object) return <default>`, and that default — `success = false`, empty error — is byte-for-byte what a provider sends when it refuses a call. A wrapper that could not read a reply therefore forged a rejection, for every input including the well-formed ones.

That second one lives in **both** consumer surfaces, and logos-qt-sdk's `bare_scalar_slots_stay_lenient` warns in its own comment that tightening a scalar decode on one surface without the other makes the two diverge. It is right, so cpp-sdk#150 and qt-sdk#44 fixed them together — and bumping them together here is the same requirement one level up. Bumping only one would ship a window in which Qt and lp modules disagree about `LogosResult`.

## Verification

```
default PASS   module-impl-abi-nm PASS   qml-integration PASS   qt-host-repoint PASS
rust-native-dep PASS   static-extlib PASS   test-framework-integration PASS
view-interface-abi PASS
```

All eight checks on x86_64-linux, from the pushed branch with no overrides.

## What this unblocks

logos-test-modules' conformance matrix registers the arity defect as `B-arity-overflow` and `B-arity-overflow-identity` — 36 cells across the two tables. They are expected to go xpass once test-modules relocks onto this, which reddens that gate until the entries are retired; the relock and the retirement are one commit there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
