### PR TITLE
chore(deps): bump logos-plugin-qt for the second void-refusal site

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3558,11 +3558,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Carries [logos-plugin-qt#29](https://github.com/logos-co/logos-plugin-qt/pull/29) (`f668ef2`): a void method's **refusal** is no longer discarded on either concurrency path.

## Why a second bump

[#28](https://github.com/logos-co/logos-plugin-qt/pull/28) — already in `b06c287`, this repo's previous pin — fixed the **multi** path only. The single path returned early:

```cpp
if (kVoidMethods.contains(methodName)) return QVariant(true);
```

before ever reaching the branch #28 changed. So a provider that rejected the call was still reported to the caller as a successful void call.

## How that was established

Not by reading the diff. With #28 in the builder, the six `logos-test-modules` conformance cells for `failure/B/arity/too-many-zero-parameter` were **re-measured and were still xfail** — the fix was in the build (verified root-to-leaf through the lock, and by content in the emitter) and the cells had not moved. That is what located the second site.

## Behaviour

An ordinary void reply still answers `QVariant(true)` on both paths. Only a provider refusal — the closed set `dispatch_failed` / `invalid_args` / `unknown_method`, matched on an object carrying a string `code` — is propagated.

## Verification

```
default PASS   module-impl-abi-nm PASS   qml-integration PASS   qt-host-repoint PASS
rust-native-dep PASS   static-extlib PASS   test-framework-integration PASS
view-interface-abi PASS
```

8/8 on x86_64-linux from the pushed branch, no overrides.

Once this lands, logos-test-modules relocks onto it and the last six `B-arity-overflow` cells are expected to go xpass — retiring that entry in full. I am measuring that rather than assuming it: #28 looked complete and was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
