### PR TITLE
fix: apply logos-nix's fetchCargoVendor User-Agent overlay in mkPkgsWith

### DIFF
--- a/lib/common.nix
+++ b/lib/common.nix
@@ -96,9 +96,19 @@ let
   # x86_64-windows cannot be produced by `import nixpkgs { system = ...; }` --
   # it needs localSystem/crossSystem plus logos-nix's mingw overlays, which is
   # exactly what logos-nix.lib.mkWindowsPkgs wraps.
+  #
+  # Native sets carry logos-nix's fetchCargoVendor User-Agent overlay (crates.io
+  # 403s the pin's UA-less helper: logos-module-builder#159, logos-nix#6).
+  # Optional-guarded so a logos-nix pin predating the attribute still evaluates.
   mkPkgsWith = extraOverlays: system:
     if system != "x86_64-windows" then
-      import nixpkgs { inherit system; overlays = extraOverlays; }
+      import nixpkgs {
+        inherit system;
+        overlays =
+          lib.optional (logos-nix != null && logos-nix ? lib.overlays.fetchCargoVendorUserAgent)
+            logos-nix.lib.overlays.fetchCargoVendorUserAgent
+          ++ extraOverlays;
+      }
     else if logos-nix == null then
       throw ("logos-module-builder: targeting x86_64-windows requires the "
              + "logos-nix input to be threaded into the builder lib.")


### PR DESCRIPTION
## Why

Every module release's cargo vendoring dies with `crates.io ... 403` (#159): the pinned nixpkgs' `fetchCargoVendor` helper sends no User-Agent. logos-co/logos-nix#6 carries the upstream fix (NixOS/nixpkgs#512735) as `logos-nix.lib.overlays.fetchCargoVendorUserAgent` on the current pin, no Qt bump — per the 2026-08-27 plan on logos-co/logos-nix#5 (https://github.com/logos-co/logos-nix/pull/5#issuecomment-5437815210) and the 2026-08-12 maintainer ask that the fix live in logos-nix.

But logos-nix's overlay only reaches package sets built through logos-nix's own helpers. This repo does its own `import nixpkgs` in `lib/common.nix` `mkPkgsWith`, so it never applied here. This is the one consumer line that hooks it up.

## What

`lib/common.nix` `mkPkgsWith`: prepend `logos-nix.lib.overlays.fetchCargoVendorUserAgent` to the native package set's overlays. Guarded with `logos-nix ? lib.overlays.fetchCargoVendorUserAgent`, so on the current lock (which predates the attribute) it is a no-op and evaluation is unchanged — the fix switches on with the lock bump. Not applied to the `x86_64-windows` set (`mkWindowsPkgs` owns that; `nixpkgs-windows` already has the upstream fix).

No `flake.lock` change. **Merge order: after logos-co/logos-nix#6, then a `nix flake update logos-nix` lock bump here** (separate commit/PR) — only then do module releases pick this up, via their `logos-module-builder` input.

## Verified (aarch64-darwin, `--override-input logos-nix github:logos-co/logos-nix/aac5338e` = #6's head)

- `checks.aarch64-darwin.rust-native-dep` instantiates; the module's own crate compile (`rust_native_dep-1.0.0.drv`) now resolves its toolchain through the overlayed set — its `cargo-auditable`/`cargo-c`/`rav1e` `-vendor-staging` FODs reference `fetch-cargo-vendor-util-ua`, whose built helper sets `User-Agent: nixpkgs-fetchCargoVendor/2 (...)` and fetches from `static.crates.io`. Without the override, every staging drv in that closure references the unpatched helper.
- A one-crate `rustPlatform.fetchCargoVendor` (`bitflags 2.9.4`) built from **this repo's** `common.mkPkgs "aarch64-darwin"`: without the overlay → `Status code: 403` (reproduces #159); with it → fetches from `static.crates.io` and produces the `cargo-deps-vendor` output (`bitflags-2.9.4/` + `.cargo/`).
- On the current lock (no override): all `checks.aarch64-darwin.*` still evaluate; `rust-native-dep`'s drvPath is unchanged (guard is a no-op).

**Not proven:** the `rust-native-dep` fixture has no external crates (its vendor dir is local), so a full run of that check does not exercise a crates.io download — hence the one-crate vendor above. Staging drvs reached via `logos-lidl-gen` (logos-rust-sdk's own nixpkgs set) stay unpatched; those are cache-served upstream tools, not a module's crates, and are out of this repo's hands. Linux not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezs1fWormzPw9QqU89oAFU
